### PR TITLE
docs: clarify v0.2 runtime path fields

### DIFF
--- a/docs/requirements/v0.2-worker-core-api-acceptance.md
+++ b/docs/requirements/v0.2-worker-core-api-acceptance.md
@@ -31,6 +31,21 @@ v0.2 focuses on:
 - **Application files** live under `app/`
 - **Runtime data** lives under `user_data/` and must not be committed
 
+### Runtime path field names (recommended)
+
+To keep logs, `/health`, and future Dock UI diagnostics consistent, prefer using the following canonical names when surfacing runtime paths:
+
+- `app_dir`: absolute path to the repository `app/` directory
+- `user_data_dir`: absolute path to the repository `user_data/` directory
+- `config_dir`: absolute path to `user_data/config/`
+- `data_dir`: absolute path to `user_data/data/`
+- `logs_dir`: absolute path to `user_data/logs/`
+
+Notes:
+
+- These are **field names**; the underlying directory layout remains `user_data/*` as defined by `AGENTS.md`.
+- If exposing absolute paths is undesirable in `/health`, it is acceptable to omit them there and keep them in startup logs only — but the field names and meanings should remain stable.
+
 ---
 
 ## Acceptance Checklist
@@ -61,7 +76,12 @@ v0.2 focuses on:
   - [ ] Worker version (or explicit `unknown` placeholder)
   - [ ] host/port
   - [ ] config path (or “no config loaded”)
-  - [ ] `user_data/` base dir and `logs_dir`
+  - [ ] runtime paths using stable field names (recommended):
+    - [ ] `app_dir`
+    - [ ] `user_data_dir`
+    - [ ] `config_dir`
+    - [ ] `data_dir`
+    - [ ] `logs_dir`
 
 ### D. Configuration Loading (Scaffold)
 
@@ -91,6 +111,12 @@ v0.2 focuses on:
   - [ ] `uptime_seconds`
   - [ ] `config_loaded` (boolean)
   - [ ] `runtime_dirs_ok` (boolean)
+- [ ] If runtime paths are included, they use stable names (recommended):
+  - [ ] `paths.app_dir`
+  - [ ] `paths.user_data_dir`
+  - [ ] `paths.config_dir`
+  - [ ] `paths.data_dir`
+  - [ ] `paths.logs_dir`
 - [ ] If startup is partially degraded (e.g. logging fallback), `/health` reflects that with `status=degraded` and details.
 
 ### G. Shutdown Behavior


### PR DESCRIPTION
## Summary
Clarify canonical runtime path field names for v0.2 so future Worker logs and `/health` responses can expose paths consistently without mixing application code and runtime data.

## Changes
- Update `docs/requirements/v0.2-worker-core-api-acceptance.md` to define recommended path field names (`app_dir`, `user_data_dir`, `config_dir`, `data_dir`, `logs_dir`).
- Tighten the acceptance checklist so startup logs and `/health` path fields use stable names.

## Related Issues
- Refs #52

## Scope Guardrails
- Documentation-only change.
- No roadmap semantic changes.
- No runtime data, secrets, tokens, logs, DBs, or generated assets committed.

## Verification
- Manual: read the updated acceptance checklist and confirm it matches `AGENTS.md` runtime separation rules.
