### PR TITLE
docs: need_manual_review contract + roadmap traceability

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [v0.3 release readiness checklist](release/v0.3-release-readiness.md)
 - [v0.4 release readiness checklist](release/v0.4-release-readiness.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
+- [v0.2 Worker Core API acceptance checklist](requirements/v0.2-worker-core-api-acceptance.md)
 - [v0.3 SQLite Foundation acceptance checklist](requirements/v0.3-sqlite-foundation-acceptance.md)
 - [v0.4 OBS Plugin Skeleton acceptance checklist](requirements/v0.4-obs-plugin-skeleton-acceptance.md)
 
@@ -34,6 +35,7 @@ Architecture documents describe technical behavior and responsibility boundaries
 
 User-facing setup and usage documents live under `docs/user/`.
 
+- [User docs index (language selector / 言語選択)](user/index.md)
 - [Installation](user/install.md)
 - [First setup](user/setup.md)
 - [Usage](user/usage.md)
@@ -51,15 +53,3 @@ Documentation validation policy lives at:
 - Treat English documents as canonical; translations should not contradict the English source.
 - Keep completed release point information in `docs/release-history.md` or a version-specific release summary.
 - Do not use documentation pages to store runtime data, credentials, screenshots, or game assets.
-
-## Validation
-
-Validate internal Markdown links (files within the repository):
-
-```powershell
-python scripts/validate_markdown_links.py
-```
-
-Notes:
-- Checks `README*.md` and `docs/**/*.md`.
-- Ignores `http(s)` and `mailto:` targets.

--- a/docs/architecture/queue.md
+++ b/docs/architecture/queue.md
@@ -106,7 +106,7 @@ On startup, reconcile `uploading` items in this order:
 
 - Retry: `need_manual_review` -> `ready_upload`
 - Discard: `need_manual_review` -> dropped (terminal; no retry)
-- (Future) Mark as uploaded by attaching `youtube_video_id` after a manual channel check
+- Mark uploaded: attach `youtube_video_id` after a manual channel check
 
 Manual adjudication evidence and allowed operator actions are defined above in `need_manual_review` Contract (v0.7+).
 

--- a/docs/architecture/queue.md
+++ b/docs/architecture/queue.md
@@ -33,6 +33,54 @@ stateDiagram-v2
 
 ---
 
+## `need_manual_review` Contract (v0.7+)
+
+This section defines the docs-first contract for manual adjudication of queue items
+in the `need_manual_review` state.
+
+### Goals
+
+- Avoid duplicate uploads.
+- Preserve enough evidence for an operator to decide without re-running blindly.
+- Keep the adjudication actions small, explicit, and auditable.
+
+### Minimum persisted evidence
+
+Persist (or be able to reconstruct) at least:
+
+- queue item id (stable)
+- local file identity (absolute path + size + mtime; optionally a hash)
+- local file existence (whether it still exists)
+- last known state + last transition time
+- last transition reason (short summary)
+- last attempt timestamp
+- last attempt summary (error class, short message, and when it occurred)
+- retry count
+- last error category (coarse; e.g. network/auth/quota/unknown)
+- if known/confirmed: remote evidence (video id / URL / uploaded_at)
+- operator note (optional; empty by default)
+
+If available, also persist a redacted, short excerpt of the remote API response that led to `need_manual_review`.
+
+### Allowed operator actions
+
+1. Retry
+   - Allowed when the local file still exists and the item is not known to be already uploaded.
+   - Must reset the item back to `ready_upload` and clear transient error state.
+2. Discard
+   - Allowed when the operator confirms the local file should not be uploaded.
+   - Must record the discard reason (free text) and permanently terminate the item.
+3. Mark uploaded
+   - Allowed when the operator can confirm the item was already uploaded.
+   - Must record the remote identifier (e.g. URL or video id) and permanently terminate the item.
+
+### Core principle
+
+Avoid duplicate uploads: when remote existence is unknown, prefer keeping the item in
+`need_manual_review` until the operator can confirm (or safely discard) it.
+
+---
+
 ## Recovery Rules
 
 Interrupted recordings are discarded.
@@ -56,9 +104,11 @@ On startup, reconcile `uploading` items in this order:
 
 `need_manual_review` should offer the user a safe choice:
 
-- Retry: `need_manual_review` → `ready_upload`
-- Discard: `need_manual_review` → discard
+- Retry: `need_manual_review` -> `ready_upload`
+- Discard: `need_manual_review` -> dropped (terminal; no retry)
 - (Future) Mark as uploaded by attaching `youtube_video_id` after a manual channel check
+
+Manual adjudication evidence and allowed operator actions are defined above in `need_manual_review` Contract (v0.7+).
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -184,6 +184,7 @@ Create recovery-safe queue processing.
 - network retry handling
 - quota_waiting state
 - need_manual_review state
+- manual adjudication contract for `need_manual_review` (docs/architecture/queue.md; tracked in #237)
 - startup recovery processing
 
 ### Deliverables


### PR DESCRIPTION
## Summary
Align docs with #237 by adding a docs-first `need_manual_review` adjudication contract and tracing it from the v0.7 roadmap notes.

## Changes
- Add `need_manual_review` contract section to `docs/architecture/queue.md`.
- Add a traceability bullet under v0.7 in `docs/roadmap.md`.
- Fix `docs/README.md` to avoid outdated validation command + add missing index/checklist links.

## Related Issues
- Refs #237

## Scope Guardrails
- Docs-only changes (`docs/**`) only.
- No implementation changes.

## Verification
- OK: `powershell -ExecutionPolicy Bypass -File docs/tools/validate_markdown_links.ps1`
- OK: `python scripts/validate_jp_user_docs_coverage.py`
- OK: `powershell -ExecutionPolicy Bypass -File scripts/validate_automation_signatures.ps1`