### PR TITLE
docs: clarify current and planned user-facing status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 OBS Duel Recorder is an OBS Studio based duel recording assistant for Yu-Gi-Oh! Master Duel.
 
-This project automatically records duel segments, manages match history, and uploads archived videos to YouTube.
+This project is being built to record duel segments, manage match history, and upload archived videos to YouTube.
 
 The project is designed around an OBS Plugin + Python Worker architecture.
 
@@ -44,16 +44,22 @@ Yu-Gi-Oh! Master Duel assets are not distributed with this software.
 
 ---
 
-## Features
+## Features (Roadmap Overview)
 
-- Automatic duel recording
-- Match queue management
-- YouTube archive upload
-- OBS overlay integration
-- Match memo support
-- SQLite based history management
-- Upload retry / recovery support
-- GitHub Actions based packaging
+Status note: This list includes current foundations and planned roadmap capabilities. For release availability, use [Current Development](#current-development), [Current Status](#current-status), and the [Roadmap](docs/roadmap.md) as the source of truth.
+
+Current released foundation:
+- SQLite runtime storage foundation
+- Worker runtime, health, logging, and migration foundations
+
+Planned roadmap capabilities:
+- Automatic duel recording (`v0.8`)
+- Match queue management (`v0.7`)
+- YouTube archive upload (`v1.0`)
+- OBS overlay integration (`v0.5`)
+- Match memo support (`v1.1`)
+- Upload retry / recovery support (`v0.7`)
+- GitHub Actions based packaging (`v1.4+`)
 
 ---
 

--- a/docs/tools/validate_markdown_links.ps1
+++ b/docs/tools/validate_markdown_links.ps1
@@ -31,7 +31,7 @@ function Get-HeadingAnchors([string]$markdown) {
       # Strip trailing hashes: "## Title ##"
       $heading = [regex]::Replace($heading, "\s#+\s*$", "")
       # Remove Markdown inline code/backticks.
-      $heading = [regex]::Replace($heading, "`{1,3}([^`]+)`{1,3}", '$1')
+      $heading = [regex]::Replace($heading, '`{1,3}([^`]+)`{1,3}', '$1')
       # Remove emphasis markers.
       $heading = $heading -replace "\*", ""
       $heading = $heading -replace "_", ""

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -1,6 +1,6 @@
 # User Documentation
 
-Status note: These pages may include planned (not-yet-released) steps. Please confirm availability in the [Roadmap](../roadmap.md).
+Status contract: These pages are roadmap-facing user docs and may include planned (not-yet-released) steps. Treat a step as currently available only when the latest release notes or [Roadmap](../roadmap.md) mark its version as released.
 
 Select language / 言語を選択してください。
 

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -1,6 +1,6 @@
 # Installation
 
-Status note: This page may include planned (not-yet-released) steps. Please confirm availability in the [Roadmap](../roadmap.md).
+Status note: This page may include planned (not-yet-released) installation steps. Confirm release availability in the [Roadmap](../roadmap.md) before treating a step as current.
 
 ## Requirements
 

--- a/docs/user/setup.md
+++ b/docs/user/setup.md
@@ -1,6 +1,6 @@
 # First Setup
 
-Status note: This page may include planned (not-yet-released) steps. Please confirm availability in the [Roadmap](../roadmap.md).
+Status note: This page may include planned (not-yet-released) setup flows, including OAuth and overlay setup. Confirm release availability in the [Roadmap](../roadmap.md) before treating a step as current.
 
 ## Initial Startup
 

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -1,6 +1,6 @@
 # Usage
 
-Status note: This page may include planned (not-yet-released) steps. Please confirm availability in the [Roadmap](../roadmap.md).
+Status note: This page may include planned (not-yet-released) usage flows, including automatic recording, manual controls, retry, and queue recovery. Confirm release availability in the [Roadmap](../roadmap.md) before treating a flow as current.
 
 ## Automatic Recording
 


### PR DESCRIPTION
## Summary
- clarify that README feature list is a roadmap overview, not all current capability
- add released-foundation vs planned-capability cues in README
- tighten user-doc status notes for installation, setup, and usage flows
- make Markdown link validation compatible with Windows PowerShell 5 inline-code heading parsing

## Verification
- `powershell -ExecutionPolicy Bypass -File docs/tools/validate_markdown_links.ps1`
- `python scripts/validate_jp_user_docs_coverage.py`

Refs #81
Refs #129