### PR TITLE
docs: define canonical validator target set (#235)

### DIFF
--- a/docs/doc-inventory.md
+++ b/docs/doc-inventory.md
@@ -1,0 +1,20 @@
+# Canonical doc inventory
+
+This page defines the **canonical documentation inventory** used by repository validators.
+
+## Inventory rule
+
+Validators should treat these paths as the canonical doc scope:
+
+- repo root `README*.md`
+- `docs/**/*.md` (includes `docs/user/**`)
+
+Validators should treat these files as canonical sources for user-doc scope:
+
+- English topic list: `docs/user/index.md`
+- Japanese index: `docs/user/ja/index.md`
+
+## Notes
+
+- English documents are the canonical source of truth for both design docs and user docs.
+- Japanese user docs under `docs/user/ja/` are translated/expanded from the English source and must not contradict it.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -9,10 +9,19 @@ This page defines what "documentation validation" means for this repository.
 
 ## Validation scope
 
-Validate these paths:
+Canonical doc inventory:
 
-- `README.md`, `README*`
-- `docs/**` (including `docs/user/**`)
+- `docs/doc-inventory.md`
+
+Canonical validator target set:
+
+- repo root `README*.md`
+- `docs/**/*.md` (includes `docs/user/**`)
+
+Canonical user-doc sources:
+
+- English topic list: `docs/user/index.md`
+- Japanese index: `docs/user/ja/index.md`
 
 ## Markdown link checks
 
@@ -61,7 +70,7 @@ $fail | Format-Table -AutoSize
 if ($fail.Count -gt 0) { exit 1 }
 ```
 
-## Localization coverage (English -> Japanese)
+## Localization coverage (English / Japanese)
 
 Validate, at a minimum:
 
@@ -79,7 +88,7 @@ python scripts/validate_jp_user_docs_coverage.py
 
 This check:
 
-- Treats the list under `docs/user/index.md` -> "Current user docs (English-base, pre-multilingual)" as canonical user topics.
+- Treats the list under `docs/user/index.md` ("Current user docs (English-base, pre-multilingual)") as canonical user topics.
 - Requires minimum v0.2 Japanese entrypoints for those topics:
   - `docs/user/ja/install.md`
   - `docs/user/ja/first-setup.md`


### PR DESCRIPTION
#235 の対応です。

- docs/validation.md に validator 共通入力（対象Markdown集合 + user-doc正本）を明示
- docs/doc-inventory.md を追加（validator共通のdoc scope契約）

ローカル検証（手元環境）:
- docs/tools/validate_markdown_links.ps1: PASS
- scripts/validate_jp_user_docs_coverage.py: PASS
- scripts/validate_automation_signatures.ps1: PASS