### PR TITLE
docs(v0.2): clarify Worker runtime path field contract

### DIFF
--- a/docs/requirements/v0.2-worker-core-api-acceptance.md
+++ b/docs/requirements/v0.2-worker-core-api-acceptance.md
@@ -31,6 +31,24 @@ v0.2 focuses on:
 - **Application files** live under `app/`
 - **Runtime data** lives under `user_data/` and must not be committed
 
+## Runtime Path Contract (v0.2)
+
+To avoid future ambiguity, v0.2 documentation and implementation SHOULD use the following canonical runtime path field names.
+
+### Canonical path fields
+
+- `app_dir`: absolute path to the repository’s `app/` directory (application code root)
+- `user_data_dir`: absolute path to the runtime data root directory (default: `<repo>/user_data/`)
+- `config_dir`: absolute path to `<user_data_dir>/config/`
+- `data_dir`: absolute path to `<user_data_dir>/data/`
+- `logs_dir`: absolute path to `<user_data_dir>/logs/`
+
+### Where these paths are surfaced
+
+- **Startup logs**: MUST log all canonical path fields (`app_dir`, `user_data_dir`, `config_dir`, `data_dir`, `logs_dir`).
+- **`GET /health`**: SHOULD include these canonical path fields under a stable `paths` object for future OBS Plugin diagnostics.
+- **Developer notes / smoke test docs**: SHOULD reference `user_data_dir` and `logs_dir` explicitly to help users locate outputs.
+
 ---
 
 ## Acceptance Checklist
@@ -40,7 +58,7 @@ v0.2 focuses on:
 - [ ] A single, documented Worker entrypoint exists (CLI command or `python -m ...`).
 - [ ] The Worker can start without requiring OBS.
 - [ ] Startup is restart-safe (no destructive deletes of runtime data).
-- [ ] Startup clearly logs the effective host/port and runtime paths.
+- [ ] Startup clearly logs the effective host/port and runtime paths (see “Runtime Path Contract (v0.2)”).
 
 ### B. Runtime Directory Creation
 
@@ -61,7 +79,7 @@ v0.2 focuses on:
   - [ ] Worker version (or explicit `unknown` placeholder)
   - [ ] host/port
   - [ ] config path (or “no config loaded”)
-  - [ ] `user_data/` base dir and `logs_dir`
+  - [ ] canonical runtime path fields (`app_dir`, `user_data_dir`, `config_dir`, `data_dir`, `logs_dir`)
 
 ### D. Configuration Loading (Scaffold)
 
@@ -91,6 +109,7 @@ v0.2 focuses on:
   - [ ] `uptime_seconds`
   - [ ] `config_loaded` (boolean)
   - [ ] `runtime_dirs_ok` (boolean)
+  - [ ] `paths` (object with canonical runtime path fields: `app_dir`, `user_data_dir`, `config_dir`, `data_dir`, `logs_dir`)
 - [ ] If startup is partially degraded (e.g. logging fallback), `/health` reflects that with `status=degraded` and details.
 
 ### G. Shutdown Behavior


### PR DESCRIPTION
## Summary
Clarifies the canonical Worker runtime path field names and where they are surfaced in the v0.2 acceptance checklist.

## Changes
- Updates `docs/requirements/v0.2-worker-core-api-acceptance.md` to define a stable set of path fields (`app_dir`, `user_data_dir`, `config_dir`, `data_dir`, `logs_dir`).
- Specifies that startup logs MUST emit these fields and `/health` SHOULD surface them under `paths`.

## Related Issues
- Closes #52

## Scope Guardrails
- Documentation-only change.
- No roadmap semantic changes.
- No runtime data, secrets, tokens, logs, or generated assets committed.

## Verification
- Manual: confirmed the updated acceptance doc reads consistently and preserves repo runtime separation rules.
