### PR TITLE
worker(v0.2): add configuration loading scaffold

### DIFF
--- a/app/worker/README.md
+++ b/app/worker/README.md
@@ -21,4 +21,8 @@ A minimal package scaffold exists under `app/worker/odr_worker/`.
 - Print version: `python -m odr_worker --version`
 - Placeholder run: `python -m odr_worker`
 
+Configuration scaffold (v0.2):
+- default config path: `user_data/config/worker.toml`
+- docs: `docs/architecture/worker-config.md`
+
 Implementation work is tracked by issues #11-#16.

--- a/app/worker/odr_worker/config.py
+++ b/app/worker/odr_worker/config.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import os
+import tomllib
+
+
+@dataclass(frozen=True)
+class WorkerConfig:
+    """Worker configuration scaffold (v0.2).
+
+    v0.2 intentionally keeps configuration minimal. Later issues can extend this
+    structure once the Worker runtime behavior is implemented.
+    """
+
+    host: str = "127.0.0.1"
+    port: int = 8787
+
+
+@dataclass(frozen=True)
+class LoadedWorkerConfig:
+    config: WorkerConfig
+    config_path: Path
+    config_loaded: bool
+
+
+def get_repo_root() -> Path:
+    """Return the repository root directory.
+
+    Assumption (v0.2 scaffold): this file lives at:
+    `<repo>/app/worker/odr_worker/config.py`.
+
+    This is a scaffold helper; if the layout changes later, update this logic.
+    """
+
+    return Path(__file__).resolve().parents[3]
+
+
+def get_user_data_dir() -> Path:
+    """Return the runtime user_data directory.
+
+    Default: `<repo>/user_data/`
+
+    Override (optional): set `ODR_USER_DATA_DIR` to an absolute path.
+    """
+
+    override = os.getenv("ODR_USER_DATA_DIR")
+    if override:
+        return Path(override).expanduser().resolve()
+
+    return get_repo_root() / "user_data"
+
+
+def get_default_config_path(user_data_dir: Path | None = None) -> Path:
+    base_dir = user_data_dir or get_user_data_dir()
+    return base_dir / "config" / "worker.toml"
+
+
+def load_worker_config(user_data_dir: Path | None = None) -> LoadedWorkerConfig:
+    """Load Worker configuration from `user_data/config/worker.toml`.
+
+    - Missing config file is allowed and returns defaults.
+    - Secrets MUST NOT be stored in git; see `AGENTS.md`.
+    """
+
+    config_path = get_default_config_path(user_data_dir)
+
+    if not config_path.exists():
+        return LoadedWorkerConfig(config=WorkerConfig(), config_path=config_path, config_loaded=False)
+
+    raw = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    config_table = raw.get("worker", {})
+
+    host = str(config_table.get("host", WorkerConfig.host))
+    port = int(config_table.get("port", WorkerConfig.port))
+
+    return LoadedWorkerConfig(
+        config=WorkerConfig(host=host, port=port),
+        config_path=config_path,
+        config_loaded=True,
+    )

--- a/docs/architecture/worker-config.md
+++ b/docs/architecture/worker-config.md
@@ -1,0 +1,49 @@
+# Worker Configuration (v0.2 scaffold)
+
+This document defines where the Python Worker loads configuration from in **v0.2**.
+
+This is intentionally minimal and designed to preserve:
+- responsibility separation (Plugin vs Worker)
+- restart safety
+- runtime data separation (`user_data/`)
+- secret-safety (no OAuth tokens or credentials in git)
+
+## Runtime location
+
+The Worker loads config from the runtime directory:
+
+- `user_data/config/worker.toml`
+
+The Worker MUST be able to start with **no config file present**.
+
+## Secrets
+
+Secrets / OAuth credentials MUST NOT be committed to git.
+
+The following paths MUST remain ignored (see `AGENTS.md`):
+- `config/secrets/`
+- `user_data/config/secrets/`
+
+## v0.2 config shape
+
+The Worker reads a single TOML file with a top-level `[worker]` table.
+
+Example:
+
+```toml
+[worker]
+host = "127.0.0.1"
+port = 8787
+```
+
+Notes:
+- v0.2 keeps this minimal (host/port only).
+- Additional settings (logging, feature flags, etc.) should be added by later issues.
+
+## Environment override (optional)
+
+For development, the Worker may support overriding the runtime directory via an environment variable:
+
+- `ODR_USER_DATA_DIR` (absolute path)
+
+This should remain an optional developer convenience; the default is still `<repo>/user_data/`.


### PR DESCRIPTION
## Summary
Adds a minimal Worker configuration loading scaffold and documents the v0.2 config location under `user_data/`.

## Changes
- Adds `app/worker/odr_worker/config.py` with default config path `user_data/config/worker.toml` and optional `ODR_USER_DATA_DIR` override.
- Adds `docs/architecture/worker-config.md` describing v0.2 config shape and secret-safety rules.
- Updates `app/worker/README.md` to reference the config scaffold.

## Related Issues
- Closes #12

## Scope Guardrails
- No FastAPI/uvicorn, no API endpoints.
- No runtime data, secrets, OAuth tokens, logs, DBs, or generated media committed.
- Keeps Plugin/Worker responsibility separation intact.

## Verification
- Manual: reviewed paths and ensured missing config file behavior remains supported by design.
