### PR TITLE
docs(v0.4): clarify compatibility surface for /health and /version

### DIFF
--- a/docs/architecture/compatibility.md
+++ b/docs/architecture/compatibility.md
@@ -23,7 +23,7 @@ For v0.x, the API version is treated as a **minor-level contract**: patch releas
 
 ## Canonical fields
 
-The Worker SHOULD surface these fields via `GET /health`:
+The Worker SHOULD surface these fields via `GET /health` (canonical):
 
 - `version: string`
   - Worker version (SemVer recommended), e.g. `0.2.0`.
@@ -39,7 +39,7 @@ The Plugin SHOULD know its own:
 
 ## Where compatibility is surfaced
 
-### `GET /health`
+### `GET /health` (canonical)
 
 The Worker MUST expose a compatibility signal in `GET /health`.
 
@@ -53,13 +53,30 @@ Recommended minimal shape (illustrative):
 }
 ```
 
-The exact v0.2 `/health` payload is defined by v0.2 docs and acceptance criteria, but the compatibility fields above should be considered stable.
+The exact `/health` payload is version-scoped by acceptance criteria, but the compatibility fields above should be considered stable.
+
+### `GET /version` (optional)
+
+If the Worker exposes `GET /version`, it SHOULD include at least:
+
+```json
+{
+  "version": "0.2.0",
+  "api_version": "0.2"
+}
+```
+
+Notes:
+- `GET /version` is intended as a lightweight compatibility preflight.
+- `GET /version` must not be treated as a readiness/health signal by itself.
 
 ---
 
 ## Plugin behavior (high level)
 
-When the Plugin can reach the Worker API:
+### Compatibility gating
+
+When the Plugin can reach the Worker API and can read compatibility fields (via `/health` and/or `/version`):
 
 - If `api_version == expected_api_version`:
   - treat as compatible and continue.
@@ -69,14 +86,30 @@ When the Plugin can reach the Worker API:
   - avoid performing further API calls (do not attempt to continue with a mismatched contract).
   - show a clear action: update Plugin and/or Worker to a compatible pair.
 
-When the Worker is running but `GET /health` is unreachable:
+`version_mismatch` should be reserved for cases where a version range/matrix is explicitly defined. If no explicit rule exists yet, prefer using `api_incompatible` as the compatibility gate.
+
+### Port-collision / foreign process preflight
+
+Before spawning a Worker, the Plugin may do a preflight on the target `host:port`:
+
+- Preferred: call `GET /version` first (if available), then call `GET /health` if needed.
+- Fallback: call `GET /health` directly when `/version` is not implemented.
+
+If a response is reachable but is not compatible (or the Plugin cannot confirm it is the intended Worker instance), treat it as a **launch failure** (port collision / foreign process).
+
+### Startup vs mismatch
+
+When the Worker process is running but `GET /health` is unreachable:
 - treat as `starting` (early) or `unhealthy` (after timeout), not as a compatibility mismatch.
+
+Even if `GET /version` succeeds, a failing `GET /health` during startup should still map to startup/health diagnostics (not mismatch) unless an explicit compatibility mismatch is observed.
 
 ---
 
 ## Related docs
 
 - `docs/architecture/worker-diagnostics.md`
+- `docs/architecture/plugin-worker.md`
 - `docs/requirements/v0.2-worker-core-api-acceptance.md`
 
 Refs: #54

--- a/docs/architecture/plugin-worker.md
+++ b/docs/architecture/plugin-worker.md
@@ -144,6 +144,9 @@ Minimum policy (v0.4):
 - If `/health` is reachable but is not compatible, or the plugin cannot confirm it is the intended Worker instance, treat it as a **launch failure** (port collision / foreign process) and do not continue as "running".
 - If the port is in use but `/health` is not reachable or returns invalid responses, treat it as a **launch failure** (stale/unknown process) and do not automatically kill the process.
 
+Optional refinement:
+- If the Worker implements `GET /version`, the plugin may use it as a lighter preflight (read `version` / `api_version`) before calling `/health`.
+
 The definition of "intended Worker instance" may be minimal initially (e.g. same `ODR_USER_DATA_DIR` and compatible `/health` fields) and can be tightened later.
 
 ### Handoff to Other v0.4 Concerns

--- a/docs/architecture/worker-diagnostics.md
+++ b/docs/architecture/worker-diagnostics.md
@@ -83,7 +83,7 @@ Recommended user action:
 
 ## Mapping Guidance (high level)
 
-This section is guidance only; the concrete field names live in the v0.2 `/health` contract and related docs.
+This section is guidance only; the concrete field names live in the version-scoped `/health` contract and related docs.
 
 For the minimal compatibility contract and gating rules, see:
 - `docs/architecture/compatibility.md`
@@ -97,11 +97,19 @@ The Plugin can map to a diagnostic state using (in priority order):
 2. **API reachability**
    - `GET /health` fails consistently while process is running → `starting` (early) or `unhealthy` (after timeout)
 
-3. **/health semantics** (when available)
+   Notes:
+   - If `GET /version` is implemented, the Plugin may use it as an earlier/lighter reachability signal.
+   - `GET /version` success with `GET /health` failure should still be treated as startup/health diagnostics (not an automatic mismatch).
+
+3. **/health (and /version) semantics** (when available)
    - Health OK → `running`
    - Health not OK with a config-related reason → `config_error`
    - Health not OK with a runtime dir/path reason → `runtime_dir_error`
-   - Compatibility/version fields indicate mismatch → `version_mismatch` or `api_incompatible`
+   - Compatibility fields indicate mismatch → `version_mismatch` or `api_incompatible`
+
+Compatibility guidance:
+- Prefer `api_incompatible` when `api_version` does not match expected.
+- Reserve `version_mismatch` for cases where the Plugin explicitly defines a version range/matrix beyond API version gating.
 
 ---
 


### PR DESCRIPTION
## Summary
Clarify the v0.4 docs-first contract for how Plugin compatibility gating should treat `GET /health` vs `GET /version`.

## Motivation
PR #136 adds `GET /version`, but the existing compatibility/diagnostics docs still assume `/health`-only. Without an explicit responsibility split, wrapper/diagnostics work (#123) can drift.

## Scope
- Update `docs/architecture/compatibility.md` to:
  - keep `/health` as canonical
  - define `/version` as optional lightweight preflight
  - clarify mismatch vs startup semantics
- Update `docs/architecture/worker-diagnostics.md` mapping notes for `/version`.
- Update `docs/architecture/plugin-worker.md` to mention `/version` as optional preflight refinement.

## Non-goals
- No new endpoints or implementation changes.
- No acceptance/release checklist changes.

## Related
- Refs #137 (idea: define responsibility split)
- Supports #123 (wrapper/diagnostics)
- Context: #110 (v0.4 tracking) / PR #136
