### PR TITLE
worker(v0.2): implement FastAPI /health and startup

### DIFF
--- a/app/worker/README.md
+++ b/app/worker/README.md
@@ -19,7 +19,23 @@ The Worker must support restart-safe execution.
 A minimal package scaffold exists under `app/worker/odr_worker/`.
 
 - Print version: `python -m odr_worker --version`
-- Placeholder run: `python -m odr_worker`
+- Run API server (default host/port): `python -m odr_worker`
+
+### Quick start (Windows PowerShell)
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -e app/worker
+python -m odr_worker
+```
+
+Health check:
+
+```powershell
+Invoke-WebRequest http://127.0.0.1:8787/health | Select-Object -ExpandProperty Content
+```
 
 Configuration scaffold (v0.2):
 - default config path: `user_data/config/worker.toml`

--- a/app/worker/odr_worker/__main__.py
+++ b/app/worker/odr_worker/__main__.py
@@ -7,7 +7,7 @@ import sys
 import uvicorn
 
 from .api import create_app
-from .config import load_worker_config
+from .config import get_default_config_path, load_worker_config
 from .logging_setup import init_worker_logging
 from .runtime_dirs import RuntimeDirError, ensure_runtime_dirs
 from .version import __version__
@@ -33,10 +33,17 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Runtime directory initialization failed: {exc}", file=sys.stderr)
         return 2
 
-    loaded_config = load_worker_config(runtime_dirs.user_data_dir)
-
     log_path = init_worker_logging(runtime_dirs.logs_dir)
     logger = logging.getLogger(__name__)
+
+    try:
+        loaded_config = load_worker_config(runtime_dirs.user_data_dir)
+    except Exception as exc:
+        config_path = get_default_config_path(runtime_dirs.user_data_dir)
+        logger.exception("Failed to load worker config", extra={"config_path": str(config_path)})
+        print(f"Failed to load Worker config: {config_path}\nReason: {exc}", file=sys.stderr)
+        print(f"Logs: {log_path}", file=sys.stderr)
+        return 3
 
     logger.info("Worker startup initialized")
     logger.info("version=%s", __version__)

--- a/app/worker/odr_worker/__main__.py
+++ b/app/worker/odr_worker/__main__.py
@@ -4,6 +4,10 @@ import argparse
 import logging
 import sys
 
+import uvicorn
+
+from .api import create_app
+from .config import load_worker_config
 from .logging_setup import init_worker_logging
 from .runtime_dirs import RuntimeDirError, ensure_runtime_dirs
 from .version import __version__
@@ -29,17 +33,34 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Runtime directory initialization failed: {exc}", file=sys.stderr)
         return 2
 
-    log_path = init_worker_logging(runtime_dirs.logs_dir)
-    logging.getLogger(__name__).info("Worker startup initialized")
+    loaded_config = load_worker_config(runtime_dirs.user_data_dir)
 
-    print(
-        "OBS Duel Recorder Worker (v0.2 scaffold)\n"
-        "\n"
-        "This is a placeholder entrypoint added by the v0.2 skeleton issue.\n"
-        "Implementation is tracked by issues #11-#16.\n"
-        "\n"
-        f"Runtime directories ensured under: {runtime_dirs.user_data_dir}\n"
-        f"Logging initialized: {log_path}\n"
+    log_path = init_worker_logging(runtime_dirs.logs_dir)
+    logger = logging.getLogger(__name__)
+
+    logger.info("Worker startup initialized")
+    logger.info("version=%s", __version__)
+    logger.info("config_loaded=%s config_path=%s", loaded_config.config_loaded, loaded_config.config_path)
+    logger.info(
+        "paths app_dir=%s user_data_dir=%s config_dir=%s data_dir=%s logs_dir=%s",
+        (runtime_dirs.user_data_dir.parent / "app").resolve(),
+        runtime_dirs.user_data_dir,
+        runtime_dirs.config_dir,
+        runtime_dirs.data_dir,
+        runtime_dirs.logs_dir,
+    )
+
+    app = create_app(runtime_dirs=runtime_dirs, loaded_config=loaded_config)
+
+    logger.info("Starting API server host=%s port=%s", loaded_config.config.host, loaded_config.config.port)
+    logger.info("logs=%s", log_path)
+
+    uvicorn.run(
+        app,
+        host=loaded_config.config.host,
+        port=loaded_config.config.port,
+        log_config=None,
+        access_log=False,
     )
     return 0
 

--- a/app/worker/odr_worker/api.py
+++ b/app/worker/odr_worker/api.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from .config import LoadedWorkerConfig, get_repo_root
+from .health import WorkerPaths, build_health_payload
+from .runtime_dirs import RuntimeDirs
+
+
+def _error_payload(*, code: str, message: str, details: object | None = None) -> dict[str, object]:
+    payload: dict[str, object] = {"code": code, "message": message}
+    if details is not None:
+        payload["details"] = details
+    return payload
+
+
+def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig) -> FastAPI:
+    app = FastAPI(title="OBS Duel Recorder Worker", version="0.2.0-dev")
+
+    app_dir = (get_repo_root() / "app").resolve()
+
+    worker_paths = WorkerPaths(
+        app_dir=app_dir,
+        user_data_dir=runtime_dirs.user_data_dir,
+        config_dir=runtime_dirs.config_dir,
+        data_dir=runtime_dirs.data_dir,
+        logs_dir=runtime_dirs.logs_dir,
+    )
+
+    app.state.paths = worker_paths
+    app.state.config_loaded = loaded_config.config_loaded
+
+    @app.get("/health")
+    def health() -> dict[str, object]:
+        return build_health_payload(paths=app.state.paths, config_loaded=app.state.config_loaded)
+
+    @app.exception_handler(Exception)
+    async def unhandled_exception_handler(request: Request, exc: Exception):
+        logging.getLogger(__name__).exception("Unhandled exception", extra={"path": str(request.url.path)})
+        return JSONResponse(
+            status_code=500,
+            content=_error_payload(code="internal_error", message="Internal server error"),
+        )
+
+    return app

--- a/app/worker/odr_worker/health.py
+++ b/app/worker/odr_worker/health.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from .version import __version__
+
+
+API_VERSION = "0.2"
+_START_TIME = time.monotonic()
+
+
+@dataclass(frozen=True)
+class WorkerPaths:
+    app_dir: Path
+    user_data_dir: Path
+    config_dir: Path
+    data_dir: Path
+    logs_dir: Path
+
+
+def _as_posix(path: Path) -> str:
+    return path.resolve().as_posix()
+
+
+def build_health_payload(*, paths: WorkerPaths, config_loaded: bool) -> dict[str, object]:
+    uptime_seconds = int(max(0.0, time.monotonic() - _START_TIME))
+
+    return {
+        "status": "ok",
+        "version": __version__,
+        "api_version": API_VERSION,
+        "uptime_seconds": uptime_seconds,
+        "config_loaded": config_loaded,
+        "runtime_dirs_ok": True,
+        "paths": {
+            "app_dir": _as_posix(paths.app_dir),
+            "user_data_dir": _as_posix(paths.user_data_dir),
+            "config_dir": _as_posix(paths.config_dir),
+            "data_dir": _as_posix(paths.data_dir),
+            "logs_dir": _as_posix(paths.logs_dir),
+        },
+    }

--- a/app/worker/pyproject.toml
+++ b/app/worker/pyproject.toml
@@ -7,8 +7,11 @@ requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [{ name = "Tao-pyth" }]
 
-# v0.2 skeleton: keep dependencies minimal. Later issues add FastAPI/uvicorn.
-dependencies = []
+# v0.2: minimal localhost HTTP API foundation.
+dependencies = [
+  "fastapi>=0.110",
+  "uvicorn>=0.27",
+]
 
 [project.scripts]
 odr-worker = "odr_worker.__main__:main"

--- a/docs/architecture/plugin-worker.md
+++ b/docs/architecture/plugin-worker.md
@@ -103,6 +103,9 @@ For runtime directory rules and startup-safe directory creation, see:
 For v0.2 Worker logging behavior, see:
 - `docs/architecture/worker-logging.md`
 
+For the v0.2 Worker API contract, see:
+- `docs/architecture/worker-api.md`
+
 Example:
 - GET /health
 - POST /events/recording-started

--- a/docs/architecture/worker-api.md
+++ b/docs/architecture/worker-api.md
@@ -1,0 +1,41 @@
+# Worker API (v0.2)
+
+This document defines the minimal localhost HTTP API for **v0.2 - Worker Core API**.
+
+Scope (v0.2):
+- `GET /health` only
+- No queue / upload / OCR / template matching endpoints
+
+The Worker must run on localhost by default.
+
+---
+
+## `GET /health`
+
+Purpose:
+- Allow the OBS Plugin to detect whether the Worker is reachable and healthy.
+- Provide minimal diagnostic fields for the Dock UI.
+- Provide compatibility gating fields (`api_version`).
+
+### Response (v0.2)
+
+Minimum fields:
+
+- `status`: `ok` (v0.2 uses `ok` only; later versions may introduce `degraded`)
+- `version`: Worker version string
+- `api_version`: API contract version string (v0.2: `0.2`)
+- `uptime_seconds`: integer seconds since Worker start
+- `config_loaded`: whether `user_data/config/worker.toml` was loaded
+- `runtime_dirs_ok`: whether runtime directories were initialized successfully
+- `paths`: canonical runtime path fields
+  - `app_dir`
+  - `user_data_dir`
+  - `config_dir`
+  - `data_dir`
+  - `logs_dir`
+
+Compatibility rules for `api_version` live in:
+- `docs/architecture/compatibility.md`
+
+Canonical v0.2 acceptance criteria:
+- `docs/requirements/v0.2-worker-core-api-acceptance.md`


### PR DESCRIPTION
## Summary
Implements the minimal v0.2 Worker startup flow and localhost HTTP API foundation.

## Changes
- Add FastAPI app with `GET /health` (`app/worker/odr_worker/api.py`, `app/worker/odr_worker/health.py`)
- Make `python -m odr_worker` start the API server (`app/worker/odr_worker/__main__.py`)
- Add v0.2 Worker deps (`fastapi`, `uvicorn`) in `app/worker/pyproject.toml`
- Document `/health` contract (`docs/architecture/worker-api.md`)
- Add quick-start + health check notes (`app/worker/README.md`)

## Related
- Closes #11
- Closes #13
- Refs #72

## Guardrails
- No runtime data committed
- No workflow changes
