### PR TITLE
docs: add version release tracking system

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [Requirements](requirements/requirements.md)
 - [Traceability](traceability.md)
 - [Release and tag policy](release.md)
+- [Release history](release-history.md)
+- [Version tracking issue template](release/version-tracking-issue-template.md)
 - [v0.2 release readiness checklist](release/v0.2-release-readiness.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
 
@@ -33,4 +35,5 @@ User-facing setup and usage documents live under `docs/user/`.
 - Keep important design decisions under `docs/`.
 - Keep user-facing documentation under `docs/user/`.
 - Keep architecture and runtime behavior under `docs/architecture/`.
+- Keep completed release point information in `docs/release-history.md` or a version-specific release summary.
 - Do not use documentation pages to store runtime data, credentials, screenshots, or game assets.

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -1,0 +1,33 @@
+# Release History
+
+This document records completed release outcomes for OBS Duel Recorder.
+
+Use this file as the durable index for release point information. If a release needs more detail, create a version-specific summary under `docs/release/` and link it from this file.
+
+## Recording Policy
+
+For each completed release, record at least:
+
+- version and tag name
+- tag target commit SHA
+- release date/time
+- version tracking issue
+- release readiness checklist
+- major child issues and PRs
+- deferred items and their follow-up links
+- next version tracking issue
+
+The version tracking issue may contain the working release summary, but finalized release point information should be copied here before the tracking issue is closed.
+
+## Releases
+
+No release records have been finalized yet.
+
+### Planned: v0.2.0 - Worker Core API
+
+- Version tracking issue: #72
+- Milestone: `v0.2`
+- Release readiness checklist: `docs/release/v0.2-release-readiness.md`
+- Expected tag: `v0.2.0`
+- Release summary: `docs/release/v0.2-release-summary.md` if created
+- Status: in progress

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,6 @@
 # Release and Tag Policy
 
-This document defines release tagging rules for OBS Duel Recorder.
+This document defines release tracking and release tagging rules for OBS Duel Recorder.
 
 ## Version Format
 
@@ -21,6 +21,57 @@ Examples:
 - `v0.2.0`
 - `v1.0.0`
 
+## Version Terms
+
+Use separate terms for released and in-development versions:
+
+- `released_version`: the latest completed and published version.
+- `current_development_version`: the version currently being developed toward the next release boundary.
+
+Avoid using a single `current_version` term when it is unclear whether it means a released version or an in-development target.
+
+## Major and Minor Release Tracking
+
+Each major or minor roadmap version should have one version tracking issue.
+
+Tracking issue title format:
+
+```text
+[vX.Y] <roadmap scope> release tracking
+```
+
+Examples:
+- `[v0.2] Worker Core API release tracking`
+- `[v0.3] SQLite Foundation release tracking`
+
+The tracking issue is for version management, progress aggregation, release readiness, release records, and handoff to the next version. Implementation work, documentation changes, validation work, and fixes must be handled by child issues or PRs.
+
+Milestones are prepared by maintainers. The version tracking issue and its child issues should be assigned to the same version milestone when that milestone exists.
+
+A parent-specific label is not required. Use existing labels and the milestone to classify work.
+
+## Child Issues
+
+All active work for a version should be represented by child issues unless it is already captured by an existing non-duplicate issue.
+
+Child issues should remain scoped to one responsibility. Do not avoid creating a child issue merely because it is small, as long as it is not a duplicate and it belongs to the version scope.
+
+Work that does not belong to the target version should be excluded or moved to another version. Work that belongs to the target version but will not be completed before release must be explicitly deferred to a follow-up issue or later version tracking issue.
+
+## Patch Releases
+
+Patch versions are not the normal unit for roadmap milestone progress.
+
+Patch tags are optional. They should be created only when a patch release is packaged, published, or used as a recovery/update boundary.
+
+Maintenance, documentation, and automation updates made during ongoing minor-version development are normally absorbed into the next minor release. Do not increment patch versions for every small change.
+
+If a completed release needs a patch boundary, create a small patch tracking issue when useful, for example:
+
+```text
+[v0.2.1] Patch release tracking
+```
+
 ## When Tags Are Required
 
 Tags are required when a major or minor version is completed and merged into `main`.
@@ -29,7 +80,7 @@ Required tag points:
 - Major release completion: tag the merged release commit as `vX.0.0`, unless the release plan explicitly defines a different minor or patch number.
 - Minor release completion: tag the merged release commit as `vX.Y.0`.
 
-Patch tags are optional. They should be created when a patch release is packaged, published, or used as a recovery/update boundary.
+Patch tags are optional and are created only when a patch release boundary is intentionally needed.
 
 ## Tag Target
 
@@ -47,15 +98,40 @@ Use a version-scoped readiness checklist before tagging:
 
 Do not retroactively create a `v0.1.0` tag unless explicitly approved.
 
+## Release Records
+
+Release point information must be preserved outside the tracking issue before the tracking issue is closed.
+
+Use:
+- `docs/release-history.md` as the release history index.
+- `docs/release/vX.Y-release-summary.md` when a release needs a detailed summary.
+
+Record at least:
+- release version and tag name
+- tag target commit SHA
+- release date/time
+- version tracking issue
+- major child issues and PRs
+- deferred items and their follow-up links
+- next version tracking issue
+
+The tracking issue may contain the latest working summary, but it should not be the only durable release record.
+
 ## Agent Responsibilities
 
 When a major or minor roadmap milestone is completed:
 
-1. Confirm all required issues for the milestone are closed or intentionally deferred.
-2. Confirm the release PR is merged into `main`.
-3. Identify the merged commit SHA on `main`.
-4. Create the release tag if the available GitHub tooling supports tag creation.
-5. If tag creation is not available, report the intended tag name and target commit SHA.
+1. Confirm all required child issues for the milestone are closed or intentionally deferred.
+2. Confirm open PRs for the version are merged or intentionally deferred.
+3. Confirm the release readiness checklist is complete.
+4. Confirm the release PR is merged into `main`.
+5. Identify the merged commit SHA on `main`.
+6. Create the release tag if the available GitHub tooling supports tag creation.
+7. If tag creation is not available, report the intended tag name and target commit SHA.
+8. Save release point information to persistent release docs.
+9. Confirm version information such as `released_version` and `current_development_version` is updated where defined.
+10. Confirm the next version tracking issue is created from `docs/roadmap.md`.
+11. Link the next version tracking issue from the completed tracking issue.
 
 Agents must preserve runtime data and must not include secrets, OAuth tokens, logs, databases, generated media, screenshots, or game assets in release work.
 
@@ -66,3 +142,9 @@ Automation may create release-preparation issues or PRs when a milestone is near
 Automation must not merge release PRs.
 
 Automation must not move existing tags.
+
+Automation must not create labels or milestones.
+
+Recurring issue review should treat version tracking issues as coordination records, not as implementation tasks. Implementation and documentation work should happen through child issues or PRs.
+
+Documentation automation should report validation failures to the appropriate validation issue or configured memory/reporting location rather than repeatedly updating the version tracking issue.

--- a/docs/release/v0.2-release-readiness.md
+++ b/docs/release/v0.2-release-readiness.md
@@ -6,6 +6,10 @@ Scope:
 - Documentation and verification steps for **v0.2 - Worker Core API** readiness.
 - No implementation work is performed by this checklist.
 
+Tracking:
+- Version tracking issue: #72 (`[v0.2] Worker Core API release tracking`)
+- Milestone: `v0.2`
+
 Non-goals:
 - Creating the tag in this document.
 - Retroactively tagging `v0.1.0`.
@@ -14,8 +18,10 @@ Non-goals:
 
 ## A. Milestone readiness
 
-- [ ] All required v0.2 issues are **closed** or explicitly **deferred** with a clear note.
+- [ ] All required v0.2 child issues are **closed** or explicitly **deferred** with a clear note.
 - [ ] Any deferred issues have an owner and a target version (e.g. v0.3+).
+- [ ] The version tracking issue lists required child issues, related PRs, deferred work, and next-version handoff status.
+- [ ] No implementation or documentation work is tracked only in the version tracking issue.
 
 ## B. Documentation readiness
 
@@ -23,8 +29,12 @@ Non-goals:
   - [ ] `docs/roadmap.md` (canonical; do not rewrite during release)
   - [ ] `docs/requirements/requirements.md`
   - [ ] `docs/traceability.md`
+  - [ ] `docs/release.md`
 - [ ] v0.2 acceptance checklist reflects the intended behavior and has been reviewed:
   - [ ] `docs/requirements/v0.2-worker-core-api-acceptance.md`
+- [ ] Release record location is prepared:
+  - [ ] `docs/release-history.md`
+  - [ ] `docs/release/v0.2-release-summary.md` if a detailed summary is needed
 
 ## C. Verification (smoke)
 
@@ -49,3 +59,10 @@ Perform these checks on Windows (no OBS required):
 - [ ] Create tag `v0.2.0` pointing to the merge commit SHA on `main`.
 - [ ] Do **not** create a retroactive `v0.1.0` tag unless explicitly approved.
 
+## F. Release record and handoff
+
+- [ ] Release point information is saved in `docs/release-history.md` or `docs/release/v0.2-release-summary.md`.
+- [ ] `released_version` and `current_development_version` information is updated where defined.
+- [ ] The next version tracking issue is created from `docs/roadmap.md`.
+- [ ] The next version tracking issue is linked from #72.
+- [ ] #72 is closed only after release record and next-version handoff are complete.

--- a/docs/release/version-tracking-issue-template.md
+++ b/docs/release/version-tracking-issue-template.md
@@ -1,0 +1,96 @@
+# Version Tracking Issue Template
+
+Use this template for major and minor roadmap version tracking issues.
+
+Tracking issue title format:
+
+```text
+[vX.Y] <roadmap scope> release tracking
+```
+
+Examples:
+- `[v0.2] Worker Core API release tracking`
+- `[v0.3] SQLite Foundation release tracking`
+
+```markdown
+## Summary
+Track vX.Y release progress, child issues, readiness, release record, and handoff to the next version.
+
+This is a version management issue. Implementation, documentation changes, validation work, and fixes must be handled by child issues or PRs.
+
+## Scope
+Roadmap section: `docs/roadmap.md` -> `vX.Y - <scope>`
+
+## Non-goals
+- Work outside the vX.Y milestone
+- Roadmap semantic changes
+- Implementation work directly from this tracking issue
+
+## Canonical Sources
+- Roadmap: `docs/roadmap.md`
+- Requirements: `docs/requirements/requirements.md`
+- Acceptance checklist:
+- Release readiness checklist:
+- Release and tag policy: `docs/release.md`
+
+## Child Issues
+
+### Required Scope
+- [ ] #...
+
+### Documentation / Validation Scope
+- [ ] #...
+
+### Deferred / Out of Scope
+- #...
+
+## Related PRs
+- [ ] #...
+
+## Release Readiness
+- [ ] Required child issues are closed or explicitly deferred.
+- [ ] Open version PRs are reviewed and merged or deferred.
+- [ ] Acceptance checklist is reviewed.
+- [ ] Release readiness checklist is complete.
+- [ ] Release PR is merged into `main`.
+- [ ] Tag target commit SHA on `main` is identified.
+- [ ] Completion tag is created, or intended tag/SHA is reported if tooling cannot create it.
+- [ ] Release point information is saved to persistent release docs.
+- [ ] Version information is updated where defined.
+- [ ] Next version tracking issue is created from `docs/roadmap.md`.
+- [ ] Next version tracking issue is linked here.
+- [ ] Deferred work is moved to follow-up issues or later version tracking.
+
+## Release Record
+After release, save finalized release point information in persistent docs:
+
+- `docs/release-history.md`
+- optionally `docs/release/vX.Y-release-summary.md`
+
+Record at least:
+- tag name
+- commit SHA
+- created date/time
+- this tracking issue
+- major child issues and PRs
+- deferred items
+
+## Automation Boundaries
+- Recurring issue review may organize child issues and report status here when explicitly asked.
+- Idea discussion may propose or promote child issues, but should not change release gates directly.
+- Documentation automation should report validation failures to the appropriate docs validation issue, not repeatedly update this issue.
+- 12-hour summaries should be stored in the configured summary or memory location and only linked here when useful.
+
+## Next Version
+- Parent issue: TBD
+```
+
+## Patch Release Tracking
+
+Patch tracking issues are optional and should be created only when a completed release needs an intentional patch boundary.
+
+Patch tracking title format:
+
+```text
+[vX.Y.Z] Patch release tracking
+```

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -1,43 +1,63 @@
 # Traceability
 
-This page links the canonical roadmap (`docs/roadmap.md`) to the requirements (`docs/requirements/requirements.md`) and version-scoped acceptance checklists.
+This page links the canonical roadmap (`docs/roadmap.md`) to requirements, version-scoped acceptance checklists, release tracking issues, and release records.
 
 Goals:
-- Reduce duplicate/overlapping issues by making “where is this defined?” easy to answer.
+- Reduce duplicate/overlapping issues by making "where is this defined?" easy to answer.
 - Keep `docs/roadmap.md` as the canonical feature plan.
 - Keep `docs/requirements/requirements.md` as stable, cross-version requirements.
-- Use acceptance checklists to define “done” for a specific roadmap minor version.
+- Use acceptance checklists to define "done" for a specific roadmap minor version.
+- Use version tracking issues to coordinate child issues, PRs, release readiness, and next-version handoff.
+- Preserve completed release point information in release history docs.
 
 ---
 
 ## v0.x
 
-### v0.1 — Repository Foundation
+### v0.1 - Repository Foundation
 
-- Roadmap: `docs/roadmap.md` → **v0.1 - Repository Foundation**
+- Roadmap: `docs/roadmap.md` -> **v0.1 - Repository Foundation**
 - Acceptance checklist: `docs/requirements/v0.1-acceptance.md`
 - Requirements (relevant sections):
-  - `docs/requirements/requirements.md` → Architecture / Platform / Runtime Rules
+  - `docs/requirements/requirements.md` -> Architecture / Platform / Runtime Rules
 
-### v0.2 — Worker Core API
+### v0.2 - Worker Core API
 
-- Roadmap: `docs/roadmap.md` → **v0.2 - Worker Core API**
+- Roadmap: `docs/roadmap.md` -> **v0.2 - Worker Core API**
+- Version tracking issue: `#72` - `[v0.2] Worker Core API release tracking`
+- Milestone: `v0.2`
 - Acceptance checklist: `docs/requirements/v0.2-worker-core-api-acceptance.md`
+- Release readiness checklist: `docs/release/v0.2-release-readiness.md`
+- Release record: `docs/release-history.md`; use `docs/release/v0.2-release-summary.md` if a detailed release summary is needed.
 - Requirements (relevant sections):
-  - `docs/requirements/requirements.md` → Architecture / Platform / Runtime Rules
-  - `AGENTS.md` → Logging Rules / Runtime Directory Rules / Responsibility Separation
+  - `docs/requirements/requirements.md` -> Architecture / Platform / Runtime Rules
+  - `AGENTS.md` -> Logging Rules / Runtime Directory Rules / Responsibility Separation
 
 ---
 
 ## Policy
 
+### Source roles
+
+- `docs/roadmap.md` is the canonical plan for what each roadmap version covers.
+- `docs/requirements/requirements.md` stores stable cross-version requirements.
+- Version acceptance checklists define the version-specific definition of done.
+- Version tracking issues coordinate active child issues, related PRs, readiness, release records, and next-version handoff.
+- `docs/release-history.md` and optional `docs/release/vX.Y-release-summary.md` files preserve finalized release point information after release.
+
 ### When to update `docs/requirements/requirements.md`
 
-Update requirements when the rule is expected to remain true across versions (e.g., responsibility separation, runtime-data persistence, “no assets distributed”, logging location rules).
+Update requirements when the rule is expected to remain true across versions (e.g., responsibility separation, runtime-data persistence, "no assets distributed", logging location rules).
 
 ### When to add or update an acceptance checklist
 
-Add (or extend) an acceptance checklist when you need version-scoped “definition of done” criteria to guide implementation and review for a specific roadmap minor version (e.g., v0.2 Worker Core API).
+Add (or extend) an acceptance checklist when you need version-scoped "definition of done" criteria to guide implementation and review for a specific roadmap minor version (e.g., v0.2 Worker Core API).
+
+### When to create a child issue
+
+Create or use a child issue for active implementation, documentation, validation, or release-preparation work that belongs to a version and is not already covered by a non-duplicate issue.
+
+The version tracking issue itself is not an implementation work item.
 
 ### When to create a new issue vs update docs
 
@@ -49,3 +69,4 @@ Add (or extend) an acceptance checklist when you need version-scoped “definiti
 ## Related Issues
 
 - Refs #56
+- Refs #72


### PR DESCRIPTION
## Summary

Document the version tracking issue system for major/minor releases and add the first v0.2 tracking references.

## Changes

- Expand `docs/release.md` with version tracking issue rules, patch release handling, version terms, release records, and automation boundaries.
- Link v0.2 tracking issue #72 from `docs/traceability.md` and `docs/release/v0.2-release-readiness.md`.
- Add `docs/release-history.md` as the durable release record index.
- Add `docs/release/version-tracking-issue-template.md` for future release tracking issues.
- Link the new release docs from `docs/README.md`.

## Related Issues

- Refs #72

## Scope Guardrails

- Documentation-only change.
- Does not change `docs/roadmap.md` semantics.
- Does not create labels or milestones.
- Does not create release tags.
- Does not touch runtime data, secrets, OAuth tokens, logs, databases, generated media, screenshots, or game assets.

## Verification

- Compared branch against `main`; changed only release/traceability documentation.
- Confirmed new docs are linked from `docs/README.md`.
- Confirmed v0.2 tracking issue #72 exists and is referenced from release readiness/traceability docs.
