### PR TITLE
test(worker): assert identity fields stable for /health and /version

### DIFF
--- a/app/worker/tests/test_health.py
+++ b/app/worker/tests/test_health.py
@@ -3,12 +3,21 @@ from __future__ import annotations
 import sys
 import tempfile
 import unittest
+from datetime import datetime
 from pathlib import Path
 
 
 # Ensure `app/worker` is on sys.path so `import odr_worker` works without install.
 WORKER_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(WORKER_ROOT))
+
+
+def _parse_started_at(value: object) -> None:
+    if not isinstance(value, str):
+        raise AssertionError("started_at must be a string")
+    if not value.endswith("Z"):
+        raise AssertionError("started_at must be in UTC (Z suffix)")
+    datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
 class HealthEndpointTests(unittest.TestCase):
@@ -81,6 +90,46 @@ class HealthEndpointTests(unittest.TestCase):
             data = resp.json()
             for key in ("version", "api_version", "instance_id"):
                 self.assertIn(key, data)
+
+    def test_health_and_version_identity_fields_are_stable(self) -> None:
+        """Wrapper diagnostics can treat these as stable per-process signals.
+
+        Supports v0.4 singleton-worker diagnostics (#144/#123).
+        """
+        from fastapi.testclient import TestClient
+
+        from odr_worker.api import create_app
+        from odr_worker.config import LoadedWorkerConfig, WorkerConfig
+        from odr_worker.runtime_dirs import ensure_runtime_dirs
+
+        with tempfile.TemporaryDirectory() as tmp:
+            user_data_dir = Path(tmp)
+            runtime_dirs = ensure_runtime_dirs(user_data_dir=user_data_dir)
+            loaded_config = LoadedWorkerConfig(
+                config=WorkerConfig(),
+                config_path=runtime_dirs.config_dir / "worker.toml",
+                config_loaded=False,
+            )
+
+            app = create_app(runtime_dirs=runtime_dirs, loaded_config=loaded_config)
+            client = TestClient(app)
+
+            health1 = client.get("/health").json()
+            version = client.get("/version").json()
+            health2 = client.get("/health").json()
+
+            keys = ["instance_id"]
+            if all(k in health1 for k in ("pid", "started_at")) and all(
+                k in version for k in ("pid", "started_at")
+            ):
+                keys.extend(["pid", "started_at"])
+
+            for key in keys:
+                self.assertEqual(health1[key], version[key])
+                self.assertEqual(health1[key], health2[key])
+
+            if "started_at" in health1:
+                _parse_started_at(health1["started_at"])
 
 
 if __name__ == "__main__":

--- a/app/worker/tests/test_health.py
+++ b/app/worker/tests/test_health.py
@@ -118,13 +118,14 @@ class HealthEndpointTests(unittest.TestCase):
             version = client.get("/version").json()
             health2 = client.get("/health").json()
 
-            keys = ["instance_id"]
-            if all(k in health1 for k in ("pid", "started_at")) and all(
-                k in version for k in ("pid", "started_at")
-            ):
-                keys.extend(["pid", "started_at"])
+            for key in ("instance_id", "pid", "started_at"):
+                if key not in health1 and key not in version:
+                    continue
 
-            for key in keys:
+                self.assertIn(key, health1)
+                self.assertIn(key, version)
+                self.assertIn(key, health2)
+
                 self.assertEqual(health1[key], version[key])
                 self.assertEqual(health1[key], health2[key])
 


### PR DESCRIPTION
## What
Add a unit test that asserts `/health` and `/version` expose stable per-process identity signals across repeated calls.

- Always checks `instance_id`.
- If `pid` / `started_at` are present (e.g. when #152 lands), also checks those and validates `started_at` is UTC `Z`.

## Why
Supports v0.4 singleton-worker / localhost wrapper diagnostics: callers can treat these fields as evidence without turning them into an ownership gate.

Refs: #144 #123