### PR TITLE
docs: finalize v0.2 release status

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ Major and minor release completions are tagged as `vMajor.Minor.Patch`. See [Rel
 
 ## Current Development
 
-Current release target:
+Latest released version:
 - `v0.2.0` - Worker Core API
 
-Next roadmap targets:
+Current development target:
 - `v0.3` - SQLite Foundation
+
+Next roadmap target:
 - `v0.4` - OBS Plugin Skeleton
 
 ---
@@ -97,15 +99,16 @@ obs-duel-recorder/
 
 ## Current Status
 
-### Current Release Candidate
+### Latest Release
 
 - Version: `v0.2.0`
 - Scope: Worker Core API
-- Status: pending release tag creation
+- Status: released
+- Tag target: `f64c8a5cdeecadfcc4d5406045d9ea4af9e268a0`
 - Tracking issue: [#72](https://github.com/Tao-pyth/obs-duel-recorder/issues/72)
 - Release record: [docs/release-history.md](docs/release-history.md)
 
-### Planned for v0.2
+### Completed in v0.2
 
 - FastAPI Worker foundation
 - Localhost HTTP API

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -21,15 +21,16 @@ The version tracking issue may contain the working release summary, but finalize
 
 ## Releases
 
-No release records have been finalized yet.
-
-### Planned: v0.2.0 - Worker Core API
+### v0.2.0 - Worker Core API
 
 - Version tracking issue: #72
 - Milestone: `v0.2`
 - Release readiness checklist: `docs/release/v0.2-release-readiness.md`
-- Intended tag: `v0.2.0`
-- Tag target (main HEAD): `f64c8a5cdeecadfcc4d5406045d9ea4af9e268a0`
+- Tag: `v0.2.0`
+- Tag target: `f64c8a5cdeecadfcc4d5406045d9ea4af9e268a0`
 - Release summary: `docs/release/v0.2-release-summary.md`
-- Deferred item: #50 (workflow change required; post-release)
-- Status: pending tag creation
+- Major PRs: #84, #87, #89
+- Version cleanup PR: #99 (merged after the existing tag target; tag was intentionally kept unchanged)
+- Deferred item: #97 (workflow validation automation; post-release because it changes `.github/workflows/**`)
+- Next version tracking issue: #88
+- Status: released

--- a/docs/release/v0.2-release-summary.md
+++ b/docs/release/v0.2-release-summary.md
@@ -1,27 +1,40 @@
 # v0.2.0 Release Summary (Worker Core API)
 
-Status: **ready for tagging** (pending maintainer action)
+Status: **released**
 
 ## Release Point
 
-- Intended tag: `v0.2.0`
-- Tag target (main HEAD): `f64c8a5cdeecadfcc4d5406045d9ea4af9e268a0`
-- Alternative (merge of #84): `a4099f869b34ef3bb94a1a9fbdc7c82a7214eb58`
+- Tag: `v0.2.0`
+- Tag target: `f64c8a5cdeecadfcc4d5406045d9ea4af9e268a0`
 - Version tracking issue: #72
 - Release readiness checklist: `docs/release/v0.2-release-readiness.md`
+- Tag handling decision: keep the already-created tag as-is; do not move it to the later #99 merge commit.
 
-Note: This automation run cannot create or move tags via repository settings; please create `v0.2.0` after confirming the target SHA.
+Note: #99 updated Worker version strings to `0.2.0` after the existing tag target and is recorded as post-tag release-boundary cleanup already merged into `main`.
 
 ## Major PRs
 
 - #84 `worker(v0.2): run FastAPI server + /health + smoke docs/tests`
 - #87 `docs hygiene`
+- #89 `docs: add v0.2 release record`
+- #99 `chore(worker): bump version to 0.2.0`
+
+## Completed Scope
+
+- FastAPI Worker foundation
+- Localhost HTTP API
+- Worker startup flow
+- `GET /health` endpoint
+- Worker configuration loading
+- Logging initialization
+- Runtime directory creation
+- Smoke verification and developer notes
 
 ## Deferred / Follow-ups
 
-- #50 Run documentation validation on a recurring schedule
-  - Deferred reason: requires `.github/workflows/*` change (needs maintainer approval)
-  - Target: v0.3+ (or patch after v0.2.0)
+- #97 `ci: add scheduled documentation validation`
+  - Deferred reason: requires `.github/workflows/**` change.
+  - Target: post-release review/merge when workflow changes are approved.
 
 ## Next Version
 


### PR DESCRIPTION
## Summary
- Update README from pending v0.2 tag creation to released v0.2.0 status.
- Finalize `docs/release-history.md` for the existing `v0.2.0` tag target.
- Finalize the v0.2 release summary and record the decision to keep the existing tag target unchanged.

## Notes
- Records #99 as post-tag release-boundary cleanup already merged into `main`.
- Keeps #97 as a post-release deferred workflow-change PR.

## Verification
- Documentation-only change; no code tests run.