### PR TITLE
feat(v0.3): add SQLite foundation (init + migrations + minimal tables)

### DIFF
--- a/app/worker/odr_worker/__main__.py
+++ b/app/worker/odr_worker/__main__.py
@@ -11,6 +11,7 @@ from .config import (
     get_default_config_path,
     load_worker_config,
 )
+from .db import DbInitError, init_db
 from .logging_setup import init_worker_logging
 from .runtime_dirs import RuntimeDirError, ensure_runtime_dirs
 from .version import __version__
@@ -66,6 +67,14 @@ def main(argv: list[str] | None = None) -> int:
         return 3
 
     try:
+        db_info = init_db(runtime_dirs=runtime_dirs, logger=logger)
+    except DbInitError as exc:
+        logger.error("SQLite initialization failed: %s", exc, extra={"db_dir": str(runtime_dirs.db_dir)})
+        print(f"SQLite initialization failed: {exc}", file=sys.stderr)
+        print(f"Logs: {log_path}", file=sys.stderr)
+        return 3
+
+    try:
         import uvicorn  # type: ignore
         from .api import create_app
     except Exception:  # pragma: no cover
@@ -88,7 +97,7 @@ def main(argv: list[str] | None = None) -> int:
         runtime_dirs.logs_dir,
     )
 
-    app = create_app(runtime_dirs=runtime_dirs, loaded_config=loaded_config)
+    app = create_app(runtime_dirs=runtime_dirs, loaded_config=loaded_config, db_info=db_info)
 
     logger.info("Starting API server host=%s port=%s", loaded_config.config.host, loaded_config.config.port)
     logger.info("logs=%s", log_path)

--- a/app/worker/odr_worker/api.py
+++ b/app/worker/odr_worker/api.py
@@ -7,7 +7,8 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from .config import LoadedWorkerConfig, get_repo_root
-from .health import WorkerPaths, build_health_payload
+from .db import DbInfo
+from .health import WorkerDb, WorkerPaths, build_health_payload
 from .runtime_dirs import RuntimeDirs
 from .version import __version__
 
@@ -19,7 +20,7 @@ def _error_payload(*, code: str, message: str, details: object | None = None) ->
     return payload
 
 
-def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig) -> FastAPI:
+def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, db_info: DbInfo | None = None) -> FastAPI:
     app = FastAPI(title="OBS Duel Recorder Worker", version=__version__)
 
     app_dir = (get_repo_root() / "app").resolve()
@@ -35,9 +36,17 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig) 
     app.state.paths = worker_paths
     app.state.config_loaded = loaded_config.config_loaded
 
+    app.state.db = None
+    if db_info is not None:
+        app.state.db = WorkerDb(
+            db_path=db_info.db_path,
+            schema_version=db_info.schema_version,
+            applied_migrations=db_info.applied_migrations,
+        )
+
     @app.get("/health")
     def health() -> dict[str, object]:
-        return build_health_payload(paths=app.state.paths, config_loaded=app.state.config_loaded)
+        return build_health_payload(paths=app.state.paths, config_loaded=app.state.config_loaded, db=app.state.db)
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception):

--- a/app/worker/odr_worker/db.py
+++ b/app/worker/odr_worker/db.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from .runtime_dirs import RuntimeDirs
+
+
+class DbInitError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class DbInfo:
+    db_path: Path
+    schema_version: int
+    applied_migrations: tuple[str, ...]
+
+
+_MIGRATIONS: tuple[str, ...] = (
+    "0001_init",
+    "0002_tables",
+)
+
+
+def get_db_path(*, runtime_dirs: RuntimeDirs) -> Path:
+    return (runtime_dirs.db_dir / "odr.sqlite3").resolve()
+
+
+def _read_migration_sql(migration_id: str) -> str:
+    migrations_dir = Path(__file__).resolve().parent / "migrations"
+    path = migrations_dir / f"{migration_id}.sql"
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise DbInitError(f"Failed to read migration file: {path}") from exc
+
+
+def _utc_now_iso() -> str:
+    return _dt.datetime.now(tz=_dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _ensure_meta_tables(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS odr_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS schema_migrations (id TEXT PRIMARY KEY, applied_at TEXT NOT NULL);"
+    )
+
+
+def _get_schema_version(conn: sqlite3.Connection) -> int:
+    row = conn.execute("SELECT value FROM odr_meta WHERE key = 'schema_version';").fetchone()
+    if row is None:
+        return 0
+    try:
+        return int(row[0])
+    except (TypeError, ValueError):
+        return 0
+
+
+def _set_schema_version(conn: sqlite3.Connection, schema_version: int) -> None:
+    conn.execute(
+        "INSERT INTO odr_meta(key, value) VALUES('schema_version', ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value;",
+        (str(schema_version),),
+    )
+
+
+def _migration_version(migration_id: str) -> int:
+    try:
+        return int(migration_id.split("_", 1)[0])
+    except (IndexError, ValueError):
+        return 0
+
+
+def _get_applied_migration_ids(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute("SELECT id FROM schema_migrations;").fetchall()
+    return {str(r[0]) for r in rows}
+
+
+def init_db(*, runtime_dirs: RuntimeDirs, logger: logging.Logger | None = None) -> DbInfo:
+    """Initialize SQLite and apply v0.3 migrations.
+
+    Goals:
+    - DB lives under runtime data (`user_data/`)
+    - startup is idempotent and restart-safe
+    - migrations apply deterministically and at most once
+    """
+
+    log = logger or logging.getLogger(__name__)
+    db_path = get_db_path(runtime_dirs=runtime_dirs)
+
+    try:
+        conn = sqlite3.connect(db_path)
+    except OSError as exc:
+        raise DbInitError(f"Failed to open SQLite DB: {db_path}") from exc
+
+    try:
+        conn.execute("PRAGMA foreign_keys = ON;")
+        _ensure_meta_tables(conn)
+        applied = _get_applied_migration_ids(conn)
+
+        applied_in_order: list[str] = []
+        current_version = _get_schema_version(conn)
+        log.info("sqlite db=%s schema_version=%s", db_path, current_version)
+
+        for migration_id in _MIGRATIONS:
+            if migration_id in applied:
+                applied_in_order.append(migration_id)
+                continue
+
+            sql = _read_migration_sql(migration_id)
+            try:
+                conn.execute("BEGIN;")
+                conn.executescript(sql)
+                conn.execute(
+                    "INSERT INTO schema_migrations(id, applied_at) VALUES(?, ?);",
+                    (migration_id, _utc_now_iso()),
+                )
+                new_version = max(current_version, _migration_version(migration_id))
+                _set_schema_version(conn, new_version)
+                conn.execute("COMMIT;")
+                current_version = new_version
+            except sqlite3.DatabaseError as exc:
+                conn.execute("ROLLBACK;")
+                raise DbInitError(f"SQLite migration failed: {migration_id}: {exc}") from exc
+
+            applied_in_order.append(migration_id)
+
+        return DbInfo(db_path=db_path, schema_version=current_version, applied_migrations=tuple(applied_in_order))
+    finally:
+        conn.close()

--- a/app/worker/odr_worker/health.py
+++ b/app/worker/odr_worker/health.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from .version import __version__
 
 
-API_VERSION = "0.2"
+API_VERSION = "0.3"
 _START_TIME = time.monotonic()
 
 
@@ -20,14 +20,21 @@ class WorkerPaths:
     logs_dir: Path
 
 
+@dataclass(frozen=True)
+class WorkerDb:
+    db_path: Path
+    schema_version: int
+    applied_migrations: tuple[str, ...]
+
+
 def _as_posix(path: Path) -> str:
     return path.resolve().as_posix()
 
 
-def build_health_payload(*, paths: WorkerPaths, config_loaded: bool) -> dict[str, object]:
+def build_health_payload(*, paths: WorkerPaths, config_loaded: bool, db: WorkerDb | None = None) -> dict[str, object]:
     uptime_seconds = int(max(0.0, time.monotonic() - _START_TIME))
 
-    return {
+    payload: dict[str, object] = {
         "status": "ok",
         "version": __version__,
         "api_version": API_VERSION,
@@ -42,3 +49,12 @@ def build_health_payload(*, paths: WorkerPaths, config_loaded: bool) -> dict[str
             "logs_dir": _as_posix(paths.logs_dir),
         },
     }
+
+    if db is not None:
+        payload["db"] = {
+            "path": _as_posix(db.db_path),
+            "schema_version": db.schema_version,
+            "applied_migrations": list(db.applied_migrations),
+        }
+
+    return payload

--- a/app/worker/odr_worker/migrations/0001_init.sql
+++ b/app/worker/odr_worker/migrations/0001_init.sql
@@ -1,0 +1,12 @@
+-- v0.3 migration 0001_init
+-- Purpose: create metadata tables required for deterministic, restart-safe migrations.
+
+CREATE TABLE IF NOT EXISTS odr_meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  id TEXT PRIMARY KEY,
+  applied_at TEXT NOT NULL
+);

--- a/app/worker/odr_worker/migrations/0002_tables.sql
+++ b/app/worker/odr_worker/migrations/0002_tables.sql
@@ -1,0 +1,17 @@
+-- v0.3 migration 0002_tables
+-- Purpose: create initial tables required by v0.3 acceptance checklist.
+
+CREATE TABLE IF NOT EXISTS matches (
+  id INTEGER PRIMARY KEY,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS upload_queue (
+  id INTEGER PRIMARY KEY,
+  match_id INTEGER,
+  state TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  FOREIGN KEY(match_id) REFERENCES matches(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_upload_queue_state ON upload_queue(state);

--- a/app/worker/tests/test_db.py
+++ b/app/worker/tests/test_db.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+# Ensure `app/worker` is on sys.path so `import odr_worker` works without install.
+WORKER_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(WORKER_ROOT))
+
+
+class SqliteFoundationTests(unittest.TestCase):
+    def test_init_db_creates_db_and_tables(self) -> None:
+        from odr_worker.db import init_db
+        from odr_worker.runtime_dirs import ensure_runtime_dirs
+
+        with tempfile.TemporaryDirectory() as tmp:
+            user_data_dir = Path(tmp)
+            runtime_dirs = ensure_runtime_dirs(user_data_dir=user_data_dir)
+
+            db_info = init_db(runtime_dirs=runtime_dirs)
+            self.assertTrue(db_info.db_path.exists())
+            self.assertGreaterEqual(db_info.schema_version, 2)
+            self.assertEqual(db_info.applied_migrations, ("0001_init", "0002_tables"))
+
+            conn = sqlite3.connect(db_info.db_path)
+            try:
+                tables = {
+                    row[0]
+                    for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table';").fetchall()
+                }
+                self.assertIn("matches", tables)
+                self.assertIn("upload_queue", tables)
+
+                conn.execute("INSERT INTO matches DEFAULT VALUES;")
+                match_id = conn.execute("SELECT id FROM matches ORDER BY id DESC LIMIT 1;").fetchone()[0]
+                conn.execute("INSERT INTO upload_queue(match_id, state) VALUES(?, ?);", (match_id, "ready_upload"))
+                conn.commit()
+
+                row = conn.execute("SELECT state FROM upload_queue WHERE match_id = ?;", (match_id,)).fetchone()
+                self.assertEqual(row[0], "ready_upload")
+            finally:
+                conn.close()
+
+    def test_init_db_is_restart_safe(self) -> None:
+        from odr_worker.db import init_db
+        from odr_worker.runtime_dirs import ensure_runtime_dirs
+
+        with tempfile.TemporaryDirectory() as tmp:
+            user_data_dir = Path(tmp)
+            runtime_dirs = ensure_runtime_dirs(user_data_dir=user_data_dir)
+
+            first = init_db(runtime_dirs=runtime_dirs)
+            second = init_db(runtime_dirs=runtime_dirs)
+
+            self.assertEqual(first.db_path, second.db_path)
+            self.assertEqual(first.schema_version, second.schema_version)
+            self.assertEqual(first.applied_migrations, second.applied_migrations)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/architecture/db.md
+++ b/docs/architecture/db.md
@@ -6,19 +6,36 @@ SQLite
 
 ---
 
+## Location (runtime contract)
+
+The SQLite DB file is runtime data and must live under `user_data/`.
+
+Default location (v0.3):
+- `user_data/data/db/odr.sqlite3`
+
+---
+
 ## Migration
 
 Database schema migration is required.
 
-The database must maintain schema version information.
+- Schema version information is stored in the DB (`odr_meta.schema_version`).
+- Applied migrations are tracked in `schema_migrations`.
+- Migrations live under `app/worker/odr_worker/migrations/*.sql` and are applied in deterministic order.
 
 ---
 
 ## Main Tables
 
+v0.3 creates a minimal schema so future versions can evolve it via migrations.
+
 ### matches
 
-- id
+Initial (v0.3):
+- `id`
+- `created_at`
+
+Planned (future; evolves via migrations):
 - deck_name
 - deck_seq
 - opponent_deck
@@ -31,3 +48,11 @@ The database must maintain schema version information.
 - upload_status
 - youtube_video_id
 - youtube_url
+
+### upload_queue
+
+Initial (v0.3):
+- `id`
+- `match_id`
+- `state`
+- `created_at`


### PR DESCRIPTION
## Summary
Implements v0.3 SQLite Foundation core pieces:
- SQLite DB initialization under runtime (`user_data/data/db/odr.sqlite3`)
- schema version management + deterministic migrations (apply at most once)
- initial tables (`matches`, `upload_queue`)
- unit tests for init/restart/migrations/tables

## Scope guardrails
- No new dependencies (uses stdlib `sqlite3`).
- No workflows changes.
- No runtime data committed.

## Related issues
- Refs #88
- Addresses #93 #94 #95

## Verification
- Local: `python -m unittest discover -s app/worker/tests -p "test_*.py" -v`