### PR TITLE
docs(v0.4): document plugin->worker launch contract

### DIFF
--- a/docs/architecture/plugin-worker.md
+++ b/docs/architecture/plugin-worker.md
@@ -87,6 +87,66 @@ flowchart LR
 
 ---
 
+## Worker Launch Contract (v0.4)
+
+This section defines the minimal contract for launching the Worker process from the OBS plugin.
+
+Tracking:
+- Child issue: #120
+- Parent tracking issue: #110
+
+### Ownership
+
+- The OBS plugin owns the Worker process lifecycle (spawn / stop).
+- The Worker is responsible for initializing its own runtime dirs and logging under `user_data/`.
+- The plugin must avoid spawning multiple Workers for the same `ODR_USER_DATA_DIR`.
+
+### Inputs
+
+The plugin must define these launch inputs deterministically:
+
+- `ODR_USER_DATA_DIR` (required): absolute path to the runtime root directory.
+  - The Worker creates subdirectories under this root (`config/`, `data/`, `logs/`).
+  - If unset, the Worker defaults to `<repo>/user_data/` (repo-layout dependent).
+- `host` / `port` (recommended): bind address for the localhost HTTP API.
+  - Defaults (Worker v0.2 scaffold): `127.0.0.1:8787`.
+  - Overrides are supported via CLI: `--host` / `--port`.
+
+Optional:
+- `user_data/config/worker.toml` may define `host` / `port` as defaults.
+
+### Recommended Invocation
+
+The plugin should prefer invoking the packaged CLI entrypoint when available:
+
+- `odr-worker --host 127.0.0.1 --port 8787`
+
+If the plugin embeds Python or launches via `python -m`, the command must still behave equivalently and use the same `ODR_USER_DATA_DIR`.
+
+### Startup Handshake
+
+- After spawning the Worker, the plugin must wait until the API becomes ready.
+- Readiness signal: successful response from `GET /health`.
+- The plugin should apply a bounded timeout and surface actionable diagnostics when startup fails.
+
+### Shutdown Contract
+
+- The plugin must stop the Worker when OBS is shutting down or when the user explicitly stops it.
+- Preferred flow:
+  - graceful terminate with a short timeout, then
+  - force kill as a fallback.
+
+### Failure Reporting
+
+The plugin should surface at least:
+
+- worker exit code (if available)
+- the resolved `ODR_USER_DATA_DIR`
+- the Worker log directory (`<ODR_USER_DATA_DIR>/logs/`)
+- the API target (`host:port`) used for health checks
+
+---
+
 ## Communication
 
 Plugin and Worker communicate using localhost HTTP APIs.


### PR DESCRIPTION
## Summary
Document the minimal plugin->worker process launch contract for v0.4.

## Motivation
Issue #120 notes that launch/stop behavior must be deterministic and testable (at least via manual smoke). This PR documents the first-pass ownership boundaries and required launch inputs.

## Scope
- Docs-only update: `docs/architecture/plugin-worker.md`
- No dependencies
- No workflows

## Tracking
- Refs #120
- Parent #110