### PR TITLE
ci: add lightweight pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           cache-dependency-path: app/worker/pyproject.toml
 
       - name: Install Worker package
-        run: python -m pip install -e app/worker
+        run: python -m pip install -e "app/worker[test]"
 
       - name: Run Worker tests
         run: python -m unittest discover -s app/worker/tests -p "test_*.py" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  docs:
+    name: Docs validation
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Validate Markdown links
+        shell: powershell
+        run: powershell -ExecutionPolicy Bypass -File docs/tools/validate_markdown_links.ps1
+
+      - name: Validate Japanese user docs coverage
+        shell: powershell
+        run: python scripts/validate_jp_user_docs_coverage.py --root .
+
+  worker-tests:
+    name: Worker unit tests
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: app/worker/pyproject.toml
+
+      - name: Install Worker package
+        run: python -m pip install -e app/worker
+
+      - name: Run Worker tests
+        run: python -m unittest discover -s app/worker/tests -p "test_*.py" -v

--- a/app/worker/pyproject.toml
+++ b/app/worker/pyproject.toml
@@ -13,6 +13,11 @@ dependencies = [
   "uvicorn>=0.27",
 ]
 
+[project.optional-dependencies]
+test = [
+  "httpx>=0.27",
+]
+
 [project.scripts]
 odr-worker = "odr_worker.__main__:main"
 

--- a/docs/tools/validate_markdown_links.ps1
+++ b/docs/tools/validate_markdown_links.ps1
@@ -58,7 +58,7 @@ function Get-HeadingAnchors([string]$markdown) {
   }
 
   # Also allow explicit HTML ids: <a id="..."></a>
-  foreach ($m in [regex]::Matches($markdown, "(?i)<a\s+[^>]*id\s*=\s*`\"([^`\"]+)`\"[^>]*>")) {
+  foreach ($m in [regex]::Matches($markdown, '(?i)<a\s+[^>]*id\s*=\s*"([^"]+)"[^>]*>')) {
     $id = $m.Groups[1].Value.Trim()
     if ($id) { [void]$anchors.Add($id) }
   }
@@ -68,7 +68,7 @@ function Get-HeadingAnchors([string]$markdown) {
 
 if ([string]::IsNullOrWhiteSpace($Root)) {
   $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-  $Root = (Resolve-Path (Join-Path $scriptDir "..\\..")).Path
+  $Root = (Resolve-Path (Join-Path $scriptDir "..\..")).Path
 }
 
 $rootPath = (Resolve-Path $Root).Path


### PR DESCRIPTION
## Summary
- Add a lightweight CI workflow for pull requests and pushes to `main`
- Run docs validation and Japanese user docs coverage checks
- Run Worker unit tests on Windows with Python 3.12
- Fix PowerShell quoting in the Markdown link validator so it can run in CI

## Scope
- No branch protection changes
- No secrets, deploys, artifacts, or write permissions
- Workflow permissions are limited to `contents: read`

## Local checks
- `powershell -ExecutionPolicy Bypass -File docs/tools/validate_markdown_links.ps1` PASS (49 files)
- `python scripts/validate_jp_user_docs_coverage.py --root .` PASS
- `python -m unittest discover -s app/worker/tests -p test_*.py -v` PASS (8 tests)