### PR TITLE
docs: link v0.4 tracking issue from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Latest released version:
 
 Current development target:
 - `v0.4` - OBS Plugin Skeleton
+- Tracking issue: [#110](https://github.com/Tao-pyth/obs-duel-recorder/issues/110)
 
 Next roadmap target:
 - `v0.5` - Overlay Integration


### PR DESCRIPTION
## Summary
Link the v0.4 tracking issue from the README "Current Development" section for easier navigation.

## Changes
- Update `README.md` to include a bullet linking to #110 under `v0.4`.

## Related Issues
- Refs #110

## Scope Guardrails
- Docs-only change: `README.md` only.
- No dependencies, workflows, or runtime data changes.

## Verification
- Local: `powershell -File docs/tools/validate_markdown_links.ps1` (OK)
- Local: `python scripts/validate_jp_user_docs_coverage.py` (OK)
