### PR TITLE
docs(v0.3): add SQLite Foundation acceptance checklist

### DIFF
--- a/docs/requirements/v0.3-sqlite-foundation-acceptance.md
+++ b/docs/requirements/v0.3-sqlite-foundation-acceptance.md
@@ -1,0 +1,83 @@
+# v0.3 SQLite Foundation - Acceptance Checklist
+
+This document defines the acceptance criteria for **v0.3 - SQLite Foundation** as described in:
+
+- `docs/roadmap.md` (canonical roadmap)
+- `docs/requirements/requirements.md` (stable cross-version requirements)
+- `AGENTS.md` (runtime rules, responsibility separation)
+
+This checklist is docs-first and is meant to be reviewed before implementation.
+
+## Scope
+
+v0.3 focuses on:
+
+- SQLite initialization under runtime data (`user_data/`)
+- schema version management
+- a minimal migration framework
+- initial tables to support future features
+- restart-safe, idempotent startup behavior
+
+## Non-goals (explicitly out of scope for v0.3)
+
+- YouTube upload processing
+- queue recovery runtime (v0.7)
+- OBS Plugin lifecycle or UI (v0.4+)
+- OCR / template matching (v0.8+)
+- advanced migration recovery UX (unless explicitly tracked)
+
+## Terms
+
+- **Application files** live under `app/`
+- **Runtime data** lives under `user_data/` and must not be committed
+
+---
+
+## Acceptance Checklist
+
+### A. DB Location / Runtime Contract
+
+- [ ] SQLite DB file lives under `user_data/` (not under `app/` and not under `docs/`).
+- [ ] The DB directory is stable and documented (recommended: under `user_data/data/db/`).
+- [ ] Startup creates DB directories idempotently (no destructive delete of existing runtime data).
+- [ ] If the DB path is not writable, the Worker fails fast with actionable diagnostics.
+
+### B. SQLite Initialization
+
+- [ ] Worker can start with an empty runtime and creates the SQLite DB file.
+- [ ] Worker can start with an existing DB file (no reset, no overwrite).
+- [ ] Startup is restart-safe and idempotent.
+
+### C. Schema Version Management
+
+- [ ] The database stores schema version information in a durable form.
+- [ ] Worker reads schema version on startup.
+- [ ] Worker reports the effective schema version in logs and/or diagnostics endpoints (as appropriate).
+
+### D. Migration Framework (Minimal)
+
+- [ ] Migrations can be applied in a deterministic order.
+- [ ] Each migration is applied at most once.
+- [ ] Applied migration state is persisted (so a restart does not re-apply).
+- [ ] On migration failure, startup fails with actionable diagnostics (and does not corrupt existing DB).
+
+### E. Initial Tables
+
+- [ ] `matches` table exists after startup/migration.
+- [ ] `upload_queue` table exists after startup/migration.
+- [ ] Basic insert/select smoke is possible in unit tests.
+
+### F. Developer Verification
+
+- [ ] Unit tests cover:
+  - [ ] fresh runtime DB initialization
+  - [ ] restart-safe startup (existing DB)
+  - [ ] migration ordering (at least a minimal ordering test)
+  - [ ] tables exist after migrations
+
+---
+
+## Notes for future phases
+
+- v0.4 introduces OBS Plugin skeleton.
+- v0.7 introduces queue recovery behavior.

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -33,6 +33,16 @@ Goals:
   - `docs/requirements/requirements.md` -> Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Logging Rules / Runtime Directory Rules / Responsibility Separation
 
+### v0.3 - SQLite Foundation
+
+- Roadmap: `docs/roadmap.md` -> **v0.3 - SQLite Foundation**
+- Version tracking issue: `#88` - `[v0.3] SQLite Foundation release tracking`
+- Acceptance checklist: `docs/requirements/v0.3-sqlite-foundation-acceptance.md`
+- Release readiness checklist: TBD
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` -> Architecture / Platform / Runtime Rules
+  - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
+
 ---
 
 ## Policy
@@ -70,3 +80,4 @@ The version tracking issue itself is not an implementation work item.
 
 - Refs #56
 - Refs #72
+- Refs #88


### PR DESCRIPTION
## Summary
Add the docs-first acceptance checklist for v0.3 (SQLite Foundation) and link it from traceability.

## Changes
- Add `docs/requirements/v0.3-sqlite-foundation-acceptance.md`
- Update `docs/traceability.md` to include the v0.3 entry

## Related Issues
- Closes #92
- Refs #88

## Scope Guardrails
- Docs-only (`docs/**`) changes
- No workflows changes
- No runtime data committed

## Verification
- Doc-only change; no executable behavior to validate here
