### PR TITLE
chore(worker): align package version to 0.3.0

### DIFF
--- a/app/worker/pyproject.toml
+++ b/app/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obs-duel-recorder-worker"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python Worker for OBS Duel Recorder"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
Align Worker distribution metadata version with runtime `__version__` for v0.3.0 release readiness:
- `app/worker/pyproject.toml` `version = "0.3.0"`

## Motivation
PR #112 bumped runtime `odr_worker/version.py` to `0.3.0`, but `pyproject.toml` still advertises `0.2.0`. This version skew can confuse packaging/release workflows.

## Scope
- No new dependencies.
- No workflow changes.
- No runtime data.

## Related
- Refs #88
- Follow-up to #112

## Notes
After this is merged, the v0.3 tag target should be re-identified on `main` (prefer the merge commit that includes this PR) before creating `v0.3.0`.