### PR TITLE
docs(requirements): require per-startup-date log files in v0.2 acceptance

### DIFF
--- a/docs/requirements/v0.2-worker-core-api-acceptance.md
+++ b/docs/requirements/v0.2-worker-core-api-acceptance.md
@@ -55,6 +55,7 @@ v0.2 focuses on:
 
 - [ ] Logging initializes early in startup.
 - [ ] Logs are written under `user_data/logs/`.
+- [ ] Log files are generated per startup date (see `AGENTS.md`, Logging Rules).
 - [ ] Logs are preserved by default (no automatic deletion).
 - [ ] Startup logs include (at minimum):
   - [ ] Worker version (or explicit `unknown` placeholder)


### PR DESCRIPTION
## Summary
Align the v0.2 Worker Core API acceptance checklist with the repository logging contract in `AGENTS.md`.

## Changes
- Add an explicit checklist item requiring log files to be generated per startup date

## Related Issues
- Closes #9

## Scope Guardrails
- No roadmap meaning changes
- Docs-only change
- No runtime data committed

## Verification
- Review markdown content (`docs/requirements/v0.2-worker-core-api-acceptance.md`)
