### PR TITLE
chore(worker): align pyproject version to 0.3.0

### DIFF
--- a/app/worker/pyproject.toml
+++ b/app/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obs-duel-recorder-worker"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python Worker for OBS Duel Recorder"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
Align Worker distribution metadata with runtime version:
- Update `app/worker/pyproject.toml` `version` to `0.3.0`.

This resolves the version skew pointed out on PR #112 (runtime `__version__` vs package metadata).

## Related
- Refs #88 (v0.3 tracking)
- Follow-up to PR #112 review note

## Verification
- No runtime behavior change; metadata only.
