### PR TITLE
docs(v0.4): reference rebind semantics planning input (#154)

### DIFF
--- a/docs/release/v0.4-release-readiness.md
+++ b/docs/release/v0.4-release-readiness.md
@@ -41,6 +41,7 @@ Perform these checks on Windows with OBS installed:
 - [ ] Plugin can stop the Worker process (or clearly reports why it cannot).
 - [ ] Plugin can detect Worker health via `GET /health` and surfaces status in the Dock UI.
 - [ ] Heartbeat timeout behavior is documented and observable in logs / diagnostics (see `docs/architecture/worker-diagnostics.md` - Failure Evidence (minimum)).
+- [ ] Heartbeat monitoring documents rebind/baseline-reset semantics when the Worker process is replaced mid-session (planning input: #154).
 - [ ] Smoke notes record the concrete environment and evidence (see `docs/architecture/v0.4-smoke.md`).
 
 ## D. Release PR readiness


### PR DESCRIPTION
## What
Add a v0.4 release readiness checklist item that points readers to the planning input about rebind/baseline-reset semantics when the Worker process is replaced mid-session.

## Why
Tracking issue #110 and heartbeat issue #121 both reference process replacement/rebind as an open planning point; surfacing it in `docs/release/v0.4-release-readiness.md` keeps the release checklist aligned with the latest design inputs.

Refs: #110 #121 #154