### PR TITLE
feat(plugin): add worker launch preflight and localhost wrapper

### DIFF
--- a/app/plugin/CMakeLists.txt
+++ b/app/plugin/CMakeLists.txt
@@ -7,6 +7,8 @@ find_package(obs-frontend-api REQUIRED)
 
 add_library(obs-duel-recorder MODULE
   src/plugin-main.cpp
+  src/worker-api.cpp
+  src/worker-launcher.cpp
 )
 
 target_compile_features(obs-duel-recorder PRIVATE cxx_std_17)
@@ -16,6 +18,10 @@ target_link_libraries(obs-duel-recorder
     OBS::libobs
     OBS::obs-frontend-api
 )
+
+if(WIN32)
+  target_link_libraries(obs-duel-recorder PRIVATE winhttp)
+endif()
 
 set_target_properties(obs-duel-recorder PROPERTIES
   PREFIX ""

--- a/app/plugin/README.md
+++ b/app/plugin/README.md
@@ -20,14 +20,15 @@ The Plugin must not:
 
 ## Current v0.4 Scaffold
 
-The current scaffold is intentionally minimal for #119:
+The current scaffold is intentionally minimal for #119/#120/#123/#144:
 
 - Build a loadable OBS module.
 - Register minimal OBS Frontend API lifecycle hooks.
 - Log plugin startup and shutdown messages.
+- Probe and launch the Worker when `ODR_USER_DATA_DIR` is explicitly configured.
+- Reuse a healthy singleton Worker for the same `ODR_USER_DATA_DIR`.
 
 Current non-goals:
-- Worker process launch.
 - Worker heartbeat monitoring.
 - Settings UI.
 - Browser Dock UI.
@@ -59,13 +60,37 @@ Expected artifact:
 build/plugin/Release/obs-duel-recorder.dll
 ```
 
+## Worker Launch Inputs
+
+The v0.4 launch path is intentionally conservative until the settings page exists.
+
+Required environment:
+- `ODR_USER_DATA_DIR`: absolute runtime root to pass to the Worker.
+
+Defaults:
+- Worker command: `odr-worker`
+- Host: `127.0.0.1`
+- Port: `8787`
+- Expected Worker API version: `0.3`
+- Expected Worker version: `0.3.0`
+
+Startup behavior:
+- On OBS frontend ready, the Plugin probes `GET /health` on the configured host/port.
+- If a compatible Worker is already running for the same `ODR_USER_DATA_DIR`, the Plugin reuses it.
+- If a reachable Worker reports a different runtime root, incompatible API version, or unexpected Worker version, startup is blocked and the Plugin logs diagnostics.
+- If no Worker is reachable, the Plugin starts `odr-worker --host 127.0.0.1 --port 8787` with `ODR_USER_DATA_DIR` in the child process environment.
+
+Shutdown behavior:
+- Plugin-spawned Workers are stopped on OBS shutdown/plugin unload.
+- Reused existing Workers are not stopped by the Plugin.
+
 ## Manual Smoke
 
 Use the canonical v0.4 smoke procedure:
 
 - `docs/architecture/v0.4-smoke.md`
 
-For #119, the minimum passing evidence is:
+For #119/#120/#123/#144, the minimum passing evidence is:
 
 - The CMake configure and build commands used.
 - The produced plugin DLL path.
@@ -73,9 +98,12 @@ For #119, the minimum passing evidence is:
 - OBS or ODR logs include:
   - `OBS Duel Recorder plugin startup`
   - `OBS Duel Recorder plugin shutdown`
+  - worker preflight or launch result
+  - `ODR_USER_DATA_DIR`
+  - Worker ownership (`plugin-spawned` or `reused-existing`)
 
 ## Current Lifecycle Surface
 
-The scaffold registers an OBS Frontend API callback and logs only lightweight lifecycle events.
+The scaffold registers an OBS Frontend API callback, logs lightweight lifecycle events, and runs the initial Worker preflight/launch flow.
 
-Heavy work must remain outside the plugin process. Worker launch, heartbeat, settings, and Dock behavior must be added through their own v0.4 issues.
+Heavy work must remain outside the plugin process. Heartbeat, settings, and Dock behavior must be added through their own v0.4 issues.

--- a/app/plugin/src/plugin-main.cpp
+++ b/app/plugin/src/plugin-main.cpp
@@ -1,21 +1,35 @@
 #include <obs-frontend-api.h>
 #include <obs-module.h>
 
+#include "worker-launcher.hpp"
+
+#include <utility>
+
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-duel-recorder", "en-US")
 
 namespace {
 
 constexpr const char *kLogPrefix = "OBS Duel Recorder";
+odr::plugin::WorkerProcessManager worker_manager;
+
+void launch_worker()
+{
+	odr::plugin::WorkerLaunchConfig config;
+	config.user_data_dir = odr::plugin::read_env_wstring(L"ODR_USER_DATA_DIR");
+	worker_manager.start_async(std::move(config));
+}
 
 void frontend_event(enum obs_frontend_event event, void *)
 {
 	switch (event) {
 	case OBS_FRONTEND_EVENT_FINISHED_LOADING:
 		blog(LOG_INFO, "%s frontend ready", kLogPrefix);
+		launch_worker();
 		break;
 	case OBS_FRONTEND_EVENT_EXIT:
 		blog(LOG_INFO, "%s frontend exit", kLogPrefix);
+		worker_manager.stop();
 		break;
 	default:
 		break;
@@ -33,6 +47,7 @@ bool obs_module_load(void)
 
 void obs_module_unload(void)
 {
+	worker_manager.stop();
 	obs_frontend_remove_event_callback(frontend_event, nullptr);
 	blog(LOG_INFO, "%s plugin shutdown", kLogPrefix);
 }

--- a/app/plugin/src/worker-api.cpp
+++ b/app/plugin/src/worker-api.cpp
@@ -1,0 +1,229 @@
+#include "worker-api.hpp"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <winhttp.h>
+#endif
+
+#include <algorithm>
+#include <cctype>
+#include <regex>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+namespace odr::plugin {
+namespace {
+
+std::string extract_json_string(const std::string &body, const char *key)
+{
+	const std::regex pattern(std::string("\"") + key + R"("\s*:\s*"([^"]*)")");
+	std::smatch match;
+	if (!std::regex_search(body, match, pattern) || match.size() < 2) {
+		return {};
+	}
+	return match[1].str();
+}
+
+std::string extract_json_number(const std::string &body, const char *key)
+{
+	const std::regex pattern(std::string("\"") + key + R"("\s*:\s*([0-9]+))");
+	std::smatch match;
+	if (!std::regex_search(body, match, pattern) || match.size() < 2) {
+		return {};
+	}
+	return match[1].str();
+}
+
+std::string normalize_path(std::string value)
+{
+	std::replace(value.begin(), value.end(), '\\', '/');
+	while (value.size() > 1 && value.back() == '/') {
+		value.pop_back();
+	}
+	std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+		return static_cast<char>(std::tolower(ch));
+	});
+	return value;
+}
+
+#ifdef _WIN32
+
+struct HttpResponse {
+	bool ok = false;
+	unsigned long status = 0;
+	std::string body;
+	std::string error;
+};
+
+HttpResponse http_get(const WorkerEndpoint &endpoint, const wchar_t *path)
+{
+	HttpResponse response;
+	HINTERNET session = WinHttpOpen(L"OBS Duel Recorder Plugin/0.4",
+				       WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+				       WINHTTP_NO_PROXY_NAME,
+				       WINHTTP_NO_PROXY_BYPASS, 0);
+	if (!session) {
+		response.error = "WinHttpOpen failed";
+		return response;
+	}
+
+	WinHttpSetTimeouts(session, 1000, 1000, 1000, 1000);
+
+	HINTERNET connection = WinHttpConnect(session, endpoint.host.c_str(), endpoint.port, 0);
+	if (!connection) {
+		response.error = "WinHttpConnect failed";
+		WinHttpCloseHandle(session);
+		return response;
+	}
+
+	HINTERNET request = WinHttpOpenRequest(connection, L"GET", path, nullptr,
+					      WINHTTP_NO_REFERER,
+					      WINHTTP_DEFAULT_ACCEPT_TYPES, 0);
+	if (!request) {
+		response.error = "WinHttpOpenRequest failed";
+		WinHttpCloseHandle(connection);
+		WinHttpCloseHandle(session);
+		return response;
+	}
+
+	if (!WinHttpSendRequest(request, WINHTTP_NO_ADDITIONAL_HEADERS, 0,
+				WINHTTP_NO_REQUEST_DATA, 0, 0, 0) ||
+	    !WinHttpReceiveResponse(request, nullptr)) {
+		response.error = "Worker API did not respond";
+		WinHttpCloseHandle(request);
+		WinHttpCloseHandle(connection);
+		WinHttpCloseHandle(session);
+		return response;
+	}
+
+	DWORD status = 0;
+	DWORD status_size = sizeof(status);
+	if (WinHttpQueryHeaders(request, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+				WINHTTP_HEADER_NAME_BY_INDEX, &status, &status_size,
+				WINHTTP_NO_HEADER_INDEX)) {
+		response.status = status;
+	}
+
+	for (;;) {
+		DWORD available = 0;
+		if (!WinHttpQueryDataAvailable(request, &available) || available == 0) {
+			break;
+		}
+
+		std::vector<char> buffer(static_cast<size_t>(available));
+		DWORD read = 0;
+		if (!WinHttpReadData(request, buffer.data(), available, &read) || read == 0) {
+			break;
+		}
+		response.body.append(buffer.data(), buffer.data() + read);
+	}
+
+	response.ok = true;
+	WinHttpCloseHandle(request);
+	WinHttpCloseHandle(connection);
+	WinHttpCloseHandle(session);
+	return response;
+}
+
+#endif
+
+} // namespace
+
+std::string to_utf8(const std::wstring &value)
+{
+#ifdef _WIN32
+	if (value.empty()) {
+		return {};
+	}
+	const int size = WideCharToMultiByte(CP_UTF8, 0, value.c_str(), -1, nullptr, 0, nullptr, nullptr);
+	if (size <= 0) {
+		return {};
+	}
+	std::string result(static_cast<size_t>(size - 1), '\0');
+	WideCharToMultiByte(CP_UTF8, 0, value.c_str(), -1, result.data(), size, nullptr, nullptr);
+	return result;
+#else
+	return std::string(value.begin(), value.end());
+#endif
+}
+
+std::wstring to_wstring(uint16_t value)
+{
+	std::wstringstream stream;
+	stream << value;
+	return stream.str();
+}
+
+LocalhostApiClient::LocalhostApiClient(std::string expected_api_version, std::string expected_worker_version)
+	: expected_api_version_(std::move(expected_api_version)),
+	  expected_worker_version_(std::move(expected_worker_version))
+{
+}
+
+WorkerProbeResult LocalhostApiClient::probe_health(const WorkerEndpoint &endpoint,
+						   const std::wstring &expected_user_data_dir) const
+{
+	WorkerProbeResult result;
+
+#ifdef _WIN32
+	const HttpResponse response = http_get(endpoint, L"/health");
+	result.http_status = response.status;
+	result.body = response.body;
+
+	if (!response.ok) {
+		result.status = WorkerProbeStatus::unreachable;
+		result.error = response.error;
+		return result;
+	}
+
+	if (response.status != 200) {
+		result.status = WorkerProbeStatus::invalid_response;
+		result.error = "GET /health returned non-200 status";
+		return result;
+	}
+
+	result.version = extract_json_string(response.body, "version");
+	result.api_version = extract_json_string(response.body, "api_version");
+	result.instance_id = extract_json_string(response.body, "instance_id");
+	result.pid = extract_json_number(response.body, "pid");
+	result.started_at = extract_json_string(response.body, "started_at");
+	result.user_data_dir = extract_json_string(response.body, "user_data_dir");
+
+	if (result.api_version.empty()) {
+		result.status = WorkerProbeStatus::invalid_response;
+		result.error = "GET /health response is missing api_version";
+		return result;
+	}
+
+	if (result.api_version != expected_api_version_) {
+		result.status = WorkerProbeStatus::api_incompatible;
+		result.error = "Worker API version is incompatible";
+		return result;
+	}
+
+	const std::string expected_root = normalize_path(to_utf8(expected_user_data_dir));
+	const std::string observed_root = normalize_path(result.user_data_dir);
+	if (observed_root.empty() || observed_root != expected_root) {
+		result.status = WorkerProbeStatus::runtime_root_mismatch;
+		result.error = "Worker runtime root does not match ODR_USER_DATA_DIR";
+		return result;
+	}
+
+	if (!expected_worker_version_.empty() && !result.version.empty() &&
+	    result.version != expected_worker_version_) {
+		result.status = WorkerProbeStatus::api_incompatible;
+		result.error = "Worker version requires restart or manual confirmation";
+		return result;
+	}
+
+	result.status = WorkerProbeStatus::reachable;
+	return result;
+#else
+	result.status = WorkerProbeStatus::unreachable;
+	result.error = "Worker probing is only implemented on Windows";
+	return result;
+#endif
+}
+
+} // namespace odr::plugin

--- a/app/plugin/src/worker-api.cpp
+++ b/app/plugin/src/worker-api.cpp
@@ -17,7 +17,7 @@ namespace {
 
 std::string extract_json_string(const std::string &body, const char *key)
 {
-	const std::regex pattern(std::string("\"") + key + R"("\s*:\s*"([^"]*)")");
+	const std::regex pattern(std::string("\"") + key + "\"\\s*:\\s*\"([^\"]*)\"");
 	std::smatch match;
 	if (!std::regex_search(body, match, pattern) || match.size() < 2) {
 		return {};
@@ -27,7 +27,7 @@ std::string extract_json_string(const std::string &body, const char *key)
 
 std::string extract_json_number(const std::string &body, const char *key)
 {
-	const std::regex pattern(std::string("\"") + key + R"("\s*:\s*([0-9]+))");
+	const std::regex pattern(std::string("\"") + key + "\"\\s*:\\s*([0-9]+)");
 	std::smatch match;
 	if (!std::regex_search(body, match, pattern) || match.size() < 2) {
 		return {};

--- a/app/plugin/src/worker-api.hpp
+++ b/app/plugin/src/worker-api.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace odr::plugin {
+
+struct WorkerEndpoint {
+	std::wstring host = L"127.0.0.1";
+	uint16_t port = 8787;
+};
+
+enum class WorkerProbeStatus {
+	reachable,
+	unreachable,
+	api_incompatible,
+	runtime_root_mismatch,
+	invalid_response,
+};
+
+struct WorkerProbeResult {
+	WorkerProbeStatus status = WorkerProbeStatus::unreachable;
+	unsigned long http_status = 0;
+	std::string version;
+	std::string api_version;
+	std::string instance_id;
+	std::string pid;
+	std::string started_at;
+	std::string user_data_dir;
+	std::string error;
+	std::string body;
+
+	bool reusable() const
+	{
+		return status == WorkerProbeStatus::reachable;
+	}
+};
+
+class LocalhostApiClient {
+public:
+	explicit LocalhostApiClient(std::string expected_api_version, std::string expected_worker_version);
+
+	WorkerProbeResult probe_health(const WorkerEndpoint &endpoint, const std::wstring &expected_user_data_dir) const;
+
+private:
+	std::string expected_api_version_;
+	std::string expected_worker_version_;
+};
+
+std::string to_utf8(const std::wstring &value);
+std::wstring to_wstring(uint16_t value);
+
+} // namespace odr::plugin

--- a/app/plugin/src/worker-launcher.cpp
+++ b/app/plugin/src/worker-launcher.cpp
@@ -1,0 +1,244 @@
+#include "worker-launcher.hpp"
+
+#include <obs-module.h>
+
+#include <chrono>
+#include <cwchar>
+#include <utility>
+#include <vector>
+
+namespace odr::plugin {
+namespace {
+
+constexpr const char *kLogPrefix = "OBS Duel Recorder";
+constexpr const char *kExpectedApiVersion = "0.3";
+constexpr const char *kExpectedWorkerVersion = "0.3.0";
+
+#ifdef _WIN32
+
+std::vector<wchar_t> build_environment_block(const std::wstring &user_data_dir)
+{
+	std::vector<wchar_t> block;
+	LPWCH current_env = GetEnvironmentStringsW();
+	if (!current_env) {
+		return block;
+	}
+
+	for (LPWCH entry = current_env; *entry != L'\0'; entry += wcslen(entry) + 1) {
+		const std::wstring value(entry);
+		if (value.rfind(L"ODR_USER_DATA_DIR=", 0) == 0) {
+			continue;
+		}
+		block.insert(block.end(), value.begin(), value.end());
+		block.push_back(L'\0');
+	}
+
+	const std::wstring override_value = L"ODR_USER_DATA_DIR=" + user_data_dir;
+	block.insert(block.end(), override_value.begin(), override_value.end());
+	block.push_back(L'\0');
+	block.push_back(L'\0');
+
+	FreeEnvironmentStringsW(current_env);
+	return block;
+}
+
+#endif
+
+} // namespace
+
+std::wstring read_env_wstring(const wchar_t *name)
+{
+#ifdef _WIN32
+	const DWORD required = GetEnvironmentVariableW(name, nullptr, 0);
+	if (required == 0) {
+		return {};
+	}
+	std::wstring value(required, L'\0');
+	const DWORD written = GetEnvironmentVariableW(name, value.data(), required);
+	if (written == 0) {
+		return {};
+	}
+	value.resize(written);
+	return value;
+#else
+	(void)name;
+	return {};
+#endif
+}
+
+WorkerProcessManager::WorkerProcessManager()
+	: api_client_(kExpectedApiVersion, kExpectedWorkerVersion)
+{
+}
+
+WorkerProcessManager::~WorkerProcessManager()
+{
+	stop();
+}
+
+void WorkerProcessManager::start_async(WorkerLaunchConfig config)
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+	if (worker_thread_.joinable() || ownership_ != WorkerOwnership::none) {
+		return;
+	}
+
+	stop_requested_ = false;
+	worker_thread_ = std::thread([this, config = std::move(config)]() mutable {
+		start(std::move(config));
+	});
+}
+
+void WorkerProcessManager::start(WorkerLaunchConfig config)
+{
+	if (config.user_data_dir.empty()) {
+		blog(LOG_WARNING, "%s config_error: ODR_USER_DATA_DIR is required before launching Worker", kLogPrefix);
+		return;
+	}
+
+	blog(LOG_INFO, "%s worker preflight host=%s port=%u user_data_dir=%s",
+	     kLogPrefix, to_utf8(config.endpoint.host).c_str(), config.endpoint.port,
+	     to_utf8(config.user_data_dir).c_str());
+
+	WorkerProbeResult preflight = api_client_.probe_health(config.endpoint, config.user_data_dir);
+	if (preflight.reusable()) {
+		std::lock_guard<std::mutex> lock(mutex_);
+		ownership_ = WorkerOwnership::reused_existing;
+		blog(LOG_INFO,
+		     "%s worker reused existing instance api_version=%s version=%s instance_id=%s pid=%s started_at=%s user_data_dir=%s",
+		     kLogPrefix, preflight.api_version.c_str(), preflight.version.c_str(),
+		     preflight.instance_id.c_str(), preflight.pid.c_str(),
+		     preflight.started_at.c_str(), preflight.user_data_dir.c_str());
+		return;
+	}
+
+	if (preflight.status != WorkerProbeStatus::unreachable) {
+		blog(LOG_WARNING,
+		     "%s worker launch blocked status=%d http=%lu error=%s api_version=%s version=%s instance_id=%s user_data_dir=%s",
+		     kLogPrefix, static_cast<int>(preflight.status), preflight.http_status,
+		     preflight.error.c_str(), preflight.api_version.c_str(), preflight.version.c_str(),
+		     preflight.instance_id.c_str(), preflight.user_data_dir.c_str());
+		return;
+	}
+
+	if (!spawn_worker(config)) {
+		return;
+	}
+
+	if (!wait_until_ready(config)) {
+		blog(LOG_WARNING, "%s worker startup timeout; terminating plugin-owned process", kLogPrefix);
+#ifdef _WIN32
+		std::lock_guard<std::mutex> lock(mutex_);
+		if (ownership_ == WorkerOwnership::spawned_by_plugin && process_info_.hProcess) {
+			TerminateProcess(process_info_.hProcess, 0);
+			WaitForSingleObject(process_info_.hProcess, 3000);
+			close_process_handles();
+			ownership_ = WorkerOwnership::none;
+		}
+#endif
+	}
+}
+
+bool WorkerProcessManager::spawn_worker(const WorkerLaunchConfig &config)
+{
+#ifdef _WIN32
+	std::wstring command_line = L"\"" + config.command + L"\" --host " + config.endpoint.host +
+				    L" --port " + to_wstring(config.endpoint.port);
+	std::vector<wchar_t> mutable_command(command_line.begin(), command_line.end());
+	mutable_command.push_back(L'\0');
+
+	std::vector<wchar_t> environment = build_environment_block(config.user_data_dir);
+	STARTUPINFOW startup_info{};
+	startup_info.cb = sizeof(startup_info);
+
+	PROCESS_INFORMATION process_info{};
+	if (!CreateProcessW(nullptr, mutable_command.data(), nullptr, nullptr, FALSE,
+			    CREATE_UNICODE_ENVIRONMENT | CREATE_NO_WINDOW,
+			    environment.empty() ? nullptr : environment.data(), nullptr,
+			    &startup_info, &process_info)) {
+		blog(LOG_WARNING, "%s worker launch failed command=%s user_data_dir=%s error=%lu",
+		     kLogPrefix, to_utf8(config.command).c_str(),
+		     to_utf8(config.user_data_dir).c_str(), GetLastError());
+		return false;
+	}
+
+	std::lock_guard<std::mutex> lock(mutex_);
+	process_info_ = process_info;
+	ownership_ = WorkerOwnership::spawned_by_plugin;
+	blog(LOG_INFO, "%s worker spawned pid=%lu user_data_dir=%s",
+	     kLogPrefix, process_info_.dwProcessId, to_utf8(config.user_data_dir).c_str());
+	return true;
+#else
+	(void)config;
+	blog(LOG_WARNING, "%s worker launch is only implemented on Windows", kLogPrefix);
+	return false;
+#endif
+}
+
+bool WorkerProcessManager::wait_until_ready(const WorkerLaunchConfig &config)
+{
+	const auto deadline = std::chrono::steady_clock::now() +
+			      std::chrono::milliseconds(config.startup_timeout_ms);
+
+	while (!stop_requested_ && std::chrono::steady_clock::now() < deadline) {
+		WorkerProbeResult probe = api_client_.probe_health(config.endpoint, config.user_data_dir);
+		if (probe.reusable()) {
+			blog(LOG_INFO,
+			     "%s worker running api_version=%s version=%s instance_id=%s pid=%s started_at=%s user_data_dir=%s",
+			     kLogPrefix, probe.api_version.c_str(), probe.version.c_str(),
+			     probe.instance_id.c_str(), probe.pid.c_str(),
+			     probe.started_at.c_str(), probe.user_data_dir.c_str());
+			return true;
+		}
+		std::this_thread::sleep_for(std::chrono::milliseconds(250));
+	}
+
+	return false;
+}
+
+void WorkerProcessManager::stop()
+{
+	stop_requested_ = true;
+	if (worker_thread_.joinable()) {
+		worker_thread_.join();
+	}
+
+	std::lock_guard<std::mutex> lock(mutex_);
+	if (ownership_ == WorkerOwnership::reused_existing) {
+		blog(LOG_INFO, "%s worker reused existing instance; not stopping foreign/manual process", kLogPrefix);
+		ownership_ = WorkerOwnership::none;
+		return;
+	}
+
+#ifdef _WIN32
+	if (ownership_ == WorkerOwnership::spawned_by_plugin && process_info_.hProcess) {
+		DWORD exit_code = 0;
+		if (GetExitCodeProcess(process_info_.hProcess, &exit_code) && exit_code == STILL_ACTIVE) {
+			TerminateProcess(process_info_.hProcess, 0);
+			WaitForSingleObject(process_info_.hProcess, 3000);
+		}
+		blog(LOG_INFO, "%s worker plugin-owned process stopped", kLogPrefix);
+		close_process_handles();
+	}
+#endif
+
+	ownership_ = WorkerOwnership::none;
+}
+
+void WorkerProcessManager::close_process_handles()
+{
+#ifdef _WIN32
+	if (process_info_.hThread) {
+		CloseHandle(process_info_.hThread);
+		process_info_.hThread = nullptr;
+	}
+	if (process_info_.hProcess) {
+		CloseHandle(process_info_.hProcess);
+		process_info_.hProcess = nullptr;
+	}
+	process_info_.dwProcessId = 0;
+	process_info_.dwThreadId = 0;
+#endif
+}
+
+} // namespace odr::plugin

--- a/app/plugin/src/worker-launcher.hpp
+++ b/app/plugin/src/worker-launcher.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "worker-api.hpp"
+
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace odr::plugin {
+
+enum class WorkerOwnership {
+	none,
+	spawned_by_plugin,
+	reused_existing,
+};
+
+struct WorkerLaunchConfig {
+	WorkerEndpoint endpoint;
+	std::wstring user_data_dir;
+	std::wstring command = L"odr-worker";
+	unsigned int startup_timeout_ms = 10000;
+};
+
+class WorkerProcessManager {
+public:
+	WorkerProcessManager();
+	~WorkerProcessManager();
+
+	void start_async(WorkerLaunchConfig config);
+	void stop();
+
+private:
+	void start(WorkerLaunchConfig config);
+	bool spawn_worker(const WorkerLaunchConfig &config);
+	bool wait_until_ready(const WorkerLaunchConfig &config);
+	void close_process_handles();
+
+	LocalhostApiClient api_client_;
+	std::mutex mutex_;
+	std::thread worker_thread_;
+	std::atomic_bool stop_requested_{false};
+	WorkerOwnership ownership_ = WorkerOwnership::none;
+
+#ifdef _WIN32
+	PROCESS_INFORMATION process_info_{};
+#endif
+};
+
+std::wstring read_env_wstring(const wchar_t *name);
+
+} // namespace odr::plugin

--- a/docs/architecture/v0.4-smoke.md
+++ b/docs/architecture/v0.4-smoke.md
@@ -46,6 +46,7 @@ Reference:
 - Confirm prerequisites are installed (documented in the plugin build instructions).
 - Build the plugin in a configuration intended for load testing (recommendation: Release).
 - Confirm the output artifact path to be used for loading in OBS.
+- Set `ODR_USER_DATA_DIR` to the runtime root used for this smoke run before starting OBS.
 
 Build instructions:
 - `app/plugin/README.md`
@@ -66,7 +67,10 @@ Capture the minimal evidence:
 - The log lines showing:
   - plugin startup
   - plugin shutdown
+  - worker preflight or launch result
 - The runtime log directory path used (must not be under `app/` and must not be committed)
+- The resolved `ODR_USER_DATA_DIR`
+- Whether the Worker was plugin-spawned or reused-existing
 
 ---
 

--- a/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
+++ b/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
@@ -56,6 +56,7 @@ Current scaffold/build reference:
 - [ ] Plugin does not require users to manually start the Worker in the normal path.
 - [ ] Plugin treats Worker as a singleton per resolved `ODR_USER_DATA_DIR`.
 - [ ] Plugin reuses an existing healthy singleton Worker for the same runtime root instead of spawning a second Worker.
+- [ ] Plugin distinguishes plugin-spawned Workers from reused-existing Workers for shutdown ownership.
 - [ ] Plugin reports launch failures with actionable diagnostics (log + UI surface).
 
 ### D. Runtime-root Continuity
@@ -82,6 +83,7 @@ Current scaffold/build reference:
 - [ ] Plugin uses a minimal API wrapper layer rather than ad-hoc HTTP calls throughout the codebase.
 - [ ] Wrapper behavior for failure cases is defined (timeouts, refused connection, incompatible API).
 - [ ] Wrapper behavior for stale-process / wrong-port / singleton invariant violations is defined.
+- [ ] Wrapper behavior for runtime-root mismatch, version-skew, and reused-existing ownership is defined.
 - [ ] `instance_id` (and other identity fields such as `pid` / `started_at`, when available) are used as diagnostic evidence rather than the primary ownership gate (primary: singleton per resolved `ODR_USER_DATA_DIR`).
 
 ### H. Developer Verification
@@ -93,6 +95,7 @@ Current scaffold/build reference:
   - [ ] logs are produced under `user_data/logs/`
   - [ ] a second launch path reuses or rejects an existing singleton Worker instead of spawning another Worker for the same runtime root
   - [ ] resolved `ODR_USER_DATA_DIR` is recorded in logs, diagnostics, and smoke notes
+  - [ ] plugin-spawned vs reused-existing Worker ownership is recorded in logs and smoke notes
 
 Reference procedure:
 - `docs/architecture/v0.4-smoke.md`


### PR DESCRIPTION
## Summary
- Adds a minimal WinHTTP localhost `/health` wrapper for Plugin -> Worker preflight.
- Adds a Worker process manager that:
  - requires explicit `ODR_USER_DATA_DIR`,
  - reuses a healthy singleton Worker for the same runtime root,
  - blocks mismatched runtime root / API / version cases with diagnostics,
  - starts `odr-worker --host 127.0.0.1 --port 8787` when no Worker is reachable,
  - stops only plugin-spawned Workers and leaves reused-existing Workers running.
- Updates v0.4 smoke and acceptance docs with ownership/runtime-root evidence.

## Scope
- No heartbeat monitor yet (#121).
- No settings page or Dock UI yet (#122).
- No full JSON parser or new third-party dependency; the wrapper extracts the stable fields needed for v0.4 diagnostics.

## Validation
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`

## Not run
- CMake/OBS plugin build smoke: this environment does not have `cmake`, Visual Studio C++ toolchain, or OBS SDK/package files configured.

Refs #110
Refs #120
Refs #123
Refs #144