### PR TITLE
docs(readme): reflect v0.3.0 ready_to_tag + v0.4 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ Major and minor release completions are tagged as `vMajor.Minor.Patch`. See [Rel
 Latest released version:
 - `v0.2.0` - Worker Core API
 
+Release pending:
+- `v0.3.0` - SQLite Foundation (ready_to_tag; tag creation pending)
+
 Current development target:
-- `v0.3` - SQLite Foundation
+- `v0.4` - OBS Plugin Skeleton
 
 Next roadmap target:
-- `v0.4` - OBS Plugin Skeleton
+- `v0.5` - Overlay Integration
 
 ---
 


### PR DESCRIPTION
## Summary
Update `README.md` "Current Development" to align with v0.3 closeout records:
- Keep latest released version as `v0.2.0`.
- Add `v0.3.0` as **ready_to_tag** (tag creation pending).
- Move current development target to `v0.4` and next roadmap target to `v0.5`.

## References
- `docs/release-history.md` (v0.3.0 status: ready_to_tag)
- #88 (v0.3 tracking) / #110 (v0.4 tracking)

## Notes
Docs-only change (`README.md` only).