### PR TITLE
docs(release): clarify v0.3 tagging follow-up (#118)

### DIFF
--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -44,6 +44,6 @@ The version tracking issue may contain the working release summary, but finalize
 - Intended tag target: `5b51a33454f469d6a782387ece8f5afba13b0d49`
 - Release summary: `docs/release/v0.3-release-summary.md`
 - Major PRs: #101, #104, #107
-- Deferred items: none
+- Follow-up PR: #118 (align Worker distribution metadata version to `0.3.0`; re-identify tag target after merge)
 - Next version tracking issue: #110
 - Status: ready_to_tag

--- a/docs/release/v0.3-release-summary.md
+++ b/docs/release/v0.3-release-summary.md
@@ -11,6 +11,8 @@ Status: **ready_to_tag**
 
 Note: Tag creation is pending. After creating the tag, record the created date/time and update status to **released**.
 
+Note: PR #118 aligns `app/worker/pyproject.toml` metadata version to `0.3.0`. After it is merged, re-identify the tag target on `main` before creating `v0.3.0`.
+
 ## Major PRs
 
 - #101 `docs: add v0.3 release readiness checklist`
@@ -27,7 +29,7 @@ Note: Tag creation is pending. After creating the tag, record the created date/t
 
 ## Deferred / Follow-ups
 
-- None
+- #118 `chore(worker): align package version to 0.3.0` (required before tagging; re-identify tag target after merge)
 
 ## Next Version
 


### PR DESCRIPTION
## Summary
Clarify v0.3 closeout notes in docs so they reflect the remaining follow-up before tagging:
- Record PR #118 as a follow-up needed before creating `v0.3.0`.
- Note that tag target should be re-identified on `main` after #118 merge.

## Files
- `docs/release-history.md`
- `docs/release/v0.3-release-summary.md`

## References
- #88 (v0.3 tracking)
- #118 (package metadata version alignment)

## Notes
Docs-only change.