### PR TITLE
ci: add scheduled documentation validation

### DIFF
--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -1,0 +1,27 @@
+name: Documentation validation
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Sunday 03:20 UTC. Keep this low-frequency to avoid noisy docs checks.
+    - cron: "20 3 * * 0"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-docs:
+    name: Validate documentation
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Validate Markdown links
+        shell: powershell
+        run: powershell -ExecutionPolicy Bypass -File docs/tools/validate_markdown_links.ps1
+
+      - name: Validate Japanese user docs coverage
+        shell: powershell
+        run: python scripts/validate_jp_user_docs_coverage.py --root .

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -86,7 +86,10 @@ This check:
   - `docs/user/ja/usage.md`
 - Emits warnings if `docs/user/ja/index.md` does not link to expected pages.
 
-## Recurring validation (planned)
+## Recurring validation
+
+Scheduled documentation validation runs from `.github/workflows/docs-validation.yml`.
+It runs weekly and can also be started manually with `workflow_dispatch`.
 
 This section defines the recommended **reporting behavior** for scheduled documentation validation runs.
 


### PR DESCRIPTION
## Summary
- Add a scheduled documentation validation GitHub Actions workflow.
- Run Markdown link validation and Japanese user docs coverage validation weekly and via manual dispatch.
- Mark the recurring validation section in `docs/validation.md` as active and point it at the workflow.

## Scope
- Adds `.github/workflows/docs-validation.yml`.
- Updates docs only to reflect the workflow path.
- Does not add issue-comment automation or broader workflow changes.

## Verification
- `powershell -ExecutionPolicy Bypass -File docs/tools/validate_markdown_links.ps1`
- `python scripts/validate_jp_user_docs_coverage.py --root .`

Closes #50