### PR TITLE
docs(v0.4): adopt singleton Worker instance model

### DIFF
--- a/docs/architecture/compatibility.md
+++ b/docs/architecture/compatibility.md
@@ -16,6 +16,8 @@ Non-goals:
 
 - **Worker version**: the Worker binary/app version (SemVer).
 - **API version**: the localhost HTTP API contract version used for compatibility gating.
+- **Runtime root**: the resolved `ODR_USER_DATA_DIR` used by the Worker for config, data, and logs.
+- **Singleton Worker**: the only Worker process that should serve one runtime root.
 
 For v0.x, the API version is treated as a **minor-level contract**: patch releases must remain compatible.
 
@@ -30,16 +32,18 @@ The Worker SHOULD surface these fields via `GET /health` (canonical):
 - `api_version: string`
   - API contract version (SemVer-like string), e.g. `0.2` for the v0.2 contract.
 
-Optional (recommended for foreign-process / port-collision detection):
+Optional diagnostic field:
 
 - `instance_id: string`
   - A per-process unique identifier generated at Worker startup.
-  - The Plugin can use this to confirm the reachable localhost API is the intended Worker instance.
+  - The Plugin can use this to diagnose stale-process, wrong-port, or singleton invariant violations.
+  - `instance_id` is not the primary ownership gate in v0.4; the primary ownership scope is the singleton Worker for the resolved `ODR_USER_DATA_DIR`.
 
 The Plugin SHOULD know its own:
 
 - `plugin_version: string`
 - `expected_api_version: string`
+- resolved `ODR_USER_DATA_DIR`
 
 ---
 
@@ -96,14 +100,21 @@ When the Plugin can reach the Worker API and can read compatibility fields (via 
 
 `version_mismatch` should be reserved for cases where a version range/matrix is explicitly defined. If no explicit rule exists yet, prefer using `api_incompatible` as the compatibility gate.
 
-### Port-collision / foreign process preflight
+### Singleton and port-collision preflight
 
-Before spawning a Worker, the Plugin may do a preflight on the target `host:port`:
+Before spawning a Worker, the Plugin should do a preflight on the target `host:port`:
 
 - Preferred: call `GET /version` first (if available), then call `GET /health` if needed.
 - Fallback: call `GET /health` directly when `/version` is not implemented.
 
-If a response is reachable but is not compatible (or the Plugin cannot confirm it is the intended Worker instance), treat it as a **launch failure** (port collision / foreign process).
+If a response is reachable, compatible, and belongs to the same runtime-root singleton scope, the Plugin should reuse that Worker instead of spawning another one.
+
+If a response is reachable but is not compatible, or the Plugin cannot confirm the same runtime-root singleton scope, treat it as a **launch failure** (port collision / foreign process).
+
+`instance_id` handling:
+- Missing `instance_id` should not block v0.4 release readiness by itself.
+- If `instance_id` changes unexpectedly during the same runtime-root session, surface a diagnostic warning or error for stale-process / wrong-port investigation.
+- `instance_id` should support singleton diagnostics, not replace runtime-root singleton ownership.
 
 ### Startup vs mismatch
 
@@ -120,4 +131,4 @@ Even if `GET /version` succeeds, a failing `GET /health` during startup should s
 - `docs/architecture/plugin-worker.md`
 - `docs/requirements/v0.2-worker-core-api-acceptance.md`
 
-Refs: #54
+Refs: #54 #144

--- a/docs/architecture/plugin-worker.md
+++ b/docs/architecture/plugin-worker.md
@@ -98,10 +98,15 @@ Tracking:
 Related design inputs:
 - #126 instance identity and port ownership
 - #127 single-instance and port-collision contract
+- #144 instance_id adoption decision
+- #145 reused-Worker ownership contract
 
 ### Ownership
 
-- The OBS plugin owns the Worker process lifecycle (spawn / stop).
+- The Worker is a singleton per `ODR_USER_DATA_DIR` runtime root.
+- The OBS plugin owns discovery and use of the singleton Worker for its configured runtime root.
+- The plugin should reuse an existing healthy singleton Worker for the same `ODR_USER_DATA_DIR`.
+- The plugin should spawn a Worker only when no healthy singleton exists for that runtime root.
 - The Worker is responsible for initializing its own runtime dirs and logging under `user_data/`.
 - The plugin must avoid spawning multiple Workers for the same `ODR_USER_DATA_DIR`.
 
@@ -112,6 +117,7 @@ The plugin must define these launch inputs deterministically:
 - `ODR_USER_DATA_DIR` (required): absolute path to the runtime root directory.
   - The Worker creates subdirectories under this root (`config/`, `data/`, `logs/`).
   - If unset, the Worker defaults to `<repo>/user_data/` (repo-layout dependent).
+  - The singleton scope is this resolved runtime root.
 - `host` / `port` (recommended): bind address for the localhost HTTP API.
   - Defaults (Worker v0.2 scaffold): `127.0.0.1:8787`.
   - Overrides are supported via CLI: `--host` / `--port`.
@@ -129,6 +135,7 @@ If the plugin embeds Python or launches via `python -m`, the command must still 
 
 ### Startup Handshake
 
+- Before spawning, the plugin should discover whether a healthy singleton Worker already exists for the resolved `ODR_USER_DATA_DIR`.
 - After spawning the Worker, the plugin must wait until the API becomes ready.
 - Readiness signal: successful response from `GET /health`.
 - The plugin should apply a bounded timeout and surface actionable diagnostics when startup fails.
@@ -140,26 +147,30 @@ The plugin must avoid accidentally talking to the wrong localhost process.
 Minimum policy (v0.4):
 
 - Preflight check: before spawning, try `GET /health` on the target `host:port`.
-- If `/health` is reachable and the response is compatible with the plugin expectation, the plugin may treat it as an already-running Worker and reuse it.
-- If `/health` is reachable but is not compatible, or the plugin cannot confirm it is the intended Worker instance, treat it as a **launch failure** (port collision / foreign process) and do not continue as "running".
+- If `/health` is reachable, compatible, and identifies the same `ODR_USER_DATA_DIR` scope, the plugin should treat it as the already-running singleton Worker and reuse it.
+- If `/health` is reachable but is not compatible, or the plugin cannot confirm the same runtime-root singleton scope, treat it as a **launch failure** (port collision / foreign process) and do not continue as "running".
 - If the port is in use but `/health` is not reachable or returns invalid responses, treat it as a **launch failure** (stale/unknown process) and do not automatically kill the process.
+- If the Worker exposes `instance_id`, the plugin should use it as a diagnostic signal for singleton invariant violations, stale processes, and wrong-port connections. `instance_id` is not the primary ownership gate.
 
 Optional refinement:
-- If the Worker implements `GET /version`, the plugin may use it as a lighter preflight (read `version` / `api_version`) before calling `/health`.
+- If the Worker implements `GET /version`, the plugin may use it as a lighter preflight (read `version` / `api_version` / `instance_id`) before calling `/health`.
 
-The definition of "intended Worker instance" may be minimal initially (e.g. same `ODR_USER_DATA_DIR` and compatible `/health` fields) and can be tightened later.
+The definition of the intended Worker is the singleton Worker for the resolved `ODR_USER_DATA_DIR`. `instance_id` can help diagnose unexpected process changes, but the runtime-root singleton is the primary contract.
 
 ### Handoff to Other v0.4 Concerns
 
 - Heartbeat cadence/timeout and failure handling lives in #121.
 - Diagnostics mapping and wrapper behavior for collision cases lives in #123.
+- The exact `instance_id` mismatch behavior lives in #144.
 
 ### Shutdown Contract
 
-- The plugin must stop the Worker when OBS is shutting down or when the user explicitly stops it.
-- Preferred flow:
+- The plugin must not stop a reused singleton Worker unless ownership rules say it is safe to do so.
+- If the plugin spawned the singleton Worker for the current runtime root, it should stop that Worker when OBS is shutting down or when the user explicitly stops it.
+- Preferred flow for plugin-owned Workers:
   - graceful terminate with a short timeout, then
   - force kill as a fallback.
+- For reused Workers, the plugin should first surface a diagnostic or confirmation path instead of blindly terminating a process that may be shared by another OBS instance.
 
 ### Failure Reporting
 
@@ -169,6 +180,7 @@ The plugin should surface at least:
 - the resolved `ODR_USER_DATA_DIR`
 - the Worker log directory (`<ODR_USER_DATA_DIR>/logs/`)
 - the API target (`host:port`) used for health checks
+- observed `instance_id` when available
 
 ---
 

--- a/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
+++ b/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
@@ -29,6 +29,7 @@ v0.4 focuses on:
 
 - **Application files** live under `app/`
 - **Runtime data** lives under `user_data/` and must not be committed
+- **Singleton Worker** means one Worker process per resolved `ODR_USER_DATA_DIR` runtime root
 
 ---
 
@@ -50,6 +51,8 @@ v0.4 focuses on:
 
 - [ ] Plugin can launch the Worker process using a documented command/entrypoint.
 - [ ] Plugin does not require users to manually start the Worker in the normal path.
+- [ ] Plugin treats Worker as a singleton per resolved `ODR_USER_DATA_DIR`.
+- [ ] Plugin reuses an existing healthy singleton Worker for the same runtime root instead of spawning a second Worker.
 - [ ] Plugin reports launch failures with actionable diagnostics (log + UI surface).
 
 ### D. Worker Health / Heartbeat
@@ -67,6 +70,8 @@ v0.4 focuses on:
 
 - [ ] Plugin uses a minimal API wrapper layer rather than ad-hoc HTTP calls throughout the codebase.
 - [ ] Wrapper behavior for failure cases is defined (timeouts, refused connection, incompatible API).
+- [ ] Wrapper behavior for stale-process / wrong-port / singleton invariant violations is defined.
+- [ ] `instance_id`, when available, is used as a diagnostic signal rather than the primary ownership gate.
 
 ### G. Developer Verification
 
@@ -75,6 +80,7 @@ v0.4 focuses on:
   - [ ] worker launches
   - [ ] dock shows health
   - [ ] logs are produced under `user_data/logs/`
+  - [ ] a second launch path reuses or rejects an existing singleton Worker instead of spawning another Worker for the same runtime root
 
 Reference procedure:
 - `docs/architecture/v0.4-smoke.md`


### PR DESCRIPTION
## Summary
- Adopt the v0.4 decision that Worker is a singleton per resolved `ODR_USER_DATA_DIR`
- Clarify that Plugin should reuse a healthy singleton Worker and spawn only when none exists
- Reframe `instance_id` as a diagnostic signal for stale-process / wrong-port / singleton invariant violations, not the primary ownership gate
- Add acceptance criteria for singleton reuse and wrapper diagnostics

## Decision
This captures the administrator decision from #144: use the singleton Worker model as the primary contract, with `instance_id` retained for diagnostics.

## Checks
- Documentation-only change
- No new links or dependencies added

Refs: #110 #120 #123 #127 #144 #145