### PR TITLE
docs(release): add v0.2 release summary + planned tag record

### DIFF
--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -28,6 +28,8 @@ No release records have been finalized yet.
 - Version tracking issue: #72
 - Milestone: `v0.2`
 - Release readiness checklist: `docs/release/v0.2-release-readiness.md`
-- Expected tag: `v0.2.0`
-- Release summary: `docs/release/v0.2-release-summary.md` if created
-- Status: in progress
+- Intended tag: `v0.2.0`
+- Tag target (main HEAD): `f64c8a5cdeecadfcc4d5406045d9ea4af9e268a0`
+- Release summary: `docs/release/v0.2-release-summary.md`
+- Deferred item: #50 (workflow change required; post-release)
+- Status: pending tag creation

--- a/docs/release/v0.2-release-summary.md
+++ b/docs/release/v0.2-release-summary.md
@@ -1,0 +1,28 @@
+# v0.2.0 Release Summary (Worker Core API)
+
+Status: **ready for tagging** (pending maintainer action)
+
+## Release Point
+
+- Intended tag: `v0.2.0`
+- Tag target (main HEAD): `f64c8a5cdeecadfcc4d5406045d9ea4af9e268a0`
+- Alternative (merge of #84): `a4099f869b34ef3bb94a1a9fbdc7c82a7214eb58`
+- Version tracking issue: #72
+- Release readiness checklist: `docs/release/v0.2-release-readiness.md`
+
+Note: This automation run cannot create or move tags via repository settings; please create `v0.2.0` after confirming the target SHA.
+
+## Major PRs
+
+- #84 `worker(v0.2): run FastAPI server + /health + smoke docs/tests`
+- #87 `docs hygiene`
+
+## Deferred / Follow-ups
+
+- #50 Run documentation validation on a recurring schedule
+  - Deferred reason: requires `.github/workflows/*` change (needs maintainer approval)
+  - Target: v0.3+ (or patch after v0.2.0)
+
+## Next Version
+
+- Next tracking issue: #88


### PR DESCRIPTION
## Summary
Prepare v0.2.0 release record docs without changing workflows.

## Changes
- Add `docs/release/v0.2-release-summary.md` (tag/SHA, major PRs, deferred items).
- Update `docs/release-history.md` planned v0.2 entry with tag target and deferred #50.

## Notes
- Tag creation is not performed here.
- No `.github/workflows/*` changes.

Refs: #72