### PR TITLE
docs: remove duplicate README disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,3 @@ Detection templates are intended to be generated locally by users.
 ## License
 
 MIT License
-
----
-
-## Disclaimer
-
-This project is an unofficial fan-made tool.
-
-This project is not affiliated with KONAMI.
-
-Yu-Gi-Oh! Master Duel assets are not distributed with this software.


### PR DESCRIPTION
## Summary

Removes the duplicate `Disclaimer` section from `README.md`.

## Changes

- Confirmed `README.md` contained two identical `Disclaimer` sections.
- Kept the first `Disclaimer` section in place.
- Removed only the trailing duplicate section after `License`.

## Scope Guardrails

- Does not change README section order.
- Does not change the existing disclaimer wording.
- Does not modify anything under `docs/`.
- Does not change implementation code.

## Verification

- Compared branch against `main`; only `README.md` changed.
- Diff is limited to 10 deleted lines.
