### PR TITLE
feat(worker): expose instance_id for localhost correlation

### DIFF
--- a/app/worker/odr_worker/api.py
+++ b/app/worker/odr_worker/api.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse
 from .config import LoadedWorkerConfig, get_repo_root
 from .db import DbInfo
 from .health import API_VERSION, WorkerDb, WorkerPaths, build_health_payload
+from .identity import INSTANCE_ID
 from .runtime_dirs import RuntimeDirs
 from .version import __version__
 
@@ -50,7 +51,7 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
 
     @app.get("/version")
     def version() -> dict[str, object]:
-        return {"version": __version__, "api_version": API_VERSION}
+        return {"version": __version__, "api_version": API_VERSION, "instance_id": INSTANCE_ID}
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception):

--- a/app/worker/odr_worker/health.py
+++ b/app/worker/odr_worker/health.py
@@ -4,6 +4,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from .identity import INSTANCE_ID
 from .version import __version__
 
 
@@ -38,6 +39,7 @@ def build_health_payload(*, paths: WorkerPaths, config_loaded: bool, db: WorkerD
         "status": "ok",
         "version": __version__,
         "api_version": API_VERSION,
+        "instance_id": INSTANCE_ID,
         "uptime_seconds": uptime_seconds,
         "config_loaded": config_loaded,
         "runtime_dirs_ok": True,

--- a/app/worker/odr_worker/identity.py
+++ b/app/worker/odr_worker/identity.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+import uuid
+
+INSTANCE_ID = uuid.uuid4().hex

--- a/app/worker/tests/test_health.py
+++ b/app/worker/tests/test_health.py
@@ -39,6 +39,7 @@ class HealthEndpointTests(unittest.TestCase):
                 "status",
                 "version",
                 "api_version",
+                "instance_id",
                 "uptime_seconds",
                 "config_loaded",
                 "runtime_dirs_ok",
@@ -78,7 +79,7 @@ class HealthEndpointTests(unittest.TestCase):
             self.assertEqual(resp.status_code, 200)
 
             data = resp.json()
-            for key in ("version", "api_version"):
+            for key in ("version", "api_version", "instance_id"):
                 self.assertIn(key, data)
 
 

--- a/docs/architecture/compatibility.md
+++ b/docs/architecture/compatibility.md
@@ -30,6 +30,12 @@ The Worker SHOULD surface these fields via `GET /health` (canonical):
 - `api_version: string`
   - API contract version (SemVer-like string), e.g. `0.2` for the v0.2 contract.
 
+Optional (recommended for foreign-process / port-collision detection):
+
+- `instance_id: string`
+  - A per-process unique identifier generated at Worker startup.
+  - The Plugin can use this to confirm the reachable localhost API is the intended Worker instance.
+
 The Plugin SHOULD know its own:
 
 - `plugin_version: string`
@@ -49,7 +55,8 @@ Recommended minimal shape (illustrative):
 {
   "status": "ok",
   "version": "0.2.0",
-  "api_version": "0.2"
+  "api_version": "0.2",
+  "instance_id": "c4dbf6b1b2a34f59a39f0bbaf43ad8a2"
 }
 ```
 
@@ -62,7 +69,8 @@ If the Worker exposes `GET /version`, it SHOULD include at least:
 ```json
 {
   "version": "0.2.0",
-  "api_version": "0.2"
+  "api_version": "0.2",
+  "instance_id": "c4dbf6b1b2a34f59a39f0bbaf43ad8a2"
 }
 ```
 


### PR DESCRIPTION
## Summary
Add a per-process `instance_id` to the Worker `/health` (canonical) and `/version` (optional) payloads, and document it as an optional correlation signal for foreign-process / port-collision detection.

## Why
Helps the Plugin (and the future localhost wrapper) confirm that the reachable localhost API is the intended Worker instance, reducing ambiguity in stale-process / wrong-port scenarios.

## Scope
- Worker: add `INSTANCE_ID` generated at startup and exposed in responses
- Tests: assert `instance_id` is present
- Docs: update `docs/architecture/compatibility.md`

## Notes
- Backwards compatible: adds a new optional field; existing fields remain unchanged.

## Checks
- Local: `python -m unittest discover -s app/worker/tests -p 'test_*.py' -v`

Refs: #123 #120 #126 #127