### PR TITLE
docs(compat): clarify pid/started_at are diagnostic-only

### DIFF
--- a/docs/architecture/compatibility.md
+++ b/docs/architecture/compatibility.md
@@ -32,12 +32,18 @@ The Worker SHOULD surface these fields via `GET /health` (canonical):
 - `api_version: string`
   - API contract version (SemVer-like string), e.g. `0.2` for the v0.2 contract.
 
-Optional diagnostic field:
+Optional diagnostic fields:
 
 - `instance_id: string`
   - A per-process unique identifier generated at Worker startup.
   - The Plugin can use this to diagnose stale-process, wrong-port, or singleton invariant violations.
   - `instance_id` is not the primary ownership gate in v0.4; the primary ownership scope is the singleton Worker for the resolved `ODR_USER_DATA_DIR`.
+- `pid: number`
+  - The Worker process id at the time the response is generated.
+  - Diagnostic evidence only (e.g. log correlation); it MUST NOT be treated as an ownership gate.
+- `started_at: string`
+  - Worker start timestamp in ISO 8601 format.
+  - Diagnostic evidence only (e.g. log correlation); it MUST NOT be treated as an ownership gate.
 
 The Plugin SHOULD know its own:
 


### PR DESCRIPTION
PR #152 の文脈（pid/started_at は ownership gate ではなく diagnostic evidence）を `docs/architecture/compatibility.md` に反映しました。

- `pid` / `started_at` を Optional diagnostic fields として明記
- いずれも ownership gate にしない旨を明文化（log 相関などの evidence 用）

関連: `docs/architecture/worker-diagnostics.md` の evidence bundle 記載とも整合します。