### PR TITLE
docs: define release tag policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,6 +332,27 @@ Patch versions are intended for:
 - runtime fixes
 - non-roadmap adjustments
 
+## Tag Rules
+
+Major and minor version releases MUST be tagged in Git after the release PR is merged.
+
+Tag format:
+```text
+vMajor.Minor.Patch
+```
+
+Required tags:
+- Major release: tag the merged release commit as `vX.0.0` unless the release plan explicitly defines a different minor or patch number.
+- Minor release: tag the merged release commit as `vX.Y.0`.
+
+Patch tags are optional and SHOULD be created when a patch release is packaged, published, or otherwise used as a recovery/update boundary.
+
+Agents SHOULD create release tags when a major or minor roadmap milestone is completed and merged into `main`, if the GitHub tooling available in the session supports tag creation. If tag creation is not available, agents MUST report the intended tag name and target commit SHA so the maintainer can create it.
+
+Agents MUST NOT move or overwrite an existing tag without explicit user approval.
+
+See `docs/release.md` for the release tagging procedure.
+
 ---
 
 # Runtime Rules

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The project is designed around an OBS Plugin + Python Worker architecture.
 | Minor | planned roadmap features |
 | Patch | bug fixes and non-roadmap changes |
 
+Major and minor release completions are tagged as `vMajor.Minor.Patch`. See [Release and tag policy](docs/release.md).
+
 ---
 
 ## Current Development
@@ -119,6 +121,7 @@ Documentation starts at [docs/README.md](docs/README.md).
 Key documents:
 - [Roadmap](docs/roadmap.md)
 - [Requirements](docs/requirements/requirements.md)
+- [Release and tag policy](docs/release.md)
 - [v0.1 acceptance checklist](docs/requirements/v0.1-acceptance.md)
 - [Architecture docs](docs/architecture/)
 - [User docs](docs/user/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This directory is the documentation entry point for OBS Duel Recorder.
 
 - [Roadmap](roadmap.md)
 - [Requirements](requirements/requirements.md)
+- [Release and tag policy](release.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
 
 ## Architecture

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,60 @@
+# Release and Tag Policy
+
+This document defines release tagging rules for OBS Duel Recorder.
+
+## Version Format
+
+The project uses:
+
+```text
+Major.Minor.Patch
+```
+
+Git tags use a leading `v`:
+
+```text
+vMajor.Minor.Patch
+```
+
+Examples:
+- `v0.1.0`
+- `v0.2.0`
+- `v1.0.0`
+
+## When Tags Are Required
+
+Tags are required when a major or minor version is completed and merged into `main`.
+
+Required tag points:
+- Major release completion: tag the merged release commit as `vX.0.0`, unless the release plan explicitly defines a different minor or patch number.
+- Minor release completion: tag the merged release commit as `vX.Y.0`.
+
+Patch tags are optional. They should be created when a patch release is packaged, published, or used as a recovery/update boundary.
+
+## Tag Target
+
+Tags should point to the merge commit on `main` that completes the release milestone.
+
+Do not tag an unmerged feature branch as a release.
+
+Do not move or overwrite an existing tag without explicit maintainer approval.
+
+## Agent Responsibilities
+
+When a major or minor roadmap milestone is completed:
+
+1. Confirm all required issues for the milestone are closed or intentionally deferred.
+2. Confirm the release PR is merged into `main`.
+3. Identify the merged commit SHA on `main`.
+4. Create the release tag if the available GitHub tooling supports tag creation.
+5. If tag creation is not available, report the intended tag name and target commit SHA.
+
+Agents must preserve runtime data and must not include secrets, OAuth tokens, logs, databases, generated media, screenshots, or game assets in release work.
+
+## Automation Notes
+
+Automation may create release-preparation issues or PRs when a milestone is nearing completion.
+
+Automation must not merge release PRs.
+
+Automation must not move existing tags.


### PR DESCRIPTION
## Summary

Defines the repository policy for creating Git tags when major or minor roadmap versions are completed.

## Changes

- Adds `docs/release.md` with release/tag rules.
- Updates `AGENTS.md` with Tag Rules for major/minor releases.
- Links the release policy from `README.md` and `docs/README.md`.
- Updates automation instructions so scheduled runs can create release tags when supported, or report the intended tag and target SHA when not supported.

## Scope Guardrails

- Does not modify `docs/roadmap.md`.
- Does not create a release tag now because no new major/minor completion is being performed in this PR.
- Does not add implementation code.
- Does not add runtime data, credentials, logs, databases, generated media, screenshots, or game assets.

## Verification

- Compared branch against `main`; changed only documentation files.
- Confirmed `docs/release.md` and `AGENTS.md` are readable from the branch.

Refs #9
