### PR TITLE
worker(v0.2): create runtime directories on startup

### DIFF
--- a/app/worker/odr_worker/__main__.py
+++ b/app/worker/odr_worker/__main__.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
+from .runtime_dirs import RuntimeDirError, ensure_runtime_dirs
 from .version import __version__
 
 
@@ -19,11 +21,19 @@ def main(argv: list[str] | None = None) -> int:
         print(__version__)
         return 0
 
+    try:
+        runtime_dirs = ensure_runtime_dirs()
+    except RuntimeDirError as exc:
+        print(f"Runtime directory initialization failed: {exc}", file=sys.stderr)
+        return 2
+
     print(
         "OBS Duel Recorder Worker (v0.2 scaffold)\n"
         "\n"
         "This is a placeholder entrypoint added by the v0.2 skeleton issue.\n"
         "Implementation is tracked by issues #11-#16.\n"
+        "\n"
+        f"Runtime directories ensured under: {runtime_dirs.user_data_dir}\n"
     )
     return 0
 

--- a/app/worker/odr_worker/runtime_dirs.py
+++ b/app/worker/odr_worker/runtime_dirs.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .config import get_user_data_dir
+
+
+class RuntimeDirError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class RuntimeDirs:
+    user_data_dir: Path
+    config_dir: Path
+    data_dir: Path
+    logs_dir: Path
+    db_dir: Path
+    videos_dir: Path
+    screenshots_dir: Path
+    exports_dir: Path
+
+
+def _mkdir_or_raise(path: Path, label: str) -> None:
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RuntimeDirError(f"Failed to create {label} directory: {path}") from exc
+
+    if not path.is_dir():
+        raise RuntimeDirError(f"Expected {label} to be a directory: {path}")
+
+
+def ensure_runtime_dirs(user_data_dir: Path | None = None) -> RuntimeDirs:
+    """Ensure v0.2 runtime directories exist.
+
+    This is intentionally restart-safe and idempotent:
+    - creates directories if missing
+    - never deletes or overwrites existing runtime data
+
+    Default runtime root is `<repo>/user_data/`, but can be overridden using
+    `ODR_USER_DATA_DIR` (see `odr_worker.config.get_user_data_dir`).
+    """
+
+    root = (user_data_dir or get_user_data_dir()).expanduser().resolve()
+
+    config_dir = root / "config"
+    data_dir = root / "data"
+    logs_dir = root / "logs"
+
+    db_dir = data_dir / "db"
+    videos_dir = data_dir / "videos"
+    screenshots_dir = data_dir / "screenshots"
+    exports_dir = data_dir / "exports"
+
+    _mkdir_or_raise(root, "user_data")
+    _mkdir_or_raise(config_dir, "config")
+    _mkdir_or_raise(data_dir, "data")
+    _mkdir_or_raise(logs_dir, "logs")
+
+    _mkdir_or_raise(db_dir, "db")
+    _mkdir_or_raise(videos_dir, "videos")
+    _mkdir_or_raise(screenshots_dir, "screenshots")
+    _mkdir_or_raise(exports_dir, "exports")
+
+    return RuntimeDirs(
+        user_data_dir=root,
+        config_dir=config_dir,
+        data_dir=data_dir,
+        logs_dir=logs_dir,
+        db_dir=db_dir,
+        videos_dir=videos_dir,
+        screenshots_dir=screenshots_dir,
+        exports_dir=exports_dir,
+    )

--- a/docs/architecture/plugin-worker.md
+++ b/docs/architecture/plugin-worker.md
@@ -94,6 +94,9 @@ Plugin and Worker communicate using localhost HTTP APIs.
 For Dock UI behavior and actionable diagnostics, see:
 - `docs/architecture/worker-diagnostics.md`
 
+For runtime directory rules and startup-safe directory creation, see:
+- `docs/architecture/runtime-dirs.md`
+
 Example:
 - GET /health
 - POST /events/recording-started

--- a/docs/architecture/runtime-dirs.md
+++ b/docs/architecture/runtime-dirs.md
@@ -1,0 +1,49 @@
+# Runtime Directories (v0.2)
+
+The Worker must keep **application code** and **runtime data** separated:
+
+- Application code: `app/`
+- Runtime data: `user_data/`
+
+This document describes the v0.2 runtime directory layout and the expected Worker startup behavior.
+
+---
+
+## Directory Layout
+
+The Worker uses the following runtime directories under the runtime root:
+
+- `user_data/config/`
+- `user_data/data/`
+  - `user_data/data/db/`
+  - `user_data/data/videos/`
+  - `user_data/data/screenshots/`
+  - `user_data/data/exports/`
+- `user_data/logs/`
+
+---
+
+## Startup Behavior
+
+On startup, the Worker SHOULD:
+
+- Create the required directories if they do not exist.
+- Treat directory creation as **idempotent** (safe to run repeatedly).
+- Fail fast with an actionable error if any required directory cannot be created.
+
+The Worker MUST NOT:
+
+- Delete or overwrite existing runtime data during directory creation.
+- Commit any runtime data (DBs, logs, screenshots, videos, exports, tokens, secrets) to git.
+
+---
+
+## Runtime Root Override
+
+By default, the runtime root is `<repo>/user_data/`.
+
+If needed, the runtime root can be overridden using the environment variable:
+
+- `ODR_USER_DATA_DIR` (absolute path recommended)
+
+See `odr_worker.config.get_user_data_dir` for the current v0.2 scaffold behavior.


### PR DESCRIPTION
## Summary
Implements v0.2 runtime directory creation as an idempotent, restart-safe initializer, and wires it into the current Worker CLI scaffold.

## Changes
- Add `app/worker/odr_worker/runtime_dirs.py` providing `ensure_runtime_dirs()` and `RuntimeDirs`.
- Update `app/worker/odr_worker/__main__.py` to ensure runtime directories before continuing.
- Add `docs/architecture/runtime-dirs.md` documenting the v0.2 runtime directory layout and safety rules.
- Link the new doc from `docs/architecture/plugin-worker.md`.

## Related Issues
- Closes #15

## Scope Guardrails
- No logging implementation (tracked separately).
- No FastAPI/`/health` implementation (tracked separately).
- No runtime data, secrets, OAuth tokens, logs, DBs, or generated media committed.

## Verification
- Manual: ensure runtime dir creation is idempotent and does not delete or overwrite existing `user_data/` contents.
