### PR TITLE
chore: add focused issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Report a reproducible problem in OBS Duel Recorder
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken?
+      placeholder: The Worker fails to start when...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Keep this focused and reproducible.
+      placeholder: |
+        1. Start OBS...
+        2. Open the dock...
+        3. Trigger...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: The recorder should...
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: Instead...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - OBS Plugin
+        - Python Worker
+        - Dock UI / overlay
+        - SQLite / runtime data
+        - YouTube upload
+        - Documentation
+        - Unknown
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      placeholder: v0.2.0, commit SHA, or branch name
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: OBS version, OS, Python version, plugin/worker launch method
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Remove OAuth tokens, secrets, local account details, game screenshots, and generated exports before posting.
+      render: text
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Safety checks
+      options:
+        - label: I removed secrets, OAuth tokens, logs with private data, and Yu-Gi-Oh! Master Duel assets/screenshots.
+          required: true
+        - label: I searched existing issues before opening this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,53 @@
+name: Documentation issue
+description: Report missing, unclear, or stale documentation
+title: "[Docs]: "
+labels:
+  - documentation
+body:
+  - type: textarea
+    id: location
+    attributes:
+      label: Documentation location
+      description: Link the page, heading, file path, or section if known.
+      placeholder: docs/user/ja/youtube-setup.md, README.md, or unknown
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: What needs to change?
+      description: Describe what is missing, unclear, incorrect, or outdated.
+      placeholder: The setup guide does not explain...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected documentation
+      placeholder: It should explain...
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Audience
+      options:
+        - User
+        - Contributor
+        - Maintainer
+        - Release manager
+        - Unknown
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      placeholder: Related issue, PR, version, or implementation detail.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I checked whether this belongs in README.md, docs/, or user documentation.
+          required: true
+        - label: I searched existing issues before opening this documentation issue.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Propose a scoped enhancement for OBS Duel Recorder
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or workflow
+      description: What user or maintainer workflow should this improve?
+      placeholder: When reviewing recorded duels, it is hard to...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the smallest useful behavior change.
+      placeholder: Add...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - OBS Plugin
+        - Python Worker
+        - Dock UI / overlay
+        - SQLite / runtime data
+        - YouTube upload
+        - Packaging / release
+        - Documentation
+        - Cross-component
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      placeholder: Manual workaround, smaller scope, or reason this belongs later.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - ...
+        - ...
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: This is a concrete enhancement, not only an open-ended idea.
+          required: true
+        - label: I searched existing issues before opening this request.
+          required: true

--- a/.github/ISSUE_TEMPLATE/idea.yml
+++ b/.github/ISSUE_TEMPLATE/idea.yml
@@ -1,0 +1,54 @@
+name: Idea
+description: Capture an early concept that is not ready as a scoped feature
+title: "[Idea]: "
+labels:
+  - Idea
+body:
+  - type: textarea
+    id: concept
+    attributes:
+      label: Idea
+      description: Describe the concept in a few sentences.
+      placeholder: It might be useful if...
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why might this be valuable for OBS Duel Recorder?
+      placeholder: This could help because...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Possible area
+      options:
+        - OBS Plugin
+        - Python Worker
+        - Dock UI / overlay
+        - SQLite / runtime data
+        - YouTube upload
+        - Documentation
+        - Release / packaging
+        - Cross-component
+        - Not sure yet
+    validations:
+      required: true
+  - type: textarea
+    id: questions
+    attributes:
+      label: Open questions
+      placeholder: |
+        - Is this needed before v1.0?
+        - Does this belong in Worker or Plugin?
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: This is intentionally exploratory and may need refinement before implementation.
+          required: true
+        - label: I searched existing issues before opening this idea.
+          required: true


### PR DESCRIPTION
## Summary

- Add focused GitHub Issue forms for bug reports, feature requests, documentation issues, and early ideas.
- Apply existing labels: `bug`, `enhancement`, `documentation`, and `Idea`.
- Disable blank issues so new issues start from a structured form.

## Testing

- Not run; GitHub issue template configuration only.

## Scope

- Issue templates only.
- No repository settings, milestones, branch protection, or issue #64 changes.