### PR TITLE
docs(v0.4): record runtime-root continuity policy

### DIFF
--- a/docs/architecture/runtime-dirs.md
+++ b/docs/architecture/runtime-dirs.md
@@ -47,3 +47,26 @@ If needed, the runtime root can be overridden using the environment variable:
 - `ODR_USER_DATA_DIR` (absolute path recommended)
 
 See `odr_worker.config.get_user_data_dir` for the current v0.2 scaffold behavior.
+
+---
+
+## Runtime-root Continuity (v0.4)
+
+The v0.4 OBS Plugin launch path keeps the existing `<repo>/user_data/` runtime root as the continuity default. Existing config, DB, queue state, logs, videos, screenshots, exports, and local secrets remain under that root unless the user intentionally configures another root.
+
+If the Plugin is configured with a different runtime root, the Worker and Plugin MUST NOT automatically migrate data from the existing `<repo>/user_data/` root. The safe default is to fail closed or continue with an explicit **manual action required** diagnostic, depending on the detected condition. Automatic migration belongs to a later, separately scoped design.
+
+Minimum evidence for any Plugin-launched Worker session:
+
+- resolved `ODR_USER_DATA_DIR`
+- whether the root is the default `<repo>/user_data/` or an override
+- log directory derived from the resolved root
+- enough diagnostics to distinguish wrong runtime root from wrong process / wrong port
+
+The resolved runtime root MUST be visible in:
+
+- startup logs
+- diagnostics surfaced to the Plugin / Dock UI
+- v0.4 smoke notes
+
+This policy records the administrator decision from #141 and supports #120, #123, #126, #144, #145, and #149.

--- a/docs/architecture/worker-logging.md
+++ b/docs/architecture/worker-logging.md
@@ -39,6 +39,21 @@ On startup, the Worker SHOULD:
 
 ---
 
+## Runtime-root Evidence (v0.4)
+
+When launched by the OBS Plugin, the Worker MUST log the resolved `ODR_USER_DATA_DIR` during startup.
+
+Minimum startup log evidence:
+
+- resolved `ODR_USER_DATA_DIR`
+- resolved log directory
+- whether the runtime root is the default `<repo>/user_data/` or an override
+- any manual-action diagnostic caused by a runtime-root continuity mismatch
+
+This evidence allows support and smoke verification to distinguish wrong runtime root, wrong persisted state, and wrong process / wrong port cases.
+
+---
+
 ## Scope Guardrails (v0.2)
 
 This document covers only minimal startup logging.

--- a/docs/release/v0.4-release-readiness.md
+++ b/docs/release/v0.4-release-readiness.md
@@ -25,6 +25,8 @@ Non-goals:
   - [ ] `docs/requirements/requirements.md`
   - [ ] `docs/traceability.md`
   - [ ] `docs/architecture/plugin-worker.md`
+  - [ ] `docs/architecture/runtime-dirs.md`
+  - [ ] `docs/architecture/worker-logging.md`
   - [ ] `docs/architecture/compatibility.md`
   - [ ] `docs/architecture/worker-diagnostics.md`
 - [ ] v0.4 acceptance checklist reflects the intended behavior and has been reviewed:
@@ -40,6 +42,11 @@ Perform these checks on Windows with OBS installed:
 - [ ] Plugin can start the Worker process using the documented contract.
 - [ ] Plugin can stop the Worker process (or clearly reports why it cannot).
 - [ ] Plugin can detect Worker health via `GET /health` and surfaces status in the Dock UI.
+- [ ] Runtime-root continuity is observable:
+  - [ ] existing `<repo>/user_data/` remains the default continuity root
+  - [ ] a different configured runtime root does not trigger automatic migration
+  - [ ] manual-action diagnostics are surfaced for ambiguous continuity cases
+  - [ ] resolved `ODR_USER_DATA_DIR` appears in logs / diagnostics / smoke notes
 - [ ] Heartbeat timeout behavior is documented and observable in logs / diagnostics (see `docs/architecture/worker-diagnostics.md` - Failure Evidence (minimum)).
 - [ ] Heartbeat monitoring documents rebind/baseline-reset semantics when the Worker process is replaced mid-session (planning input: #154).
 - [ ] Smoke notes record the concrete environment and evidence (see `docs/architecture/v0.4-smoke.md`).

--- a/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
+++ b/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
@@ -55,25 +55,33 @@ v0.4 focuses on:
 - [ ] Plugin reuses an existing healthy singleton Worker for the same runtime root instead of spawning a second Worker.
 - [ ] Plugin reports launch failures with actionable diagnostics (log + UI surface).
 
-### D. Worker Health / Heartbeat
+### D. Runtime-root Continuity
+
+- [ ] Existing `<repo>/user_data/` remains the default continuity root for v0.4.
+- [ ] If a different runtime root is configured, the Plugin/Worker does not automatically migrate existing data.
+- [ ] Different runtime-root cases surface a manual-action diagnostic instead of silently continuing with ambiguous persisted state.
+- [ ] Startup logs include the resolved `ODR_USER_DATA_DIR` and derived log directory.
+- [ ] Diagnostics and smoke notes record the resolved `ODR_USER_DATA_DIR` so wrong-root cases can be separated from wrong-port / wrong-process cases.
+
+### E. Worker Health / Heartbeat
 
 - [ ] Plugin monitors Worker health via `GET /health`.
 - [ ] A heartbeat timeout and failure mode vocabulary is defined and used consistently.
 - [ ] Plugin surfaces Worker state in a Dock UI (minimum: `starting` / `running` / `unhealthy` / `crashed` / `api_incompatible`).
 
-### E. Plugin Settings + Dock UI
+### F. Plugin Settings + Dock UI
 
 - [ ] A Plugin settings page exists for minimal configuration (host/port, user_data_dir, etc).
 - [ ] A Browser Dock UI exists and can display Worker status and key diagnostics.
 
-### F. Localhost API Wrapper
+### G. Localhost API Wrapper
 
 - [ ] Plugin uses a minimal API wrapper layer rather than ad-hoc HTTP calls throughout the codebase.
 - [ ] Wrapper behavior for failure cases is defined (timeouts, refused connection, incompatible API).
 - [ ] Wrapper behavior for stale-process / wrong-port / singleton invariant violations is defined.
 - [ ] `instance_id` (and other identity fields such as `pid` / `started_at`, when available) are used as diagnostic evidence rather than the primary ownership gate (primary: singleton per resolved `ODR_USER_DATA_DIR`).
 
-### G. Developer Verification
+### H. Developer Verification
 
 - [ ] A smoke procedure exists describing how to verify:
   - [ ] plugin loads
@@ -81,6 +89,7 @@ v0.4 focuses on:
   - [ ] dock shows health
   - [ ] logs are produced under `user_data/logs/`
   - [ ] a second launch path reuses or rejects an existing singleton Worker instead of spawning another Worker for the same runtime root
+  - [ ] resolved `ODR_USER_DATA_DIR` is recorded in logs, diagnostics, and smoke notes
 
 Reference procedure:
 - `docs/architecture/v0.4-smoke.md`


### PR DESCRIPTION
## Summary
Record the administrator decision from #141 as v0.4 docs-first runtime-root continuity policy.

## Changes
- Define `<repo>/user_data/` as the default continuity root in `runtime-dirs.md`.
- State that alternate runtime roots do not trigger automatic migration and should surface manual-action diagnostics for ambiguous continuity cases.
- Require resolved `ODR_USER_DATA_DIR` evidence in startup logs, diagnostics, and smoke notes.
- Add v0.4 acceptance and release-readiness checks for runtime-root continuity.

## Related
- Fixes / records decision for #141
- Supports #120, #123, #126, #144, #145, and #149

## Verification
- Docs-only change prepared via GitHub contents API.
- Diff reviewed with compare_commits: 4 files changed.