### PR TITLE
worker(v0.2): initialize logging on startup

### DIFF
--- a/app/worker/odr_worker/__main__.py
+++ b/app/worker/odr_worker/__main__.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import sys
 
+from .logging_setup import init_worker_logging
 from .runtime_dirs import RuntimeDirError, ensure_runtime_dirs
 from .version import __version__
 
@@ -27,6 +29,9 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Runtime directory initialization failed: {exc}", file=sys.stderr)
         return 2
 
+    log_path = init_worker_logging(runtime_dirs.logs_dir)
+    logging.getLogger(__name__).info("Worker startup initialized")
+
     print(
         "OBS Duel Recorder Worker (v0.2 scaffold)\n"
         "\n"
@@ -34,6 +39,7 @@ def main(argv: list[str] | None = None) -> int:
         "Implementation is tracked by issues #11-#16.\n"
         "\n"
         f"Runtime directories ensured under: {runtime_dirs.user_data_dir}\n"
+        f"Logging initialized: {log_path}\n"
     )
     return 0
 

--- a/app/worker/odr_worker/logging_setup.py
+++ b/app/worker/odr_worker/logging_setup.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+from pathlib import Path
+
+
+def init_worker_logging(logs_dir: Path, level: int = logging.INFO) -> Path:
+    """Initialize minimal Worker logging.
+
+    v0.2 goals:
+    - write logs under `user_data/logs/`
+    - use per-startup-date log files
+    - keep initialization idempotent (safe to call multiple times)
+    """
+
+    logs_dir = logs_dir.expanduser().resolve()
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    log_name = f"worker-{_dt.date.today().isoformat()}.log"
+    log_path = (logs_dir / log_name).resolve()
+
+    root = logging.getLogger()
+    root.setLevel(level)
+
+    for handler in root.handlers:
+        if isinstance(handler, logging.FileHandler):
+            existing = getattr(handler, "baseFilename", None)
+            if existing and Path(existing).resolve() == log_path:
+                return log_path
+
+    file_handler = logging.FileHandler(log_path, encoding="utf-8")
+    file_handler.setLevel(level)
+    file_handler.setFormatter(
+        logging.Formatter(
+            fmt="%(asctime)s %(levelname)s %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
+    root.addHandler(file_handler)
+
+    if not any(isinstance(h, logging.StreamHandler) for h in root.handlers):
+        stream_handler = logging.StreamHandler()
+        stream_handler.setLevel(level)
+        stream_handler.setFormatter(logging.Formatter(fmt="%(levelname)s %(name)s: %(message)s"))
+        root.addHandler(stream_handler)
+
+    return log_path

--- a/docs/architecture/plugin-worker.md
+++ b/docs/architecture/plugin-worker.md
@@ -97,6 +97,9 @@ For Dock UI behavior and actionable diagnostics, see:
 For runtime directory rules and startup-safe directory creation, see:
 - `docs/architecture/runtime-dirs.md`
 
+For v0.2 Worker logging behavior, see:
+- `docs/architecture/worker-logging.md`
+
 Example:
 - GET /health
 - POST /events/recording-started

--- a/docs/architecture/worker-logging.md
+++ b/docs/architecture/worker-logging.md
@@ -1,0 +1,52 @@
+# Worker Logging (v0.2)
+
+This document defines the minimal logging behavior for the Python Worker during v0.2.
+
+Goals:
+- Write logs to a predictable location under `user_data/`.
+- Use date-based log files for easy troubleshooting.
+- Keep logging initialization lightweight and restart-safe.
+
+---
+
+## Log Location
+
+Worker logs MUST be written under:
+
+- `user_data/logs/`
+
+The Worker MUST NOT commit logs to git.
+
+---
+
+## Log File Naming
+
+v0.2 uses per-startup-date log files:
+
+- `worker-YYYY-MM-DD.log`
+
+Multiple runs on the same date append to the same file.
+
+---
+
+## Startup Behavior
+
+On startup, the Worker SHOULD:
+
+- Ensure `user_data/logs/` exists.
+- Initialize logging early so startup failures can be captured.
+- Avoid adding duplicate handlers when initialized multiple times.
+
+---
+
+## Scope Guardrails (v0.2)
+
+This document covers only minimal startup logging.
+
+It does NOT define:
+- structured logging
+- log rotation
+- per-module log levels
+- upload/queue/database logging policies
+
+Those can be expanded in later milestones.


### PR DESCRIPTION
## Summary
Add minimal Worker logging initialization for v0.2, writing date-based log files under `user_data/logs/`.

## Changes
- Add `app/worker/odr_worker/logging_setup.py` with `init_worker_logging()`.
- Initialize logging in `app/worker/odr_worker/__main__.py` immediately after runtime dirs are ensured.
- Add `docs/architecture/worker-logging.md` and link it from `docs/architecture/plugin-worker.md`.

## Related Issues
- Refs #14
- Depends on #15 (implemented in PR #60)

## Scope Guardrails
- No FastAPI/`/health` implementation (tracked separately).
- No queue/SQLite/upload/OCR/template matching logging policy.
- No runtime data, secrets, OAuth tokens, logs, DBs, or generated media committed.

## Verification
- Manual: run `odr-worker` twice and confirm `user_data/logs/worker-YYYY-MM-DD.log` is created and appended to without duplicate handler spam.
