### PR TITLE
feat(worker): add /version endpoint for plugin integration

### DIFF
--- a/app/worker/odr_worker/api.py
+++ b/app/worker/odr_worker/api.py
@@ -8,7 +8,7 @@ from fastapi.responses import JSONResponse
 
 from .config import LoadedWorkerConfig, get_repo_root
 from .db import DbInfo
-from .health import WorkerDb, WorkerPaths, build_health_payload
+from .health import API_VERSION, WorkerDb, WorkerPaths, build_health_payload
 from .runtime_dirs import RuntimeDirs
 from .version import __version__
 
@@ -47,6 +47,10 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
     @app.get("/health")
     def health() -> dict[str, object]:
         return build_health_payload(paths=app.state.paths, config_loaded=app.state.config_loaded, db=app.state.db)
+
+    @app.get("/version")
+    def version() -> dict[str, object]:
+        return {"version": __version__, "api_version": API_VERSION}
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception):

--- a/app/worker/tests/test_health.py
+++ b/app/worker/tests/test_health.py
@@ -55,6 +55,32 @@ class HealthEndpointTests(unittest.TestCase):
             ):
                 self.assertIn(path_key, data["paths"])
 
+    def test_version_endpoint_has_required_fields(self) -> None:
+        from fastapi.testclient import TestClient
+
+        from odr_worker.api import create_app
+        from odr_worker.config import LoadedWorkerConfig, WorkerConfig
+        from odr_worker.runtime_dirs import ensure_runtime_dirs
+
+        with tempfile.TemporaryDirectory() as tmp:
+            user_data_dir = Path(tmp)
+            runtime_dirs = ensure_runtime_dirs(user_data_dir=user_data_dir)
+            loaded_config = LoadedWorkerConfig(
+                config=WorkerConfig(),
+                config_path=runtime_dirs.config_dir / "worker.toml",
+                config_loaded=False,
+            )
+
+            app = create_app(runtime_dirs=runtime_dirs, loaded_config=loaded_config)
+
+            client = TestClient(app)
+            resp = client.get("/version")
+            self.assertEqual(resp.status_code, 200)
+
+            data = resp.json()
+            for key in ("version", "api_version"):
+                self.assertIn(key, data)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/architecture/plugin-worker.md
+++ b/docs/architecture/plugin-worker.md
@@ -108,5 +108,6 @@ For the v0.2 Worker API contract, see:
 
 Example:
 - GET /health
+- GET /version
 - POST /events/recording-started
 - POST /events/recording-stopped


### PR DESCRIPTION
## Summary
Add a minimal `GET /version` endpoint to the Worker localhost API.

## Motivation
v0.4 Plugin skeleton work (#123/#120) benefits from a lightweight way to check version/API-compatibility without parsing the full `/health` payload.

## Scope
- Add `GET /version` returning `{ version, api_version }`.
- Document the endpoint in `docs/architecture/plugin-worker.md`.
- Add a small unit test.

## Non-goals
- No plugin-side wrapper implementation.
- No behavior change to `/health`.

## Related
- Refs #110 (v0.4 tracking)
- Supports #123 (localhost API wrapper)
