### PR TITLE
docs(requirements): include per-startup-date logging in v0.2 acceptance

### DIFF
--- a/docs/requirements/v0.2-worker-core-api-acceptance.md
+++ b/docs/requirements/v0.2-worker-core-api-acceptance.md
@@ -55,6 +55,7 @@ v0.2 focuses on:
 
 - [ ] Logging initializes early in startup.
 - [ ] Logs are written under `user_data/logs/`.
+- [ ] Logs are generated per startup date (new file per startup; filename includes date).
 - [ ] Logs are preserved by default (no automatic deletion).
 - [ ] Startup logs include (at minimum):
   - [ ] Worker version (or explicit `unknown` placeholder)


### PR DESCRIPTION
## Summary
Align the v0.2 Worker Core API acceptance checklist with `AGENTS.md` logging rules by requiring logs to be generated per startup date.

## Changes
- Update `docs/requirements/v0.2-worker-core-api-acceptance.md` to include a per-startup-date logging checklist item.

## Related Issues
- Refs #9

## Scope Guardrails
- Docs-only change
- No roadmap meaning changes
- No runtime data committed
- No implementation code added

## Verification
- Review markdown content for clarity and consistency with `AGENTS.md` Logging Rules
