### PR TITLE
feat(plugin): add v0.4 OBS plugin scaffold

### DIFF
--- a/app/plugin/CMakeLists.txt
+++ b/app/plugin/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.24)
+
+project(obs-duel-recorder-plugin VERSION 0.4.0 LANGUAGES CXX)
+
+find_package(libobs REQUIRED)
+find_package(obs-frontend-api REQUIRED)
+
+add_library(obs-duel-recorder MODULE
+  src/plugin-main.cpp
+)
+
+target_compile_features(obs-duel-recorder PRIVATE cxx_std_17)
+
+target_link_libraries(obs-duel-recorder
+  PRIVATE
+    OBS::libobs
+    OBS::obs-frontend-api
+)
+
+set_target_properties(obs-duel-recorder PROPERTIES
+  PREFIX ""
+  OUTPUT_NAME "obs-duel-recorder"
+)

--- a/app/plugin/README.md
+++ b/app/plugin/README.md
@@ -1,6 +1,6 @@
 # OBS Plugin
 
-This directory is reserved for OBS Plugin code.
+This directory contains the OBS Plugin code.
 
 The Plugin is responsible for:
 - OBS Frontend API integration
@@ -18,4 +18,64 @@ The Plugin must not:
 - directly manipulate SQLite
 - directly upload to YouTube
 
-Implementation code is intentionally not added in v0.1 Repository Foundation.
+## Current v0.4 Scaffold
+
+The current scaffold is intentionally minimal for #119:
+
+- Build a loadable OBS module.
+- Register minimal OBS Frontend API lifecycle hooks.
+- Log plugin startup and shutdown messages.
+
+Current non-goals:
+- Worker process launch.
+- Worker heartbeat monitoring.
+- Settings UI.
+- Browser Dock UI.
+
+Those items are tracked by separate v0.4 child issues.
+
+## Prerequisites
+
+- Windows x64
+- OBS Studio latest stable x64
+- Visual Studio 2022 with C++ desktop workload
+- CMake 3.24+
+- OBS CMake package files and development headers/libraries available through `CMAKE_PREFIX_PATH`
+
+The exact OBS SDK or source/build location depends on the contributor environment. Point `CMAKE_PREFIX_PATH` at the directory that exposes `libobs` and `obs-frontend-api` CMake packages.
+
+## Build
+
+Run from the repository root:
+
+```powershell
+cmake -S app/plugin -B build/plugin -G "Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH="C:\Path\To\obs-studio-or-sdk"
+cmake --build build/plugin --config Release
+```
+
+Expected artifact:
+
+```text
+build/plugin/Release/obs-duel-recorder.dll
+```
+
+## Manual Smoke
+
+Use the canonical v0.4 smoke procedure:
+
+- `docs/architecture/v0.4-smoke.md`
+
+For #119, the minimum passing evidence is:
+
+- The CMake configure and build commands used.
+- The produced plugin DLL path.
+- OBS loads the plugin without crashing.
+- OBS or ODR logs include:
+  - `OBS Duel Recorder plugin startup`
+  - `OBS Duel Recorder plugin shutdown`
+
+## Current Lifecycle Surface
+
+The scaffold registers an OBS Frontend API callback and logs only lightweight lifecycle events.
+
+Heavy work must remain outside the plugin process. Worker launch, heartbeat, settings, and Dock behavior must be added through their own v0.4 issues.

--- a/app/plugin/data/locale/en-US.ini
+++ b/app/plugin/data/locale/en-US.ini
@@ -1,0 +1,1 @@
+Plugin.Name="OBS Duel Recorder"

--- a/app/plugin/src/plugin-main.cpp
+++ b/app/plugin/src/plugin-main.cpp
@@ -1,0 +1,43 @@
+#include <obs-frontend-api.h>
+#include <obs-module.h>
+
+OBS_DECLARE_MODULE()
+OBS_MODULE_USE_DEFAULT_LOCALE("obs-duel-recorder", "en-US")
+
+namespace {
+
+constexpr const char *kLogPrefix = "OBS Duel Recorder";
+
+void frontend_event(enum obs_frontend_event event, void *)
+{
+	switch (event) {
+	case OBS_FRONTEND_EVENT_FINISHED_LOADING:
+		blog(LOG_INFO, "%s frontend ready", kLogPrefix);
+		break;
+	case OBS_FRONTEND_EVENT_EXIT:
+		blog(LOG_INFO, "%s frontend exit", kLogPrefix);
+		break;
+	default:
+		break;
+	}
+}
+
+} // namespace
+
+bool obs_module_load(void)
+{
+	obs_frontend_add_event_callback(frontend_event, nullptr);
+	blog(LOG_INFO, "%s plugin startup", kLogPrefix);
+	return true;
+}
+
+void obs_module_unload(void)
+{
+	obs_frontend_remove_event_callback(frontend_event, nullptr);
+	blog(LOG_INFO, "%s plugin shutdown", kLogPrefix);
+}
+
+const char *obs_module_description(void)
+{
+	return "OBS Duel Recorder plugin skeleton";
+}

--- a/docs/architecture/v0.4-smoke.md
+++ b/docs/architecture/v0.4-smoke.md
@@ -34,6 +34,9 @@ This smoke is considered **passed** if all of the following are true:
 
 If (2) fails (OBS crash / immediate unload), treat as a hard fail and stop.
 
+Reference:
+- Canonical runtime directory rules: `docs/architecture/runtime-dirs.md`
+
 ---
 
 ## Procedure (suggested minimal steps)
@@ -43,6 +46,9 @@ If (2) fails (OBS crash / immediate unload), treat as a hard fail and stop.
 - Confirm prerequisites are installed (documented in the plugin build instructions).
 - Build the plugin in a configuration intended for load testing (recommendation: Release).
 - Confirm the output artifact path to be used for loading in OBS.
+
+Build instructions:
+- `app/plugin/README.md`
 
 ### B. Load in OBS
 
@@ -56,6 +62,7 @@ Capture the minimal evidence:
 
 - OBS version and architecture (x64)
 - Plugin build command used
+- Plugin artifact path used for OBS loading
 - The log lines showing:
   - plugin startup
   - plugin shutdown

--- a/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
+++ b/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
@@ -41,6 +41,9 @@ v0.4 focuses on:
 - [ ] Plugin build instructions are documented (toolchain versions, prerequisites).
 - [ ] Plugin can be built on Windows with a documented command.
 
+Current scaffold/build reference:
+- `app/plugin/README.md`
+
 ### B. OBS Integration (Frontend API)
 
 - [ ] Plugin can load in OBS without crashing.

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -49,6 +49,7 @@ Goals:
 - Version tracking issue: `#110` - `[v0.4] OBS Plugin Skeleton release tracking`
 - Acceptance checklist: `docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md`
 - Release readiness checklist: `docs/release/v0.4-release-readiness.md`
+- Plugin scaffold/build notes: `app/plugin/README.md`
 - Requirements (relevant sections):
   - `docs/requirements/requirements.md` -> Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation


### PR DESCRIPTION
## Summary
- Adds the minimal `app/plugin/` OBS plugin scaffold for #119.
- Registers lightweight OBS Frontend API lifecycle hooks and startup/shutdown logging.
- Documents CMake build prerequisites, manual smoke evidence, and links the scaffold from v0.4 acceptance/traceability docs.

## Scope
- No Worker launch implementation.
- No heartbeat monitoring.
- No settings page or Browser Dock UI.

These remain in the separate v0.4 child issues tracked from #110.

## Validation
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`

## Notes
- The local workspace is not a Git checkout, so changes were applied through the GitHub connector on branch `codex/issue-110-plugin-scaffold`.
- OBS/CMake build smoke was not run here because this environment does not have the OBS development package/toolchain configured.

Refs #110
Refs #119