### PR TITLE
docs(release): add v0.2 readiness checklist (#51)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [Requirements](requirements/requirements.md)
 - [Traceability](traceability.md)
 - [Release and tag policy](release.md)
+- [v0.2 release readiness checklist](release/v0.2-release-readiness.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
 
 ## Architecture

--- a/docs/release.md
+++ b/docs/release.md
@@ -39,6 +39,14 @@ Do not tag an unmerged feature branch as a release.
 
 Do not move or overwrite an existing tag without explicit maintainer approval.
 
+## Release Readiness
+
+Use a version-scoped readiness checklist before tagging:
+
+- v0.2: `docs/release/v0.2-release-readiness.md`
+
+Do not retroactively create a `v0.1.0` tag unless explicitly approved.
+
 ## Agent Responsibilities
 
 When a major or minor roadmap milestone is completed:

--- a/docs/release/v0.2-release-readiness.md
+++ b/docs/release/v0.2-release-readiness.md
@@ -1,0 +1,51 @@
+# v0.2 Release Readiness Checklist
+
+This checklist helps contributors prepare a **v0.2.0** release for OBS Duel Recorder.
+
+Scope:
+- Documentation and verification steps for **v0.2 - Worker Core API** readiness.
+- No implementation work is performed by this checklist.
+
+Non-goals:
+- Creating the tag in this document.
+- Retroactively tagging `v0.1.0`.
+
+---
+
+## A. Milestone readiness
+
+- [ ] All required v0.2 issues are **closed** or explicitly **deferred** with a clear note.
+- [ ] Any deferred issues have an owner and a target version (e.g. v0.3+).
+
+## B. Documentation readiness
+
+- [ ] Canonical docs are up to date:
+  - [ ] `docs/roadmap.md` (canonical; do not rewrite during release)
+  - [ ] `docs/requirements/requirements.md`
+  - [ ] `docs/traceability.md`
+- [ ] v0.2 acceptance checklist reflects the intended behavior and has been reviewed:
+  - [ ] `docs/requirements/v0.2-worker-core-api-acceptance.md`
+
+## C. Verification (smoke)
+
+Perform these checks on Windows (no OBS required):
+
+- [ ] Worker starts successfully from the documented entrypoint.
+- [ ] Runtime directories exist (create-if-missing, idempotent):
+  - [ ] `user_data/config/`
+  - [ ] `user_data/data/`
+  - [ ] `user_data/logs/`
+- [ ] Logs are written under `user_data/logs/` and are preserved by default.
+- [ ] `GET /health` returns HTTP 200 and includes v0.2-required fields.
+
+## D. Release PR readiness
+
+- [ ] Release PR contains **no secrets** and does not add runtime data (logs/db/videos/screenshots).
+- [ ] The PR is merged into `main`.
+- [ ] The merge commit SHA on `main` is recorded for tagging.
+
+## E. Tagging (after merge)
+
+- [ ] Create tag `v0.2.0` pointing to the merge commit SHA on `main`.
+- [ ] Do **not** create a retroactive `v0.1.0` tag unless explicitly approved.
+


### PR DESCRIPTION
対応Issue: #51

変更内容:
- `docs/release/v0.2-release-readiness.md` を追加
- `docs/README.md` に checklist へのリンクを追加
- `docs/release.md` に readiness checklist の導線と v0.1 タグ注記を追加

差分は `docs/**` のみです。