### PR TITLE
docs: clarify localization policy and JP docs entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ obs-duel-recorder/
 - Template matching
 - Upload automation
 - Recovery system
-- GitHub Actions packaging
+- GitHub Actions based packaging
 - GitHub Pages documentation
 
 ---
@@ -124,7 +124,8 @@ Key documents:
 - [Release and tag policy](docs/release.md)
 - [v0.1 acceptance checklist](docs/requirements/v0.1-acceptance.md)
 - [Architecture docs](docs/architecture/)
-- [User docs](docs/user/)
+- [User docs (entry)](docs/user/index.md)
+- [User docs (日本語)](docs/user/ja/index.md)
 
 Planned GitHub Pages support is also included in the roadmap.
 

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -5,6 +5,12 @@ Select language / 言語を選択してください。
 - 日本語: [`docs/user/ja/index.md`](ja/index.md)
 - English (planned): [`docs/user/en/README.md`](en/README.md)
 
+## Localization policy
+
+- English documents are canonical (source of truth).
+- Japanese documents are translations and may include additional notes.
+- When content conflicts, follow the English docs and open an issue to fix the drift.
+
 ## Current user docs (English-base, pre-multilingual)
 
 These pages remain the current source of truth until `docs/user/en/**` is introduced:


### PR DESCRIPTION
## Summary
This PR is now redundant.

The same intent (README link to JP user docs + localization policy notes) has already been merged via #77.

Closing to reduce noise.
