### PR TITLE
docs: add v0.3 release readiness checklist

### DIFF
--- a/docs/release/v0.3-release-readiness.md
+++ b/docs/release/v0.3-release-readiness.md
@@ -1,0 +1,57 @@
+# v0.3 Release Readiness Checklist
+
+This checklist helps contributors prepare a **v0.3.0** release for OBS Duel Recorder.
+
+Scope:
+- Documentation and verification steps for **v0.3 - SQLite Foundation** readiness.
+- No implementation work is performed by this checklist.
+
+Non-goals:
+- Creating the tag in this document.
+- Retroactively tagging earlier versions.
+
+---
+
+## A. Milestone readiness
+
+- [ ] All required v0.3 issues are **closed** or explicitly **deferred** with a clear note.
+- [ ] Any deferred issues have an owner and a target version (e.g. v0.4+).
+
+## B. Documentation readiness
+
+- [ ] Canonical docs are up to date:
+  - [ ] `docs/roadmap.md` (canonical; do not rewrite during release)
+  - [ ] `docs/requirements/requirements.md`
+  - [ ] `docs/traceability.md`
+- [ ] v0.3 acceptance checklist reflects the intended behavior and has been reviewed:
+  - [ ] `docs/requirements/v0.3-sqlite-foundation-acceptance.md`
+
+## C. Verification (smoke)
+
+Perform these checks on Windows (no OBS required):
+
+- [ ] Worker starts successfully from the documented entrypoint.
+- [ ] Runtime directories exist (create-if-missing, idempotent):
+  - [ ] `user_data/config/`
+  - [ ] `user_data/data/`
+  - [ ] `user_data/logs/`
+- [ ] Logs are written under `user_data/logs/` and are preserved by default.
+
+SQLite-specific checks:
+
+- [ ] SQLite DB is created under `user_data/` on fresh runtime.
+- [ ] Restarting with an existing DB does not reset or corrupt it.
+- [ ] Schema version information is stored and reported (log and/or diagnostics as defined).
+- [ ] Migrations (if present) apply in a deterministic order and at most once.
+- [ ] On migration failure, startup fails with actionable diagnostics (no partial corruption).
+
+## D. Release PR readiness
+
+- [ ] Release PR contains **no secrets** and does not add runtime data (logs/db/videos/screenshots).
+- [ ] The PR is merged into `main`.
+- [ ] The merge commit SHA on `main` is recorded for tagging.
+
+## E. Tagging (after merge)
+
+- [ ] Create tag `v0.3.0` pointing to the merge commit SHA on `main`.
+- [ ] Do **not** move or overwrite existing tags.

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -38,7 +38,7 @@ Goals:
 - Roadmap: `docs/roadmap.md` -> **v0.3 - SQLite Foundation**
 - Version tracking issue: `#88` - `[v0.3] SQLite Foundation release tracking`
 - Acceptance checklist: `docs/requirements/v0.3-sqlite-foundation-acceptance.md`
-- Release readiness checklist: TBD
+- Release readiness checklist: `docs/release/v0.3-release-readiness.md`
 - Requirements (relevant sections):
   - `docs/requirements/requirements.md` -> Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation


### PR DESCRIPTION
## Summary
- Add v0.3 release readiness checklist doc.
- Link it from `docs/traceability.md`.

## Scope
- Adds `docs/release/v0.3-release-readiness.md`.
- Updates `docs/traceability.md` (v0.3 section only).

## Notes
No workflow changes. No runtime data. Docs-only.

Refs #88