### PR TITLE
feat(worker): include pid/started_at in /health and /version

### DIFF
--- a/app/worker/odr_worker/api.py
+++ b/app/worker/odr_worker/api.py
@@ -8,7 +8,7 @@ from fastapi.responses import JSONResponse
 
 from .config import LoadedWorkerConfig, get_repo_root
 from .db import DbInfo
-from .health import API_VERSION, WorkerDb, WorkerPaths, build_health_payload
+from .health import API_VERSION, PID, STARTED_AT, WorkerDb, WorkerPaths, build_health_payload
 from .identity import INSTANCE_ID
 from .runtime_dirs import RuntimeDirs
 from .version import __version__
@@ -51,7 +51,13 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
 
     @app.get("/version")
     def version() -> dict[str, object]:
-        return {"version": __version__, "api_version": API_VERSION, "instance_id": INSTANCE_ID}
+        return {
+            "version": __version__,
+            "api_version": API_VERSION,
+            "instance_id": INSTANCE_ID,
+            "pid": PID,
+            "started_at": STARTED_AT,
+        }
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception):

--- a/app/worker/odr_worker/health.py
+++ b/app/worker/odr_worker/health.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import os
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 from .identity import INSTANCE_ID
@@ -10,6 +12,8 @@ from .version import __version__
 
 API_VERSION = "0.3"
 _START_TIME = time.monotonic()
+PID = os.getpid()
+STARTED_AT = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 @dataclass(frozen=True)
@@ -40,6 +44,8 @@ def build_health_payload(*, paths: WorkerPaths, config_loaded: bool, db: WorkerD
         "version": __version__,
         "api_version": API_VERSION,
         "instance_id": INSTANCE_ID,
+        "pid": PID,
+        "started_at": STARTED_AT,
         "uptime_seconds": uptime_seconds,
         "config_loaded": config_loaded,
         "runtime_dirs_ok": True,

--- a/app/worker/tests/test_health.py
+++ b/app/worker/tests/test_health.py
@@ -99,6 +99,39 @@ class HealthEndpointTests(unittest.TestCase):
             self.assertIsInstance(data["pid"], int)
             _parse_started_at(data["started_at"])
 
+    def test_health_and_version_identity_fields_are_stable(self) -> None:
+        """Wrapper diagnostics can treat these as stable per-process signals.
+
+        Supports v0.4 singleton-worker diagnostics (#144/#123).
+        """
+        from fastapi.testclient import TestClient
+
+        from odr_worker.api import create_app
+        from odr_worker.config import LoadedWorkerConfig, WorkerConfig
+        from odr_worker.runtime_dirs import ensure_runtime_dirs
+
+        with tempfile.TemporaryDirectory() as tmp:
+            user_data_dir = Path(tmp)
+            runtime_dirs = ensure_runtime_dirs(user_data_dir=user_data_dir)
+            loaded_config = LoadedWorkerConfig(
+                config=WorkerConfig(),
+                config_path=runtime_dirs.config_dir / "worker.toml",
+                config_loaded=False,
+            )
+
+            app = create_app(runtime_dirs=runtime_dirs, loaded_config=loaded_config)
+            client = TestClient(app)
+
+            health1 = client.get("/health").json()
+            version = client.get("/version").json()
+            health2 = client.get("/health").json()
+
+            for key in ("instance_id", "pid", "started_at"):
+                self.assertEqual(health1[key], version[key])
+                self.assertEqual(health1[key], health2[key])
+
+            _parse_started_at(health1["started_at"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/app/worker/tests/test_health.py
+++ b/app/worker/tests/test_health.py
@@ -3,12 +3,21 @@ from __future__ import annotations
 import sys
 import tempfile
 import unittest
+from datetime import datetime
 from pathlib import Path
 
 
 # Ensure `app/worker` is on sys.path so `import odr_worker` works without install.
 WORKER_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(WORKER_ROOT))
+
+
+def _parse_started_at(value: object) -> None:
+    if not isinstance(value, str):
+        raise AssertionError("started_at must be a string")
+    if not value.endswith("Z"):
+        raise AssertionError("started_at must be in UTC (Z suffix)")
+    datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
 class HealthEndpointTests(unittest.TestCase):
@@ -40,12 +49,17 @@ class HealthEndpointTests(unittest.TestCase):
                 "version",
                 "api_version",
                 "instance_id",
+                "pid",
+                "started_at",
                 "uptime_seconds",
                 "config_loaded",
                 "runtime_dirs_ok",
                 "paths",
             ):
                 self.assertIn(key, data)
+
+            self.assertIsInstance(data["pid"], int)
+            _parse_started_at(data["started_at"])
 
             for path_key in (
                 "app_dir",
@@ -79,8 +93,11 @@ class HealthEndpointTests(unittest.TestCase):
             self.assertEqual(resp.status_code, 200)
 
             data = resp.json()
-            for key in ("version", "api_version", "instance_id"):
+            for key in ("version", "api_version", "instance_id", "pid", "started_at"):
                 self.assertIn(key, data)
+
+            self.assertIsInstance(data["pid"], int)
+            _parse_started_at(data["started_at"])
 
 
 if __name__ == "__main__":

--- a/docs/architecture/compatibility.md
+++ b/docs/architecture/compatibility.md
@@ -32,12 +32,20 @@ The Worker SHOULD surface these fields via `GET /health` (canonical):
 - `api_version: string`
   - API contract version (SemVer-like string), e.g. `0.2` for the v0.2 contract.
 
-Optional diagnostic field:
+Optional diagnostic fields:
 
 - `instance_id: string`
   - A per-process unique identifier generated at Worker startup.
   - The Plugin can use this to diagnose stale-process, wrong-port, or singleton invariant violations.
   - `instance_id` is not the primary ownership gate in v0.4; the primary ownership scope is the singleton Worker for the resolved `ODR_USER_DATA_DIR`.
+
+- `pid: int`
+  - The Worker process PID at the time of response.
+  - Use as an additional signal to distinguish stale/foreign processes; do not treat as an ownership gate.
+
+- `started_at: string`
+  - The Worker process start time in UTC ISO 8601 with `Z` suffix, e.g. `2026-05-18T04:06:26Z`.
+  - Helps wrapper/launch diagnostics correlate probes and avoid mistaking a foreign process for the singleton Worker; do not treat as an ownership gate.
 
 The Plugin SHOULD know its own:
 
@@ -60,7 +68,9 @@ Recommended minimal shape (illustrative):
   "status": "ok",
   "version": "0.2.0",
   "api_version": "0.2",
-  "instance_id": "c4dbf6b1b2a34f59a39f0bbaf43ad8a2"
+  "instance_id": "c4dbf6b1b2a34f59a39f0bbaf43ad8a2",
+  "pid": 12345,
+  "started_at": "2026-05-18T04:06:26Z"
 }
 ```
 
@@ -74,7 +84,9 @@ If the Worker exposes `GET /version`, it SHOULD include at least:
 {
   "version": "0.2.0",
   "api_version": "0.2",
-  "instance_id": "c4dbf6b1b2a34f59a39f0bbaf43ad8a2"
+  "instance_id": "c4dbf6b1b2a34f59a39f0bbaf43ad8a2",
+  "pid": 12345,
+  "started_at": "2026-05-18T04:06:26Z"
 }
 ```
 

--- a/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
+++ b/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
@@ -71,7 +71,7 @@ v0.4 focuses on:
 - [ ] Plugin uses a minimal API wrapper layer rather than ad-hoc HTTP calls throughout the codebase.
 - [ ] Wrapper behavior for failure cases is defined (timeouts, refused connection, incompatible API).
 - [ ] Wrapper behavior for stale-process / wrong-port / singleton invariant violations is defined.
-- [ ] `instance_id`, when available, is used as a diagnostic signal rather than the primary ownership gate.
+- [ ] `instance_id` (and other identity fields such as `pid` / `started_at`, when available) are used as diagnostic evidence rather than the primary ownership gate (primary: singleton per resolved `ODR_USER_DATA_DIR`).
 
 ### G. Developer Verification
 


### PR DESCRIPTION
## What
Expose `pid` and `started_at` (UTC) from Worker `/health` and `/version`.

## Why
Helps v0.4 wrapper/launch diagnostics distinguish stale/foreign processes and correlate localhost probes more reliably without making `instance_id` the ownership gate.

## Scope
Worker-only; no new dependencies.

Refs: #123 #120 #144