### PR TITLE
docs(release): finalize v0.3.0 release records

### DIFF
--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -40,10 +40,11 @@ The version tracking issue may contain the working release summary, but finalize
 - Version tracking issue: #88
 - Milestone: `v0.3` (not set)
 - Release readiness checklist: `docs/release/v0.3-release-readiness.md`
-- Intended tag: `v0.3.0`
-- Intended tag target: `5b51a33454f469d6a782387ece8f5afba13b0d49`
+- Tag: `v0.3.0`
+- Tag target: `5a31a55b76f5cd2d3e2a64cbf1d4cfed04642dd0`
+- Tag finalized at: `2026-05-18T07:55:10+09:00`
 - Release summary: `docs/release/v0.3-release-summary.md`
 - Major PRs: #101, #104, #107
-- Follow-up PR: #118 (align Worker distribution metadata version to `0.3.0`; re-identify tag target after merge)
+- Version PRs: #112, #118
 - Next version tracking issue: #110
-- Status: ready_to_tag
+- Status: released

--- a/docs/release/v0.3-release-summary.md
+++ b/docs/release/v0.3-release-summary.md
@@ -1,23 +1,22 @@
 # v0.3.0 Release Summary (SQLite Foundation)
 
-Status: **ready_to_tag**
+Status: **released**
 
 ## Release Point
 
-- Intended tag: `v0.3.0`
-- Intended tag target: `5b51a33454f469d6a782387ece8f5afba13b0d49`
+- Tag: `v0.3.0`
+- Tag target: `5a31a55b76f5cd2d3e2a64cbf1d4cfed04642dd0`
+- Tag finalized at: `2026-05-18T07:55:10+09:00`
 - Version tracking issue: #88
 - Release readiness checklist: `docs/release/v0.3-release-readiness.md`
-
-Note: Tag creation is pending. After creating the tag, record the created date/time and update status to **released**.
-
-Note: PR #118 aligns `app/worker/pyproject.toml` metadata version to `0.3.0`. After it is merged, re-identify the tag target on `main` before creating `v0.3.0`.
 
 ## Major PRs
 
 - #101 `docs: add v0.3 release readiness checklist`
 - #104 `feat(v0.3): add SQLite foundation`
 - #107 `fix(v0.3): harden SQLite init error handling`
+- #112 `chore(worker): bump version to 0.3.0`
+- #118 `chore(worker): align package version to 0.3.0`
 
 ## Completed Scope
 
@@ -26,10 +25,11 @@ Note: PR #118 aligns `app/worker/pyproject.toml` metadata version to `0.3.0`. Af
 - Minimal migration framework
 - Initial tables (`matches`, `upload_queue`)
 - Restart-safe, idempotent startup behavior
+- Worker runtime and package metadata version aligned to `0.3.0`
 
 ## Deferred / Follow-ups
 
-- #118 `chore(worker): align package version to 0.3.0` (required before tagging; re-identify tag target after merge)
+- None for v0.3 release completion.
 
 ## Next Version
 


### PR DESCRIPTION
## Summary
Finalize v0.3.0 release records after the `v0.3.0` tag was moved to the post-#118 merge commit.

## Changes
- Mark v0.3.0 as `released` in `docs/release-history.md`.
- Update the v0.3.0 tag target to `5a31a55b76f5cd2d3e2a64cbf1d4cfed04642dd0`.
- Mark `docs/release/v0.3-release-summary.md` as released and record the finalized tag timestamp.
- Record #112 and #118 as version PRs.

## Verification
- Docs-only change; no runtime tests required.

## Related
- Closes release-record follow-up for #88.