### PR TITLE
docs: add architecture Mermaid diagrams

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,0 +1,14 @@
+# Architecture Index
+
+Architecture documents describe technical behavior, responsibility boundaries, and runtime flows.
+
+## Diagrams
+
+- [Plugin / Worker Architecture](plugin-worker.md)
+- [Queue State Machine](queue.md)
+- [Recording State Machine](recording.md)
+- [Upload Flow](upload.md)
+
+## Supporting Documents
+
+- [Database Design](db.md)

--- a/docs/architecture/plugin-worker.md
+++ b/docs/architecture/plugin-worker.md
@@ -9,6 +9,62 @@
 
 ---
 
+## Plugin / Worker Architecture
+
+This diagram shows the responsibility boundary between the lightweight OBS Plugin and the Python Worker.
+
+```mermaid
+flowchart LR
+    subgraph OBS["OBS Studio"]
+        Frontend["OBS Frontend API"]
+        Dock["Dock UI"]
+        TextSources["Text Sources / Overlays"]
+        Recording["Recording Control"]
+    end
+
+    subgraph Plugin["OBS Plugin"]
+        PluginCore["Plugin Core"]
+        WorkerLifecycle["Worker Lifecycle"]
+        Heartbeat["Heartbeat Monitor"]
+        ApiClient["Localhost API Client"]
+    end
+
+    subgraph Worker["Python Worker"]
+        Api["FastAPI Localhost API"]
+        Queue["Queue Processing"]
+        Database["SQLite Management"]
+        Detection["Template Matching / OCR"]
+        Upload["YouTube Upload"]
+        Recovery["Recovery Processing"]
+    end
+
+    subgraph Runtime["user_data/"]
+        Config["config/"]
+        Data["data/"]
+        Logs["logs/"]
+    end
+
+    Frontend --> PluginCore
+    Dock --> PluginCore
+    PluginCore --> TextSources
+    PluginCore --> Recording
+    PluginCore --> WorkerLifecycle
+    WorkerLifecycle --> Api
+    Heartbeat --> ApiClient
+    ApiClient --> Api
+
+    Api --> Queue
+    Api --> Recovery
+    Queue --> Database
+    Detection --> Queue
+    Upload --> Queue
+    Worker --> Config
+    Worker --> Data
+    Worker --> Logs
+```
+
+---
+
 ## Plugin Responsibilities
 
 - OBS Frontend API

--- a/docs/architecture/queue.md
+++ b/docs/architecture/queue.md
@@ -9,6 +9,30 @@ Queue state must survive:
 
 ---
 
+## Queue State Machine
+
+This diagram shows the upload queue lifecycle owned by the Python Worker.
+
+```mermaid
+stateDiagram-v2
+    [*] --> ready_upload: recording finalized
+
+    ready_upload --> uploading: upload worker starts item
+    uploading --> uploaded: videos.insert success
+    uploading --> upload_failed: network or API failure
+    uploading --> quota_waiting: quota exceeded
+    uploading --> need_manual_review: unsafe or ambiguous failure
+    uploading --> [*]: missing file discarded
+
+    upload_failed --> ready_upload: retry allowed
+    quota_waiting --> ready_upload: quota reset reached
+    need_manual_review --> ready_upload: user resolves item
+    need_manual_review --> [*]: user discards item
+    uploaded --> [*]
+```
+
+---
+
 ## Recovery Rules
 
 Interrupted recordings are discarded.

--- a/docs/architecture/recording.md
+++ b/docs/architecture/recording.md
@@ -1,0 +1,34 @@
+# Recording State Machine
+
+Recording lifecycle coordination is split between the OBS Plugin and the Python Worker.
+
+The OBS Plugin owns OBS recording control and lifecycle events.
+
+The Python Worker owns queue creation, recovery decisions, and persistent runtime state.
+
+```mermaid
+stateDiagram-v2
+    [*] --> idle
+
+    idle --> recording_pending: duel start detected or manual start
+    recording_pending --> recording: OBS recording started
+    recording_pending --> idle: start rejected or cancelled
+
+    recording --> stopping_pending: duel end detected or manual stop
+    stopping_pending --> recorded: OBS recording stopped and file finalized
+    stopping_pending --> recording: stop rejected or cancelled
+
+    recorded --> queued: Worker creates upload queue item
+    queued --> idle: queue item persisted
+
+    recording --> interrupted: OBS or Worker shutdown
+    recording_pending --> interrupted: startup interrupted
+    stopping_pending --> interrupted: shutdown during stop
+    interrupted --> idle: discard interrupted recording during recovery
+```
+
+## Notes
+
+- OCR must not be the primary recording trigger mechanism.
+- Interrupted recording sessions should be discarded during recovery.
+- Queue persistence is handled by the Python Worker, not the OBS Plugin.

--- a/docs/architecture/upload.md
+++ b/docs/architecture/upload.md
@@ -9,6 +9,41 @@ recorded
 
 ---
 
+## Upload Flow Diagram
+
+This diagram shows the Worker-owned upload flow and how upload outcomes map back to queue states.
+
+```mermaid
+flowchart TD
+    Recorded["Recorded video finalized"] --> Ready["ready_upload"]
+    Ready --> Pick["Worker selects next queue item"]
+    Pick --> Exists{"Video file exists?"}
+
+    Exists -- No --> Discard["Discard queue item"]
+    Exists -- Yes --> Uploading["uploading"]
+
+    Uploading --> Insert["YouTube videos.insert"]
+    Insert --> Success{"Upload response success?"}
+
+    Success -- Yes --> Store["Store youtube_video_id and youtube_url"]
+    Store --> Uploaded["uploaded"]
+
+    Success -- Network failure --> Failed["upload_failed"]
+    Failed --> Retry["Retry later"]
+    Retry --> Ready
+
+    Success -- Quota exceeded --> Quota["quota_waiting"]
+    Quota --> Reset["Wait for quota reset"]
+    Reset --> Ready
+
+    Success -- Ambiguous failure --> Review["need_manual_review"]
+    Review --> Manual{"Manual decision"}
+    Manual -- Retry --> Ready
+    Manual -- Discard --> Discard
+```
+
+---
+
 ## Upload Success
 
 Upload success is determined by:


### PR DESCRIPTION
## Summary

Adds Mermaid diagrams under `docs/architecture` for the requested architecture and state-flow topics.

## Added / Updated Markdown

- Added `docs/architecture/index.md`
- Updated `docs/architecture/queue.md`
- Added `docs/architecture/recording.md`
- Updated `docs/architecture/plugin-worker.md`
- Updated `docs/architecture/upload.md`

## Diagram Purpose

- Queue State Machine: documents Worker-owned upload queue states and retry/recovery transitions.
- Recording State Machine: documents recording lifecycle coordination between OBS Plugin events and Worker queue creation/recovery.
- Plugin / Worker Architecture: documents responsibility separation and localhost API communication between the OBS Plugin and Python Worker.
- Upload Flow: documents upload processing outcomes and how they map to queue states.

## Scope Guardrails

- Uses Mermaid fenced code blocks only.
- Does not create image files.
- Does not modify `docs/roadmap.md` or version policy.
- Keeps Plugin responsibilities and Worker responsibilities separated according to `AGENTS.md`.
- Does not change implementation code.

## Verification

- Compared branch against `main`; changes are limited to `docs/architecture` Markdown files.
- Confirmed `docs/architecture/index.md` links to the Mermaid diagram pages.
