### PR TITLE
feat(plugin): monitor worker heartbeat via health

### DIFF
--- a/app/plugin/README.md
+++ b/app/plugin/README.md
@@ -20,16 +20,16 @@ The Plugin must not:
 
 ## Current v0.4 Scaffold
 
-The current scaffold is intentionally minimal for #119/#120/#123/#144:
+The current scaffold is intentionally minimal for #119/#120/#121/#123/#144:
 
 - Build a loadable OBS module.
 - Register minimal OBS Frontend API lifecycle hooks.
 - Log plugin startup and shutdown messages.
 - Probe and launch the Worker when `ODR_USER_DATA_DIR` is explicitly configured.
 - Reuse a healthy singleton Worker for the same `ODR_USER_DATA_DIR`.
+- Monitor Worker heartbeat through `GET /health`.
 
 Current non-goals:
-- Worker heartbeat monitoring.
 - Settings UI.
 - Browser Dock UI.
 
@@ -73,12 +73,21 @@ Defaults:
 - Port: `8787`
 - Expected Worker API version: `0.3`
 - Expected Worker version: `0.3.0`
+- Heartbeat interval: 2000 ms
+- Heartbeat timeout threshold: 3 consecutive failed probes
 
 Startup behavior:
 - On OBS frontend ready, the Plugin probes `GET /health` on the configured host/port.
 - If a compatible Worker is already running for the same `ODR_USER_DATA_DIR`, the Plugin reuses it.
 - If a reachable Worker reports a different runtime root, incompatible API version, or unexpected Worker version, startup is blocked and the Plugin logs diagnostics.
 - If no Worker is reachable, the Plugin starts `odr-worker --host 127.0.0.1 --port 8787` with `ODR_USER_DATA_DIR` in the child process environment.
+
+Heartbeat behavior:
+- `/health` is the readiness and heartbeat source of truth.
+- The Plugin records a heartbeat baseline from `api_version`, `version`, `instance_id`, `pid`, `started_at`, and `user_data_dir`.
+- Consecutive probe failures are logged with the target `host:port`, `ODR_USER_DATA_DIR`, and baseline identity evidence.
+- After the failure threshold is reached, the Plugin logs heartbeat timeout evidence.
+- If `instance_id`, `pid`, or `started_at` changes during a healthy heartbeat sequence, the Plugin logs `unexpected_process_change` evidence and does not treat those fields as ownership gates.
 
 Shutdown behavior:
 - Plugin-spawned Workers are stopped on OBS shutdown/plugin unload.
@@ -90,7 +99,7 @@ Use the canonical v0.4 smoke procedure:
 
 - `docs/architecture/v0.4-smoke.md`
 
-For #119/#120/#123/#144, the minimum passing evidence is:
+For #119/#120/#121/#123/#144, the minimum passing evidence is:
 
 - The CMake configure and build commands used.
 - The produced plugin DLL path.
@@ -99,11 +108,12 @@ For #119/#120/#123/#144, the minimum passing evidence is:
   - `OBS Duel Recorder plugin startup`
   - `OBS Duel Recorder plugin shutdown`
   - worker preflight or launch result
+  - heartbeat baseline and either heartbeat success or failure evidence
   - `ODR_USER_DATA_DIR`
   - Worker ownership (`plugin-spawned` or `reused-existing`)
 
 ## Current Lifecycle Surface
 
-The scaffold registers an OBS Frontend API callback, logs lightweight lifecycle events, and runs the initial Worker preflight/launch flow.
+The scaffold registers an OBS Frontend API callback, logs lightweight lifecycle events, and runs the initial Worker preflight/launch/heartbeat flow.
 
-Heavy work must remain outside the plugin process. Heartbeat, settings, and Dock behavior must be added through their own v0.4 issues.
+Heavy work must remain outside the plugin process. Settings and Dock behavior must be added through their own v0.4 issues.

--- a/app/plugin/src/worker-launcher.cpp
+++ b/app/plugin/src/worker-launcher.cpp
@@ -14,6 +14,13 @@ constexpr const char *kLogPrefix = "OBS Duel Recorder";
 constexpr const char *kExpectedApiVersion = "0.3";
 constexpr const char *kExpectedWorkerVersion = "0.3.0";
 
+bool identity_changed(const WorkerProbeResult &baseline, const WorkerProbeResult &current)
+{
+	return (!baseline.instance_id.empty() && !current.instance_id.empty() && baseline.instance_id != current.instance_id) ||
+	       (!baseline.pid.empty() && !current.pid.empty() && baseline.pid != current.pid) ||
+	       (!baseline.started_at.empty() && !current.started_at.empty() && baseline.started_at != current.started_at);
+}
+
 #ifdef _WIN32
 
 std::vector<wchar_t> build_environment_block(const std::wstring &user_data_dir)
@@ -102,13 +109,16 @@ void WorkerProcessManager::start(WorkerLaunchConfig config)
 
 	WorkerProbeResult preflight = api_client_.probe_health(config.endpoint, config.user_data_dir);
 	if (preflight.reusable()) {
-		std::lock_guard<std::mutex> lock(mutex_);
-		ownership_ = WorkerOwnership::reused_existing;
+		{
+			std::lock_guard<std::mutex> lock(mutex_);
+			ownership_ = WorkerOwnership::reused_existing;
+		}
 		blog(LOG_INFO,
 		     "%s worker reused existing instance api_version=%s version=%s instance_id=%s pid=%s started_at=%s user_data_dir=%s",
 		     kLogPrefix, preflight.api_version.c_str(), preflight.version.c_str(),
 		     preflight.instance_id.c_str(), preflight.pid.c_str(),
 		     preflight.started_at.c_str(), preflight.user_data_dir.c_str());
+		monitor_heartbeat(config, preflight);
 		return;
 	}
 
@@ -125,7 +135,8 @@ void WorkerProcessManager::start(WorkerLaunchConfig config)
 		return;
 	}
 
-	if (!wait_until_ready(config)) {
+	WorkerProbeResult ready_probe;
+	if (!wait_until_ready(config, ready_probe)) {
 		blog(LOG_WARNING, "%s worker startup timeout; terminating plugin-owned process", kLogPrefix);
 #ifdef _WIN32
 		std::lock_guard<std::mutex> lock(mutex_);
@@ -136,7 +147,10 @@ void WorkerProcessManager::start(WorkerLaunchConfig config)
 			ownership_ = WorkerOwnership::none;
 		}
 #endif
+		return;
 	}
+
+	monitor_heartbeat(config, ready_probe);
 }
 
 bool WorkerProcessManager::spawn_worker(const WorkerLaunchConfig &config)
@@ -175,7 +189,7 @@ bool WorkerProcessManager::spawn_worker(const WorkerLaunchConfig &config)
 #endif
 }
 
-bool WorkerProcessManager::wait_until_ready(const WorkerLaunchConfig &config)
+bool WorkerProcessManager::wait_until_ready(const WorkerLaunchConfig &config, WorkerProbeResult &ready_probe)
 {
 	const auto deadline = std::chrono::steady_clock::now() +
 			      std::chrono::milliseconds(config.startup_timeout_ms);
@@ -183,6 +197,7 @@ bool WorkerProcessManager::wait_until_ready(const WorkerLaunchConfig &config)
 	while (!stop_requested_ && std::chrono::steady_clock::now() < deadline) {
 		WorkerProbeResult probe = api_client_.probe_health(config.endpoint, config.user_data_dir);
 		if (probe.reusable()) {
+			ready_probe = probe;
 			blog(LOG_INFO,
 			     "%s worker running api_version=%s version=%s instance_id=%s pid=%s started_at=%s user_data_dir=%s",
 			     kLogPrefix, probe.api_version.c_str(), probe.version.c_str(),
@@ -194,6 +209,85 @@ bool WorkerProcessManager::wait_until_ready(const WorkerLaunchConfig &config)
 	}
 
 	return false;
+}
+
+void WorkerProcessManager::monitor_heartbeat(const WorkerLaunchConfig &config, const WorkerProbeResult &baseline)
+{
+	blog(LOG_INFO,
+	     "%s heartbeat baseline interval_ms=%u failure_threshold=%u api_version=%s version=%s instance_id=%s pid=%s started_at=%s user_data_dir=%s",
+	     kLogPrefix, config.heartbeat_interval_ms, config.heartbeat_failure_threshold,
+	     baseline.api_version.c_str(), baseline.version.c_str(), baseline.instance_id.c_str(),
+	     baseline.pid.c_str(), baseline.started_at.c_str(), baseline.user_data_dir.c_str());
+
+	unsigned int consecutive_failures = 0;
+	bool replacement_reported = false;
+	bool timeout_reported = false;
+
+	while (!stop_requested_) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(config.heartbeat_interval_ms));
+		if (stop_requested_) {
+			break;
+		}
+
+#ifdef _WIN32
+		if (current_ownership() == WorkerOwnership::spawned_by_plugin) {
+			std::lock_guard<std::mutex> lock(mutex_);
+			if (process_info_.hProcess) {
+				DWORD exit_code = 0;
+				if (GetExitCodeProcess(process_info_.hProcess, &exit_code) && exit_code != STILL_ACTIVE) {
+					blog(LOG_WARNING,
+					     "%s heartbeat crashed exit_code=%lu user_data_dir=%s instance_id=%s pid=%s started_at=%s",
+					     kLogPrefix, exit_code, to_utf8(config.user_data_dir).c_str(),
+					     baseline.instance_id.c_str(), baseline.pid.c_str(), baseline.started_at.c_str());
+					return;
+				}
+			}
+		}
+#endif
+
+		WorkerProbeResult probe = api_client_.probe_health(config.endpoint, config.user_data_dir);
+		if (probe.reusable()) {
+			if (consecutive_failures > 0) {
+				blog(LOG_INFO,
+				     "%s heartbeat recovered failures=%u api_version=%s version=%s instance_id=%s pid=%s started_at=%s user_data_dir=%s",
+				     kLogPrefix, consecutive_failures, probe.api_version.c_str(), probe.version.c_str(),
+				     probe.instance_id.c_str(), probe.pid.c_str(), probe.started_at.c_str(), probe.user_data_dir.c_str());
+			}
+			consecutive_failures = 0;
+			timeout_reported = false;
+
+			if (!replacement_reported && identity_changed(baseline, probe)) {
+				replacement_reported = true;
+				blog(LOG_WARNING,
+				     "%s heartbeat unexpected_process_change baseline_instance_id=%s current_instance_id=%s baseline_pid=%s current_pid=%s baseline_started_at=%s current_started_at=%s user_data_dir=%s",
+				     kLogPrefix, baseline.instance_id.c_str(), probe.instance_id.c_str(),
+				     baseline.pid.c_str(), probe.pid.c_str(), baseline.started_at.c_str(),
+				     probe.started_at.c_str(), probe.user_data_dir.c_str());
+			}
+			continue;
+		}
+
+		++consecutive_failures;
+		blog(LOG_WARNING,
+		     "%s heartbeat probe_failed failures=%u status=%d http=%lu error=%s user_data_dir=%s instance_id=%s pid=%s started_at=%s",
+		     kLogPrefix, consecutive_failures, static_cast<int>(probe.status), probe.http_status,
+		     probe.error.c_str(), to_utf8(config.user_data_dir).c_str(), baseline.instance_id.c_str(),
+		     baseline.pid.c_str(), baseline.started_at.c_str());
+
+		if (!timeout_reported && consecutive_failures >= config.heartbeat_failure_threshold) {
+			timeout_reported = true;
+			blog(LOG_WARNING,
+			     "%s heartbeat timeout threshold=%u host=%s port=%u user_data_dir=%s logs=<ODR_USER_DATA_DIR>/logs/",
+			     kLogPrefix, config.heartbeat_failure_threshold, to_utf8(config.endpoint.host).c_str(),
+			     config.endpoint.port, to_utf8(config.user_data_dir).c_str());
+		}
+	}
+}
+
+WorkerOwnership WorkerProcessManager::current_ownership() const
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+	return ownership_;
 }
 
 void WorkerProcessManager::stop()

--- a/app/plugin/src/worker-launcher.hpp
+++ b/app/plugin/src/worker-launcher.hpp
@@ -24,6 +24,8 @@ struct WorkerLaunchConfig {
 	std::wstring user_data_dir;
 	std::wstring command = L"odr-worker";
 	unsigned int startup_timeout_ms = 10000;
+	unsigned int heartbeat_interval_ms = 2000;
+	unsigned int heartbeat_failure_threshold = 3;
 };
 
 class WorkerProcessManager {
@@ -37,11 +39,13 @@ public:
 private:
 	void start(WorkerLaunchConfig config);
 	bool spawn_worker(const WorkerLaunchConfig &config);
-	bool wait_until_ready(const WorkerLaunchConfig &config);
+	bool wait_until_ready(const WorkerLaunchConfig &config, WorkerProbeResult &ready_probe);
+	void monitor_heartbeat(const WorkerLaunchConfig &config, const WorkerProbeResult &baseline);
+	WorkerOwnership current_ownership() const;
 	void close_process_handles();
 
 	LocalhostApiClient api_client_;
-	std::mutex mutex_;
+	mutable std::mutex mutex_;
 	std::thread worker_thread_;
 	std::atomic_bool stop_requested_{false};
 	WorkerOwnership ownership_ = WorkerOwnership::none;

--- a/docs/architecture/v0.4-smoke.md
+++ b/docs/architecture/v0.4-smoke.md
@@ -68,6 +68,8 @@ Capture the minimal evidence:
   - plugin startup
   - plugin shutdown
   - worker preflight or launch result
+  - heartbeat baseline
+  - heartbeat success, recovery, timeout, crash, or unexpected process-change evidence when observed
 - The runtime log directory path used (must not be under `app/` and must not be committed)
 - The resolved `ODR_USER_DATA_DIR`
 - Whether the Worker was plugin-spawned or reused-existing

--- a/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
+++ b/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
@@ -71,6 +71,8 @@ Current scaffold/build reference:
 
 - [ ] Plugin monitors Worker health via `GET /health`.
 - [ ] A heartbeat timeout and failure mode vocabulary is defined and used consistently.
+- [ ] Heartbeat evidence records the probe target, resolved `ODR_USER_DATA_DIR`, baseline `instance_id` / `pid` / `started_at`, and failure count on timeout-adjacent transitions.
+- [ ] Unexpected `instance_id` / `pid` / `started_at` changes are logged as diagnostic evidence, not treated as ownership gates.
 - [ ] Plugin surfaces Worker state in a Dock UI (minimum: `starting` / `running` / `unhealthy` / `crashed` / `api_incompatible`).
 
 ### F. Plugin Settings + Dock UI
@@ -93,6 +95,7 @@ Current scaffold/build reference:
   - [ ] worker launches
   - [ ] dock shows health
   - [ ] logs are produced under `user_data/logs/`
+  - [ ] heartbeat baseline and timeout/failure evidence are recorded in logs / smoke notes
   - [ ] a second launch path reuses or rejects an existing singleton Worker instead of spawning another Worker for the same runtime root
   - [ ] resolved `ODR_USER_DATA_DIR` is recorded in logs, diagnostics, and smoke notes
   - [ ] plugin-spawned vs reused-existing Worker ownership is recorded in logs and smoke notes


### PR DESCRIPTION
## Summary
- Adds a minimal Worker heartbeat loop after successful launch/reuse.
- Uses `GET /health` as the readiness and heartbeat source of truth.
- Records heartbeat baseline evidence: `api_version`, `version`, `instance_id`, `pid`, `started_at`, and `ODR_USER_DATA_DIR`.
- Logs probe failures, recovery, timeout threshold, plugin-owned crash evidence, and unexpected process identity changes.
- Updates v0.4 smoke and acceptance docs with heartbeat evidence expectations.

## Scope
- No full Dock UI yet (#122).
- No automatic rebind/backoff policy beyond evidence logging.
- Identity changes are diagnostic evidence only, not ownership gates.

## Validation
- GitHub Actions run 26290143215: Docs validation succeeded.
- GitHub Actions run 26290143215: Worker unit tests succeeded.

## Not run
- CMake/OBS plugin build smoke: this environment does not have `cmake`, Visual Studio C++ toolchain, or OBS SDK/package files configured.

Refs #110
Refs #121
Refs #154