### PR TITLE
docs: define validation reporting + restart-safe uploading rules

### DIFF
--- a/docs/architecture/queue.md
+++ b/docs/architecture/queue.md
@@ -37,7 +37,28 @@ stateDiagram-v2
 
 Interrupted recordings are discarded.
 
-Unuploaded items are resumed in order.
+Unuploaded items (`ready_upload`, `upload_failed`, `quota_waiting`) are resumed in order.
+
+### Restart reconciliation for interrupted `uploading` items
+
+An item left in `uploading` after a restart is ambiguous:
+
+- the upload may have succeeded but the Worker crashed before persisting the success state
+- the upload may have failed but the failure was not persisted
+
+Because a blind automatic retry can create duplicate uploads and waste quota, the default rule is **do not auto-retry**.
+
+On startup, reconcile `uploading` items in this order:
+
+1. If the item already has `youtube_video_id` (or equivalent success marker), treat it as `uploaded`.
+2. If the local video file is missing, discard the item.
+3. Otherwise move the item to `need_manual_review`.
+
+`need_manual_review` should offer the user a safe choice:
+
+- Retry: `need_manual_review` → `ready_upload`
+- Discard: `need_manual_review` → discard
+- (Future) Mark as uploaded by attaching `youtube_video_id` after a manual channel check
 
 ---
 

--- a/docs/architecture/upload.md
+++ b/docs/architecture/upload.md
@@ -62,3 +62,16 @@ Quota exceeded:
 
 Missing files:
 - discard queue entry
+
+---
+
+## Restart-safe behavior for `uploading`
+
+If the Worker crashes or the PC restarts while a queue item is in `uploading`, the upload outcome may be unknown.
+
+To avoid duplicate uploads and quota waste, the recommended default is:
+
+- do not automatically retry `uploading` items on startup
+- reconcile them into `need_manual_review` unless success can be proven (e.g. persisted `youtube_video_id`)
+
+See also: `docs/architecture/queue.md` → “Restart reconciliation for interrupted `uploading` items”.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -85,3 +85,39 @@ This check:
   - `docs/user/ja/first-setup.md`
   - `docs/user/ja/usage.md`
 - Emits warnings if `docs/user/ja/index.md` does not link to expected pages.
+
+## Recurring validation (planned)
+
+This section defines the recommended **reporting behavior** for scheduled documentation validation runs.
+
+### Recommended reporting contract
+
+Define one stable “report unit” per validator run:
+
+- `validator_name`: e.g. `markdown-links`, `jp-user-docs-coverage`
+- `checked_scope`: e.g. `README* + docs/**`
+- `failure_fingerprint`: a stable, deterministic fingerprint of the failure set (examples below)
+- `report_destination`: where to post (issue / comment)
+- `re_notify_condition`: when to post again for the same fingerprint
+
+Suggested fingerprints:
+
+- Markdown link validation: sorted list of `file + link_target + failure_type`
+- JP coverage validation: sorted list of `missing_page + missing_major_section` (if the validator models sections)
+
+### Low-noise reporting rules
+
+- On success: do not post anything (avoid noise).
+- On failure:
+  - Prefer commenting on an existing “documentation validation tracking” issue if one exists.
+  - Otherwise create a new issue titled `Docs validation failed: <validator_name>` and include the full failure list.
+- Re-notify only when the `failure_fingerprint` changes, or when the failure persists beyond a human-defined stale window (e.g. weekly reminder).
+
+### Suggested GitHub Actions steps (outline)
+
+This repository already defines the local commands; a scheduled workflow can run them:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File docs/tools/validate_markdown_links.ps1
+python scripts/validate_jp_user_docs_coverage.py
+```


### PR DESCRIPTION
## Summary
Document the restart-safe reconciliation behavior for interrupted `uploading` queue items, and define a low-noise reporting contract for scheduled docs validation.

## Changes
- Add deterministic restart reconciliation rules for `uploading` items (default: move to `need_manual_review` unless success is proven).
- Clarify which queue states are safe to auto-resume on restart.
- Define a recurring validation reporting contract (fingerprints + re-notify rules) in `docs/validation.md`.

## Related Issues
- Closes #64
- Refs #50

## Scope Guardrails
- Docs-only: changes are limited to `docs/**`.
- No implementation/workflow changes (e.g. `.github/workflows/**`) are included.

## Verification
- `powershell -ExecutionPolicy Bypass -File docs/tools/validate_markdown_links.ps1`