### PR TITLE
docs(user): add planned status notes

### DIFF
--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -1,5 +1,7 @@
 # User Documentation
 
+Status note: These pages may include planned (not-yet-released) steps. Please confirm availability in the [Roadmap](../roadmap.md).
+
 Select language / 言語を選択してください。
 
 - 日本語: [`docs/user/ja/index.md`](ja/index.md)

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -1,5 +1,7 @@
 # Installation
 
+Status note: This page may include planned (not-yet-released) steps. Please confirm availability in the [Roadmap](../roadmap.md).
+
 ## Requirements
 
 - Windows

--- a/docs/user/setup.md
+++ b/docs/user/setup.md
@@ -1,5 +1,7 @@
 # First Setup
 
+Status note: This page may include planned (not-yet-released) steps. Please confirm availability in the [Roadmap](../roadmap.md).
+
 ## Initial Startup
 
 If SQLite does not exist:

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -1,5 +1,7 @@
 # Usage
 
+Status note: This page may include planned (not-yet-released) steps. Please confirm availability in the [Roadmap](../roadmap.md).
+
 ## Automatic Recording
 
 The system automatically:


### PR DESCRIPTION
## What
Add short status notes to the English-base user docs so readers know the pages may include planned, not-yet-released steps and should confirm availability in the Roadmap.

Updated:
- `docs/user/index.md`
- `docs/user/install.md`
- `docs/user/setup.md`
- `docs/user/usage.md`

## Why
Closes the immediate misread risk from #159 without deciding the broader current/planned documentation contract.

Refs: #159

## Verification
- Link target checked: `docs/roadmap.md` exists on `main`.
- Full local docs validation was not rerun against this remote branch because the current workspace is not a git checkout for the repository branch.