### PR TITLE
docs(v0.4): add acceptance + readiness checklists; align version docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ Major and minor release completions are tagged as `vMajor.Minor.Patch`. See [Rel
 Latest released version:
 - `v0.2.0` - Worker Core API
 
+Release pending:
+- `v0.3.0` - SQLite Foundation (ready_to_tag; tag creation pending)
+
 Current development target:
-- `v0.3` - SQLite Foundation
+- `v0.4` - OBS Plugin Skeleton
 
 Next roadmap target:
-- `v0.4` - OBS Plugin Skeleton
+- `v0.5` - Overlay Integration
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,11 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [Release history](release-history.md)
 - [Version tracking issue template](release/version-tracking-issue-template.md)
 - [v0.2 release readiness checklist](release/v0.2-release-readiness.md)
+- [v0.3 release readiness checklist](release/v0.3-release-readiness.md)
+- [v0.4 release readiness checklist](release/v0.4-release-readiness.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
+- [v0.3 SQLite Foundation acceptance checklist](requirements/v0.3-sqlite-foundation-acceptance.md)
+- [v0.4 OBS Plugin Skeleton acceptance checklist](requirements/v0.4-obs-plugin-skeleton-acceptance.md)
 
 ## Architecture
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -95,6 +95,8 @@ Do not move or overwrite an existing tag without explicit maintainer approval.
 Use a version-scoped readiness checklist before tagging:
 
 - v0.2: `docs/release/v0.2-release-readiness.md`
+- v0.3: `docs/release/v0.3-release-readiness.md`
+- v0.4: `docs/release/v0.4-release-readiness.md`
 
 Do not retroactively create a `v0.1.0` tag unless explicitly approved.
 

--- a/docs/release/v0.4-release-readiness.md
+++ b/docs/release/v0.4-release-readiness.md
@@ -1,0 +1,54 @@
+# v0.4 Release Readiness Checklist
+
+This checklist helps contributors prepare a **v0.4.0** release for OBS Duel Recorder.
+
+Scope:
+- Documentation and verification steps for **v0.4 - OBS Plugin Skeleton** readiness.
+- No implementation work is performed by this checklist.
+
+Non-goals:
+- Creating the tag in this document.
+- Designing roadmap semantics.
+
+---
+
+## A. Milestone readiness
+
+- [ ] All required v0.4 child issues are **closed** or explicitly **deferred** with a clear note.
+- [ ] Any deferred issues have an owner and a target version.
+- [ ] Version tracking issue reflects final state (closed/deferred/next handoff).
+
+## B. Documentation readiness
+
+- [ ] Canonical docs are up to date:
+  - [ ] `docs/roadmap.md` (canonical; do not rewrite during release)
+  - [ ] `docs/requirements/requirements.md`
+  - [ ] `docs/traceability.md`
+  - [ ] `docs/architecture/plugin-worker.md`
+  - [ ] `docs/architecture/compatibility.md`
+  - [ ] `docs/architecture/worker-diagnostics.md`
+- [ ] v0.4 acceptance checklist reflects the intended behavior and has been reviewed:
+  - [ ] `docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md`
+
+## C. Verification (smoke)
+
+Perform these checks on Windows with OBS installed:
+
+- [ ] OBS Plugin builds successfully on Windows (document toolchain prerequisites if needed).
+- [ ] Plugin loads in OBS without crashing.
+- [ ] Plugin exposes a Dock UI (even if minimal) for diagnostics / control.
+- [ ] Plugin can start the Worker process using the documented contract.
+- [ ] Plugin can stop the Worker process (or clearly reports why it cannot).
+- [ ] Plugin can detect Worker health via `GET /health` and surfaces status in the Dock UI.
+- [ ] Heartbeat timeout behavior is documented and observable in logs / diagnostics.
+
+## D. Release PR readiness
+
+- [ ] Release PR contains **no secrets** and does not add runtime data (logs/db/videos/screenshots).
+- [ ] The PR is merged into `main`.
+- [ ] The merge commit SHA on `main` is recorded for tagging.
+
+## E. Tagging (after merge)
+
+- [ ] Create tag `v0.4.0` pointing to the merge commit SHA on `main`.
+- [ ] Do **not** move or overwrite existing tags.

--- a/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
+++ b/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
@@ -1,0 +1,77 @@
+# v0.4 OBS Plugin Skeleton — Acceptance Checklist
+
+This document defines the acceptance criteria for **v0.4 - OBS Plugin Skeleton** as described in:
+
+- `docs/roadmap.md` (canonical roadmap)
+- `AGENTS.md` (responsibility separation + runtime rules)
+- `docs/requirements/requirements.md` (high-level requirements)
+
+This checklist is intentionally **docs-first** and is meant to be reviewed before implementation.
+
+## Scope
+
+v0.4 focuses on:
+
+- Establishing an OBS Plugin scaffold and minimal integration layer.
+- Launching / managing the Python Worker lifecycle from OBS.
+- Providing a minimal Dock UI to surface diagnostics and status.
+- Implementing a minimal localhost API wrapper contract for Plugin <-> Worker integration.
+
+## Non-goals (explicitly out of scope for v0.4)
+
+- Overlay Integration work reserved for v0.5+
+- Recording State Management work reserved for v0.6+
+- Queue Recovery System work reserved for v0.7+
+- Template Matching MVP work reserved for v0.8+
+- Upload/OAuth work reserved for v1.0+
+
+## Terms
+
+- **Application files** live under `app/`
+- **Runtime data** lives under `user_data/` and must not be committed
+
+---
+
+## Acceptance Checklist
+
+### A. OBS Plugin Scaffold
+
+- [ ] A minimal OBS plugin project scaffold exists under `app/plugin/` (or the canonical plugin directory).
+- [ ] Plugin build instructions are documented (toolchain versions, prerequisites).
+- [ ] Plugin can be built on Windows with a documented command.
+
+### B. OBS Integration (Frontend API)
+
+- [ ] Plugin can load in OBS without crashing.
+- [ ] Plugin integrates with OBS Frontend API at least to the extent required for a loadable plugin.
+- [ ] Plugin writes logs to the canonical runtime log location (no logs committed).
+
+### C. Worker Process Launch Contract
+
+- [ ] Plugin can launch the Worker process using a documented command/entrypoint.
+- [ ] Plugin does not require users to manually start the Worker in the normal path.
+- [ ] Plugin reports launch failures with actionable diagnostics (log + UI surface).
+
+### D. Worker Health / Heartbeat
+
+- [ ] Plugin monitors Worker health via `GET /health`.
+- [ ] A heartbeat timeout and failure mode vocabulary is defined and used consistently.
+- [ ] Plugin surfaces Worker state in a Dock UI (minimum: `starting` / `running` / `unhealthy` / `crashed` / `api_incompatible`).
+
+### E. Plugin Settings + Dock UI
+
+- [ ] A Plugin settings page exists for minimal configuration (host/port, user_data_dir, etc).
+- [ ] A Browser Dock UI exists and can display Worker status and key diagnostics.
+
+### F. Localhost API Wrapper
+
+- [ ] Plugin uses a minimal API wrapper layer rather than ad-hoc HTTP calls throughout the codebase.
+- [ ] Wrapper behavior for failure cases is defined (timeouts, refused connection, incompatible API).
+
+### G. Developer Verification
+
+- [ ] A smoke procedure exists describing how to verify:
+  - [ ] plugin loads
+  - [ ] worker launches
+  - [ ] dock shows health
+  - [ ] logs are produced under `user_data/logs/`

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -43,6 +43,16 @@ Goals:
   - `docs/requirements/requirements.md` -> Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
+### v0.4 - OBS Plugin Skeleton
+
+- Roadmap: `docs/roadmap.md` -> **v0.4 - OBS Plugin Skeleton**
+- Version tracking issue: `#110` - `[v0.4] OBS Plugin Skeleton release tracking`
+- Acceptance checklist: `docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md`
+- Release readiness checklist: `docs/release/v0.4-release-readiness.md`
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` -> Architecture / Platform / Runtime Rules
+  - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
+
 ---
 
 ## Policy
@@ -81,3 +91,4 @@ The version tracking issue itself is not an implementation work item.
 - Refs #56
 - Refs #72
 - Refs #88
+- Refs #110


### PR DESCRIPTION
## Summary
- Add v0.4 acceptance checklist and release readiness checklist.
- Link v0.4 (and existing v0.3) checklists from canonical docs.
- Align README "Current Development" with `docs/release-history.md` (v0.3 is ready_to_tag).

## Issues
- Closes #124
- Closes #125

## Verification (local workspace snapshot)
- `powershell -ExecutionPolicy Bypass -File docs/tools/validate_markdown_links.ps1`
- `python scripts/validate_jp_user_docs_coverage.py --root .`
