### PR TITLE
docs(roadmap): add v0.4 tracking issue link

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -106,6 +106,8 @@ Create persistent runtime storage.
 
 Establish OBS integration layer.
 
+Tracking issue: #110
+
 ### Planned
 
 - OBS Plugin scaffold


### PR DESCRIPTION
Refs #110

## What
- Add a reference to the v0.4 tracking issue in `docs/roadmap.md` (v0.4 section).

## Verification (local)
- `docs/tools/validate_markdown_links.ps1` => OK (44 files)
- `scripts/validate_jp_user_docs_coverage.py` => OK
