### PR TITLE
fix(worker): ensure console StreamHandler is added

### DIFF
--- a/app/worker/odr_worker/logging_setup.py
+++ b/app/worker/odr_worker/logging_setup.py
@@ -39,7 +39,11 @@ def init_worker_logging(logs_dir: Path, level: int = logging.INFO) -> Path:
     )
     root.addHandler(file_handler)
 
-    if not any(isinstance(h, logging.StreamHandler) for h in root.handlers):
+    has_console_stream = any(
+        isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        for h in root.handlers
+    )
+    if not has_console_stream:
         stream_handler = logging.StreamHandler()
         stream_handler.setLevel(level)
         stream_handler.setFormatter(logging.Formatter(fmt="%(levelname)s %(name)s: %(message)s"))


### PR DESCRIPTION
## Summary
Ensure Worker logging initializes both a file handler and a console stream handler.

## Changes
- Update `app/worker/odr_worker/logging_setup.py` so the “console handler exists?” check does not treat `logging.FileHandler` as a console stream handler.

## Related Issues
- Refs #14

## Scope Guardrails
- No FastAPI/`/health` work.
- No queue/SQLite/upload/OCR/template matching changes.
- No runtime data, secrets, OAuth tokens, logs, DBs, or generated media committed.

## Verification
- Manual: run `odr-worker` and confirm logs are written to both stdout/stderr and `user_data/logs/worker-YYYY-MM-DD.log`.

Closes: (none)