### PR TITLE
docs(release): add v0.3 release closeout records

### DIFF
--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -34,3 +34,16 @@ The version tracking issue may contain the working release summary, but finalize
 - Deferred item: #97 (workflow validation automation; post-release because it changes `.github/workflows/**`)
 - Next version tracking issue: #88
 - Status: released
+
+### v0.3.0 - SQLite Foundation
+
+- Version tracking issue: #88
+- Milestone: `v0.3` (not set)
+- Release readiness checklist: `docs/release/v0.3-release-readiness.md`
+- Intended tag: `v0.3.0`
+- Intended tag target: `5b51a33454f469d6a782387ece8f5afba13b0d49`
+- Release summary: `docs/release/v0.3-release-summary.md`
+- Major PRs: #101, #104, #107
+- Deferred items: none
+- Next version tracking issue: #110
+- Status: ready_to_tag

--- a/docs/release/v0.3-release-summary.md
+++ b/docs/release/v0.3-release-summary.md
@@ -1,0 +1,34 @@
+# v0.3.0 Release Summary (SQLite Foundation)
+
+Status: **ready_to_tag**
+
+## Release Point
+
+- Intended tag: `v0.3.0`
+- Intended tag target: `5b51a33454f469d6a782387ece8f5afba13b0d49`
+- Version tracking issue: #88
+- Release readiness checklist: `docs/release/v0.3-release-readiness.md`
+
+Note: Tag creation is pending. After creating the tag, record the created date/time and update status to **released**.
+
+## Major PRs
+
+- #101 `docs: add v0.3 release readiness checklist`
+- #104 `feat(v0.3): add SQLite foundation`
+- #107 `fix(v0.3): harden SQLite init error handling`
+
+## Completed Scope
+
+- SQLite initialization under runtime data (`user_data/`)
+- Schema version management
+- Minimal migration framework
+- Initial tables (`matches`, `upload_queue`)
+- Restart-safe, idempotent startup behavior
+
+## Deferred / Follow-ups
+
+- None
+
+## Next Version
+
+- Next tracking issue: #110


### PR DESCRIPTION
## Summary
Add v0.3 closeout records for release readiness and next-version handoff:
- Add `docs/release/v0.3-release-summary.md` (draft, ready-to-tag status).
- Update `docs/release-history.md` to include v0.3 entry (intended tag target recorded).

## Related
- Refs #88
- Refs #110

## Notes
Tag creation is intentionally not performed in this PR. After the tag is created, update the status fields and record the release date/time.