### PR TITLE
docs(v0.4): add canonical manual smoke procedure

### DIFF
--- a/docs/architecture/v0.4-smoke.md
+++ b/docs/architecture/v0.4-smoke.md
@@ -1,0 +1,73 @@
+# v0.4 OBS Plugin Smoke Procedure (Manual)
+
+This document defines the **minimal manual smoke procedure** for v0.4 (**OBS Plugin Skeleton**).
+
+Goal:
+- Make the meaning of "plugin can be built and loaded in OBS" consistent across contributors.
+- Provide a stable handoff from `#119` (plugin scaffold) to v0.4 acceptance and release readiness.
+
+Non-goals:
+- Packaging / installer design
+- CI automation
+- Distribution policy changes
+
+---
+
+## Preconditions (minimal)
+
+- Windows (per `docs/requirements/requirements.md`)
+- OBS Studio: **latest stable** for Windows **x64**
+- A clean workspace with no runtime data committed (`user_data/` must not be committed)
+
+Record the exact versions used in your smoke notes (OBS version, Windows version, build toolchain where relevant).
+
+---
+
+## What "pass" means (v0.4 minimal)
+
+This smoke is considered **passed** if all of the following are true:
+
+1. The plugin builds successfully with a documented command.
+2. OBS launches and the plugin can be loaded without crashing OBS.
+3. The plugin produces a clear **startup** and **shutdown** lifecycle log entry.
+4. Logs are written under the canonical runtime log location (typically `user_data/logs/`).
+
+If (2) fails (OBS crash / immediate unload), treat as a hard fail and stop.
+
+---
+
+## Procedure (suggested minimal steps)
+
+### A. Build
+
+- Confirm prerequisites are installed (documented in the plugin build instructions).
+- Build the plugin in a configuration intended for load testing (recommendation: Release).
+- Confirm the output artifact path to be used for loading in OBS.
+
+### B. Load in OBS
+
+- Start OBS.
+- Load the plugin (using the documented approach for the scaffold).
+- Confirm OBS does not crash and stays stable after the plugin is loaded.
+
+### C. Evidence collection (minimum)
+
+Capture the minimal evidence:
+
+- OBS version and architecture (x64)
+- Plugin build command used
+- The log lines showing:
+  - plugin startup
+  - plugin shutdown
+- The runtime log directory path used (must not be under `app/` and must not be committed)
+
+---
+
+## Notes / Handoff
+
+- This document is the canonical smoke procedure referenced from:
+  - `docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md`
+  - `docs/release/v0.4-release-readiness.md`
+- If contributors find gaps that block consistent verification, raise them in:
+  - `#133` (smoke environment contract)
+  - `#119` (plugin scaffold acceptance clarification)

--- a/docs/release/v0.4-release-readiness.md
+++ b/docs/release/v0.4-release-readiness.md
@@ -41,6 +41,7 @@ Perform these checks on Windows with OBS installed:
 - [ ] Plugin can stop the Worker process (or clearly reports why it cannot).
 - [ ] Plugin can detect Worker health via `GET /health` and surfaces status in the Dock UI.
 - [ ] Heartbeat timeout behavior is documented and observable in logs / diagnostics.
+- [ ] Smoke notes record the concrete environment and evidence (see `docs/architecture/v0.4-smoke.md`).
 
 ## D. Release PR readiness
 

--- a/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
+++ b/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
@@ -75,3 +75,6 @@ v0.4 focuses on:
   - [ ] worker launches
   - [ ] dock shows health
   - [ ] logs are produced under `user_data/logs/`
+
+Reference procedure:
+- `docs/architecture/v0.4-smoke.md`


### PR DESCRIPTION
## Summary
Add a canonical minimal manual smoke procedure for v0.4 (OBS Plugin Skeleton) and wire it into the v0.4 acceptance + release readiness checklists.

## Motivation
Issue #119 / #133 repeatedly re-detect that "manual smoke" preconditions and evidence are underspecified, which risks inconsistent definition-of-done for the first v0.4 child issue.

## Scope
- Add `docs/architecture/v0.4-smoke.md`
- Link from `docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md`
- Require concrete smoke notes evidence in `docs/release/v0.4-release-readiness.md`

## Tracking
- Parent: #110
- Supports: #119, #133

## Notes
Docs-only change; no dependencies; no workflows.