### PR TITLE
docs: add traceability index (v0.1–v0.2)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This directory is the documentation entry point for OBS Duel Recorder.
 
 - [Roadmap](roadmap.md)
 - [Requirements](requirements/requirements.md)
+- [Traceability](traceability.md)
 - [Release and tag policy](release.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
 

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -1,0 +1,51 @@
+# Traceability
+
+This page links the canonical roadmap (`docs/roadmap.md`) to the requirements (`docs/requirements/requirements.md`) and version-scoped acceptance checklists.
+
+Goals:
+- Reduce duplicate/overlapping issues by making “where is this defined?” easy to answer.
+- Keep `docs/roadmap.md` as the canonical feature plan.
+- Keep `docs/requirements/requirements.md` as stable, cross-version requirements.
+- Use acceptance checklists to define “done” for a specific roadmap minor version.
+
+---
+
+## v0.x
+
+### v0.1 — Repository Foundation
+
+- Roadmap: `docs/roadmap.md` → **v0.1 - Repository Foundation**
+- Acceptance checklist: `docs/requirements/v0.1-acceptance.md`
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` → Architecture / Platform / Runtime Rules
+
+### v0.2 — Worker Core API
+
+- Roadmap: `docs/roadmap.md` → **v0.2 - Worker Core API**
+- Acceptance checklist: `docs/requirements/v0.2-worker-core-api-acceptance.md`
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` → Architecture / Platform / Runtime Rules
+  - `AGENTS.md` → Logging Rules / Runtime Directory Rules / Responsibility Separation
+
+---
+
+## Policy
+
+### When to update `docs/requirements/requirements.md`
+
+Update requirements when the rule is expected to remain true across versions (e.g., responsibility separation, runtime-data persistence, “no assets distributed”, logging location rules).
+
+### When to add or update an acceptance checklist
+
+Add (or extend) an acceptance checklist when you need version-scoped “definition of done” criteria to guide implementation and review for a specific roadmap minor version (e.g., v0.2 Worker Core API).
+
+### When to create a new issue vs update docs
+
+- If a change introduces a new responsibility or deliverable, create a new issue.
+- If a change only clarifies an existing rule or acceptance criteria, update the appropriate doc.
+
+---
+
+## Related Issues
+
+- Refs #56


### PR DESCRIPTION
## Summary
Add a docs-first traceability index that links `docs/roadmap.md`, `docs/requirements/requirements.md`, and minor-version acceptance checklists.

## Changes
- Add `docs/traceability.md` covering v0.1–v0.2 mapping and doc-update policy.
- Link the new page from `docs/README.md`.

## Related Issues
- Closes #56

## Scope Guardrails
- Documentation-only.
- No semantic changes to `docs/roadmap.md`.
- No runtime data, secrets, OAuth tokens, logs, DBs, or generated assets committed.

## Verification
- Manual: read `docs/traceability.md` and confirm links/paths match existing docs.
