### PR TITLE
feat(plugin): add status dock and persisted settings

### DIFF
--- a/app/plugin/CMakeLists.txt
+++ b/app/plugin/CMakeLists.txt
@@ -4,9 +4,12 @@ project(obs-duel-recorder-plugin VERSION 0.4.0 LANGUAGES CXX)
 
 find_package(libobs REQUIRED)
 find_package(obs-frontend-api REQUIRED)
+find_package(Qt6 REQUIRED COMPONENTS Widgets)
 
 add_library(obs-duel-recorder MODULE
   src/plugin-main.cpp
+  src/plugin-settings.cpp
+  src/plugin-ui.cpp
   src/worker-api.cpp
   src/worker-launcher.cpp
 )
@@ -17,6 +20,7 @@ target_link_libraries(obs-duel-recorder
   PRIVATE
     OBS::libobs
     OBS::obs-frontend-api
+    Qt6::Widgets
 )
 
 if(WIN32)

--- a/app/plugin/README.md
+++ b/app/plugin/README.md
@@ -20,20 +20,21 @@ The Plugin must not:
 
 ## Current v0.4 Scaffold
 
-The current scaffold is intentionally minimal for #119/#120/#121/#123/#144:
+The current scaffold is intentionally minimal for #119/#120/#121/#122/#123/#144:
 
 - Build a loadable OBS module.
 - Register minimal OBS Frontend API lifecycle hooks.
 - Log plugin startup and shutdown messages.
-- Probe and launch the Worker when `ODR_USER_DATA_DIR` is explicitly configured.
+- Persist minimal Plugin settings as JSON.
+- Probe and launch the Worker from persisted settings.
 - Reuse a healthy singleton Worker for the same `ODR_USER_DATA_DIR`.
 - Monitor Worker heartbeat through `GET /health`.
+- Register a status-first OBS Dock for Worker diagnostics.
 
 Current non-goals:
-- Settings UI.
-- Browser Dock UI.
-
-Those items are tracked by separate v0.4 child issues.
+- Full control UI.
+- Overlay UX.
+- OAuth/upload setup.
 
 ## Prerequisites
 
@@ -42,15 +43,16 @@ Those items are tracked by separate v0.4 child issues.
 - Visual Studio 2022 with C++ desktop workload
 - CMake 3.24+
 - OBS CMake package files and development headers/libraries available through `CMAKE_PREFIX_PATH`
+- Qt 6 Widgets development package available to CMake
 
-The exact OBS SDK or source/build location depends on the contributor environment. Point `CMAKE_PREFIX_PATH` at the directory that exposes `libobs` and `obs-frontend-api` CMake packages.
+The exact OBS SDK or source/build location depends on the contributor environment. Point `CMAKE_PREFIX_PATH` at the directory that exposes `libobs`, `obs-frontend-api`, and Qt 6 CMake packages.
 
 ## Build
 
 Run from the repository root:
 
 ```powershell
-cmake -S app/plugin -B build/plugin -G "Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH="C:\Path\To\obs-studio-or-sdk"
+cmake -S app/plugin -B build/plugin -G "Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH="C:\Path\To\obs-studio-or-sdk;C:\Path\To\Qt\6.x.x\msvc2022_64"
 cmake --build build/plugin --config Release
 ```
 
@@ -60,12 +62,51 @@ Expected artifact:
 build/plugin/Release/obs-duel-recorder.dll
 ```
 
+## Settings
+
+Settings are saved as JSON at:
+
+```text
+%APPDATA%\obs-duel-recorder\plugin-settings.json
+```
+
+Current keys:
+
+```json
+{
+  "host": "127.0.0.1",
+  "port": 8787,
+  "user_data_dir": "C:/path/to/user_data",
+  "restart_worker_on_change": true
+}
+```
+
+`ODR_USER_DATA_DIR` remains a compatibility fallback for initial defaults. Once the settings file is saved, `user_data_dir` in the JSON file is the Plugin launch input.
+
+Settings flow:
+- Open `Tools > OBS Duel Recorder Settings` or the `Settings` button in the Dock.
+- Edit `host`, `port`, or `user_data_dir`.
+- Save the dialog.
+- The Plugin persists the JSON file and restarts the Worker manager with the saved settings.
+
+v0.4 treats settings changes conservatively: saving settings restarts the Worker manager. Immediate apply is reserved for explicitly safe future fields. OBS restart is an exception path, not the default.
+
+## Status Dock
+
+The Plugin registers an `OBS Duel Recorder` Dock through the OBS Frontend API.
+
+The v0.4 Dock is status-first. It displays:
+- diagnostic state (`not_started`, `starting`, `running`, `unhealthy`, `config_error`, `runtime_dir_error`, `api_incompatible`, `crashed`)
+- endpoint
+- resolved `user_data_dir`
+- expected log directory
+- Worker ownership (`plugin-spawned` or `reused-existing`)
+- latest probe/detail text
+- recommended action
+
+The Dock intentionally does not provide full Worker controls in v0.4.
+
 ## Worker Launch Inputs
-
-The v0.4 launch path is intentionally conservative until the settings page exists.
-
-Required environment:
-- `ODR_USER_DATA_DIR`: absolute runtime root to pass to the Worker.
 
 Defaults:
 - Worker command: `odr-worker`
@@ -77,10 +118,12 @@ Defaults:
 - Heartbeat timeout threshold: 3 consecutive failed probes
 
 Startup behavior:
-- On OBS frontend ready, the Plugin probes `GET /health` on the configured host/port.
-- If a compatible Worker is already running for the same `ODR_USER_DATA_DIR`, the Plugin reuses it.
+- On OBS frontend ready, the Plugin loads `plugin-settings.json` and starts the Worker manager.
+- If `user_data_dir` is empty, startup is blocked with `config_error` and the Dock points to settings.
+- The Plugin probes `GET /health` on the configured host/port.
+- If a compatible Worker is already running for the same `user_data_dir`, the Plugin reuses it.
 - If a reachable Worker reports a different runtime root, incompatible API version, or unexpected Worker version, startup is blocked and the Plugin logs diagnostics.
-- If no Worker is reachable, the Plugin starts `odr-worker --host 127.0.0.1 --port 8787` with `ODR_USER_DATA_DIR` in the child process environment.
+- If no Worker is reachable, the Plugin starts `odr-worker --host <host> --port <port>` with `ODR_USER_DATA_DIR` in the child process environment.
 
 Heartbeat behavior:
 - `/health` is the readiness and heartbeat source of truth.
@@ -99,7 +142,7 @@ Use the canonical v0.4 smoke procedure:
 
 - `docs/architecture/v0.4-smoke.md`
 
-For #119/#120/#121/#123/#144, the minimum passing evidence is:
+For #119/#120/#121/#122/#123/#144, the minimum passing evidence is:
 
 - The CMake configure and build commands used.
 - The produced plugin DLL path.
@@ -107,13 +150,16 @@ For #119/#120/#121/#123/#144, the minimum passing evidence is:
 - OBS or ODR logs include:
   - `OBS Duel Recorder plugin startup`
   - `OBS Duel Recorder plugin shutdown`
+  - dock registration result
+  - settings save path or loaded settings path
   - worker preflight or launch result
   - heartbeat baseline and either heartbeat success or failure evidence
-  - `ODR_USER_DATA_DIR`
+  - `ODR_USER_DATA_DIR` or persisted `user_data_dir`
   - Worker ownership (`plugin-spawned` or `reused-existing`)
+- The Dock displays the Worker diagnostic state and settings entry point.
 
 ## Current Lifecycle Surface
 
-The scaffold registers an OBS Frontend API callback, logs lightweight lifecycle events, and runs the initial Worker preflight/launch/heartbeat flow.
+The scaffold registers an OBS Frontend API callback, logs lightweight lifecycle events, runs the initial Worker preflight/launch/heartbeat flow, and surfaces status-first diagnostics in a Dock.
 
-Heavy work must remain outside the plugin process. Settings and Dock behavior must be added through their own v0.4 issues.
+Heavy work must remain outside the plugin process. Full controls, overlay UX, and upload/OAuth setup remain later-version work.

--- a/app/plugin/src/plugin-main.cpp
+++ b/app/plugin/src/plugin-main.cpp
@@ -1,6 +1,8 @@
 #include <obs-frontend-api.h>
 #include <obs-module.h>
 
+#include "plugin-settings.hpp"
+#include "plugin-ui.hpp"
 #include "worker-launcher.hpp"
 
 #include <utility>
@@ -12,11 +14,12 @@ namespace {
 
 constexpr const char *kLogPrefix = "OBS Duel Recorder";
 odr::plugin::WorkerProcessManager worker_manager;
+odr::plugin::PluginUiController ui_controller(worker_manager);
 
 void launch_worker()
 {
-	odr::plugin::WorkerLaunchConfig config;
-	config.user_data_dir = odr::plugin::read_env_wstring(L"ODR_USER_DATA_DIR");
+	odr::plugin::PluginSettings settings = odr::plugin::load_plugin_settings();
+	odr::plugin::WorkerLaunchConfig config = odr::plugin::make_launch_config(settings);
 	worker_manager.start_async(std::move(config));
 }
 
@@ -25,6 +28,7 @@ void frontend_event(enum obs_frontend_event event, void *)
 	switch (event) {
 	case OBS_FRONTEND_EVENT_FINISHED_LOADING:
 		blog(LOG_INFO, "%s frontend ready", kLogPrefix);
+		ui_controller.register_ui();
 		launch_worker();
 		break;
 	case OBS_FRONTEND_EVENT_EXIT:
@@ -47,6 +51,7 @@ bool obs_module_load(void)
 
 void obs_module_unload(void)
 {
+	ui_controller.unregister_ui();
 	worker_manager.stop();
 	obs_frontend_remove_event_callback(frontend_event, nullptr);
 	blog(LOG_INFO, "%s plugin shutdown", kLogPrefix);

--- a/app/plugin/src/plugin-settings.cpp
+++ b/app/plugin/src/plugin-settings.cpp
@@ -1,0 +1,158 @@
+#include "plugin-settings.hpp"
+
+#include <obs-module.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+
+namespace odr::plugin {
+namespace {
+
+constexpr const char *kDefaultHost = "127.0.0.1";
+constexpr uint16_t kDefaultPort = 8787;
+constexpr const wchar_t *kSettingsDirectory = L"obs-duel-recorder";
+constexpr const wchar_t *kSettingsFile = L"plugin-settings.json";
+
+std::wstring from_utf8(const char *value)
+{
+	if (!value || value[0] == '\0') {
+		return {};
+	}
+#ifdef _WIN32
+	const int size = MultiByteToWideChar(CP_UTF8, 0, value, -1, nullptr, 0);
+	if (size <= 0) {
+		return {};
+	}
+	std::wstring result(static_cast<size_t>(size - 1), L'\0');
+	MultiByteToWideChar(CP_UTF8, 0, value, -1, result.data(), size);
+	return result;
+#else
+	return std::wstring(value, value + std::char_traits<char>::length(value));
+#endif
+}
+
+std::wstring parent_directory(const std::wstring &path)
+{
+	const size_t pos = path.find_last_of(L"\\/");
+	if (pos == std::wstring::npos) {
+		return {};
+	}
+	return path.substr(0, pos);
+}
+
+bool ensure_directory(const std::wstring &path)
+{
+	if (path.empty()) {
+		return false;
+	}
+#ifdef _WIN32
+	std::wstring current;
+	for (size_t i = 0; i < path.size(); ++i) {
+		current.push_back(path[i]);
+		if (path[i] != L'\\' && path[i] != L'/') {
+			continue;
+		}
+		if (current.size() <= 3) {
+			continue;
+		}
+		CreateDirectoryW(current.c_str(), nullptr);
+	}
+	if (!CreateDirectoryW(path.c_str(), nullptr)) {
+		const DWORD error = GetLastError();
+		return error == ERROR_ALREADY_EXISTS;
+	}
+	return true;
+#else
+	return false;
+#endif
+}
+
+uint16_t clamp_port(long long value)
+{
+	if (value <= 0 || value > 65535) {
+		return kDefaultPort;
+	}
+	return static_cast<uint16_t>(value);
+}
+
+void apply_defaults(obs_data_t *data)
+{
+	obs_data_set_default_string(data, "host", kDefaultHost);
+	obs_data_set_default_int(data, "port", kDefaultPort);
+	obs_data_set_default_string(data, "user_data_dir", to_utf8(read_env_wstring(L"ODR_USER_DATA_DIR")).c_str());
+	obs_data_set_default_bool(data, "restart_worker_on_change", true);
+}
+
+} // namespace
+
+std::wstring default_plugin_settings_path()
+{
+#ifdef _WIN32
+	const std::wstring app_data = read_env_wstring(L"APPDATA");
+	if (!app_data.empty()) {
+		return app_data + L"\\" + kSettingsDirectory + L"\\" + kSettingsFile;
+	}
+#endif
+	return std::wstring(kSettingsFile);
+}
+
+PluginSettings load_plugin_settings()
+{
+	PluginSettings settings;
+	settings.settings_path = default_plugin_settings_path();
+
+	obs_data_t *data = obs_data_create_from_json_file_safe(to_utf8(settings.settings_path).c_str(), "bak");
+	if (!data) {
+		data = obs_data_create();
+	}
+	apply_defaults(data);
+
+	settings.endpoint.host = from_utf8(obs_data_get_string(data, "host"));
+	if (settings.endpoint.host.empty()) {
+		settings.endpoint.host = from_utf8(kDefaultHost);
+	}
+	settings.endpoint.port = clamp_port(obs_data_get_int(data, "port"));
+	settings.user_data_dir = from_utf8(obs_data_get_string(data, "user_data_dir"));
+	settings.restart_worker_on_change = obs_data_get_bool(data, "restart_worker_on_change");
+
+	obs_data_release(data);
+	return settings;
+}
+
+bool save_plugin_settings(const PluginSettings &settings)
+{
+	const std::wstring parent = parent_directory(settings.settings_path);
+	if (!parent.empty() && !ensure_directory(parent)) {
+		blog(LOG_WARNING, "OBS Duel Recorder settings save failed path=%s", to_utf8(settings.settings_path).c_str());
+		return false;
+	}
+
+	obs_data_t *data = obs_data_create();
+	obs_data_set_string(data, "host", to_utf8(settings.endpoint.host).c_str());
+	obs_data_set_int(data, "port", settings.endpoint.port);
+	obs_data_set_string(data, "user_data_dir", to_utf8(settings.user_data_dir).c_str());
+	obs_data_set_bool(data, "restart_worker_on_change", settings.restart_worker_on_change);
+
+	const bool saved = obs_data_save_json_safe(data, to_utf8(settings.settings_path).c_str(), "tmp", "bak");
+	obs_data_release(data);
+
+	if (!saved) {
+		blog(LOG_WARNING, "OBS Duel Recorder settings save failed path=%s", to_utf8(settings.settings_path).c_str());
+	}
+	return saved;
+}
+
+WorkerLaunchConfig make_launch_config(const PluginSettings &settings)
+{
+	WorkerLaunchConfig config;
+	config.endpoint = settings.endpoint;
+	config.user_data_dir = settings.user_data_dir;
+	return config;
+}
+
+} // namespace odr::plugin

--- a/app/plugin/src/plugin-settings.hpp
+++ b/app/plugin/src/plugin-settings.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "worker-launcher.hpp"
+
+namespace odr::plugin {
+
+struct PluginSettings {
+	WorkerEndpoint endpoint;
+	std::wstring user_data_dir;
+	std::wstring settings_path;
+	bool restart_worker_on_change = true;
+};
+
+std::wstring default_plugin_settings_path();
+PluginSettings load_plugin_settings();
+bool save_plugin_settings(const PluginSettings &settings);
+WorkerLaunchConfig make_launch_config(const PluginSettings &settings);
+
+} // namespace odr::plugin

--- a/app/plugin/src/plugin-ui.cpp
+++ b/app/plugin/src/plugin-ui.cpp
@@ -1,0 +1,263 @@
+#include "plugin-ui.hpp"
+
+#include "plugin-settings.hpp"
+
+#include <obs-frontend-api.h>
+#include <obs-module.h>
+
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <string>
+
+namespace odr::plugin {
+namespace {
+
+constexpr const char *kDockId = "obs-duel-recorder-status";
+constexpr const char *kLogPrefix = "OBS Duel Recorder";
+
+QString qstr_utf8(const std::string &value)
+{
+	return QString::fromUtf8(value.c_str());
+}
+
+QString qstr_wide(const std::wstring &value)
+{
+	return QString::fromStdWString(value);
+}
+
+const char *state_name(WorkerDiagnosticState state)
+{
+	switch (state) {
+	case WorkerDiagnosticState::not_started:
+		return "not_started";
+	case WorkerDiagnosticState::starting:
+		return "starting";
+	case WorkerDiagnosticState::running:
+		return "running";
+	case WorkerDiagnosticState::unhealthy:
+		return "unhealthy";
+	case WorkerDiagnosticState::config_error:
+		return "config_error";
+	case WorkerDiagnosticState::runtime_dir_error:
+		return "runtime_dir_error";
+	case WorkerDiagnosticState::api_incompatible:
+		return "api_incompatible";
+	case WorkerDiagnosticState::crashed:
+		return "crashed";
+	}
+	return "unknown";
+}
+
+const char *ownership_name(WorkerOwnership ownership)
+{
+	switch (ownership) {
+	case WorkerOwnership::none:
+		return "none";
+	case WorkerOwnership::spawned_by_plugin:
+		return "plugin-spawned";
+	case WorkerOwnership::reused_existing:
+		return "reused-existing";
+	}
+	return "unknown";
+}
+
+const char *recommended_action(WorkerDiagnosticState state)
+{
+	switch (state) {
+	case WorkerDiagnosticState::not_started:
+		return "Open settings and save to start Worker.";
+	case WorkerDiagnosticState::starting:
+		return "Wait for Worker readiness; check logs if it times out.";
+	case WorkerDiagnosticState::running:
+		return "No action required.";
+	case WorkerDiagnosticState::unhealthy:
+		return "Check Worker logs and restart through settings if needed.";
+	case WorkerDiagnosticState::config_error:
+		return "Open settings and choose a valid user_data_dir.";
+	case WorkerDiagnosticState::runtime_dir_error:
+		return "Fix user_data_dir or stop the wrong-root Worker.";
+	case WorkerDiagnosticState::api_incompatible:
+		return "Update Plugin and Worker to a compatible pair.";
+	case WorkerDiagnosticState::crashed:
+		return "Check Worker logs and save settings to restart.";
+	}
+	return "Check OBS and Worker logs.";
+}
+
+QLabel *add_row(QFormLayout *layout, const char *name)
+{
+	auto *value = new QLabel;
+	value->setTextInteractionFlags(Qt::TextSelectableByMouse);
+	value->setWordWrap(true);
+	layout->addRow(QString::fromUtf8(name), value);
+	return value;
+}
+
+} // namespace
+
+PluginUiController::PluginUiController(WorkerProcessManager &worker_manager)
+	: worker_manager_(worker_manager)
+{
+}
+
+void PluginUiController::register_ui()
+{
+	if (!tools_menu_registered_) {
+		obs_frontend_add_tools_menu_item("OBS Duel Recorder Settings", open_settings_from_menu, this);
+		tools_menu_registered_ = true;
+	}
+
+	if (dock_widget_) {
+		refresh();
+		return;
+	}
+
+	dock_widget_ = new QWidget;
+	dock_widget_->setMinimumWidth(320);
+
+	auto *root = new QVBoxLayout(dock_widget_);
+	root->setContentsMargins(10, 10, 10, 10);
+	root->setSpacing(8);
+
+	auto *form = new QFormLayout;
+	form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
+	state_value_ = add_row(form, "State");
+	endpoint_value_ = add_row(form, "Endpoint");
+	user_data_value_ = add_row(form, "User data");
+	logs_value_ = add_row(form, "Logs");
+	ownership_value_ = add_row(form, "Ownership");
+	detail_value_ = add_row(form, "Detail");
+	action_value_ = add_row(form, "Action");
+	root->addLayout(form);
+
+	auto *settings_button = new QPushButton("Settings");
+	QObject::connect(settings_button, &QPushButton::clicked, [this]() { show_settings_dialog(); });
+	root->addWidget(settings_button);
+	root->addStretch(1);
+
+	if (!obs_frontend_add_dock_by_id(kDockId, "OBS Duel Recorder", dock_widget_)) {
+		blog(LOG_WARNING, "%s dock registration failed id=%s", kLogPrefix, kDockId);
+		delete dock_widget_;
+		dock_widget_ = nullptr;
+		return;
+	}
+
+	refresh_timer_ = new QTimer(dock_widget_);
+	QObject::connect(refresh_timer_, &QTimer::timeout, [this]() { refresh(); });
+	refresh_timer_->start(1000);
+	refresh();
+	blog(LOG_INFO, "%s dock registered id=%s", kLogPrefix, kDockId);
+}
+
+void PluginUiController::unregister_ui()
+{
+	if (refresh_timer_) {
+		refresh_timer_->stop();
+		refresh_timer_ = nullptr;
+	}
+	if (dock_widget_) {
+		obs_frontend_remove_dock(kDockId);
+		delete dock_widget_;
+		dock_widget_ = nullptr;
+	}
+}
+
+void PluginUiController::refresh()
+{
+	if (!dock_widget_) {
+		return;
+	}
+
+	const WorkerStatusSnapshot snapshot = worker_manager_.status_snapshot();
+	const std::string endpoint = to_utf8(snapshot.endpoint.host) + ":" + std::to_string(snapshot.endpoint.port);
+	const std::string logs = snapshot.user_data_dir.empty() ? std::string{} :
+				 to_utf8(snapshot.user_data_dir) + "/logs/";
+
+	state_value_->setText(QString::fromUtf8(state_name(snapshot.state)));
+	endpoint_value_->setText(qstr_utf8(endpoint));
+	user_data_value_->setText(snapshot.user_data_dir.empty() ? QString::fromUtf8("not configured") : qstr_wide(snapshot.user_data_dir));
+	logs_value_->setText(logs.empty() ? QString::fromUtf8("not available") : qstr_utf8(logs));
+	ownership_value_->setText(QString::fromUtf8(ownership_name(snapshot.ownership)));
+	detail_value_->setText(qstr_utf8(snapshot.error.empty() ? snapshot.last_probe_summary : snapshot.error));
+	action_value_->setText(QString::fromUtf8(recommended_action(snapshot.state)));
+}
+
+void PluginUiController::open_settings_from_menu(void *private_data)
+{
+	auto *controller = static_cast<PluginUiController *>(private_data);
+	if (controller) {
+		controller->show_settings_dialog();
+	}
+}
+
+void PluginUiController::show_settings_dialog()
+{
+	PluginSettings settings = load_plugin_settings();
+
+	QDialog dialog(dock_widget_);
+	dialog.setWindowTitle("OBS Duel Recorder Settings");
+
+	auto *layout = new QVBoxLayout(&dialog);
+	auto *form = new QFormLayout;
+
+	auto *host_input = new QLineEdit(qstr_wide(settings.endpoint.host));
+	auto *port_input = new QSpinBox;
+	port_input->setRange(1, 65535);
+	port_input->setValue(settings.endpoint.port);
+	auto *user_data_input = new QLineEdit(qstr_wide(settings.user_data_dir));
+	auto *settings_path = new QLabel(qstr_wide(settings.settings_path));
+	settings_path->setTextInteractionFlags(Qt::TextSelectableByMouse);
+	settings_path->setWordWrap(true);
+
+	form->addRow("Host", host_input);
+	form->addRow("Port", port_input);
+	form->addRow("User data dir", user_data_input);
+	form->addRow("Settings file", settings_path);
+	layout->addLayout(form);
+
+	auto *note = new QLabel("Saving restarts the Worker with the persisted settings.");
+	note->setWordWrap(true);
+	layout->addWidget(note);
+
+	auto *buttons = new QDialogButtonBox(QDialogButtonBox::Save | QDialogButtonBox::Cancel);
+	QObject::connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+	QObject::connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+	layout->addWidget(buttons);
+
+	if (dialog.exec() != QDialog::Accepted) {
+		return;
+	}
+
+	settings.endpoint.host = host_input->text().toStdWString();
+	settings.endpoint.port = static_cast<uint16_t>(port_input->value());
+	settings.user_data_dir = user_data_input->text().toStdWString();
+	settings.restart_worker_on_change = true;
+	save_settings_and_restart(settings);
+}
+
+void PluginUiController::save_settings_and_restart(const PluginSettings &settings)
+{
+	if (!save_plugin_settings(settings)) {
+		return;
+	}
+
+	blog(LOG_INFO, "%s settings saved path=%s host=%s port=%u user_data_dir=%s apply=worker_restart",
+	     kLogPrefix, to_utf8(settings.settings_path).c_str(), to_utf8(settings.endpoint.host).c_str(),
+	     settings.endpoint.port, to_utf8(settings.user_data_dir).c_str());
+
+	worker_manager_.stop();
+	worker_manager_.start_async(make_launch_config(settings));
+	refresh();
+}
+
+} // namespace odr::plugin

--- a/app/plugin/src/plugin-ui.hpp
+++ b/app/plugin/src/plugin-ui.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "worker-launcher.hpp"
+
+class QLabel;
+class QTimer;
+class QWidget;
+
+namespace odr::plugin {
+
+class PluginUiController {
+public:
+	explicit PluginUiController(WorkerProcessManager &worker_manager);
+
+	void register_ui();
+	void unregister_ui();
+	void refresh();
+
+private:
+	static void open_settings_from_menu(void *private_data);
+	void show_settings_dialog();
+	void save_settings_and_restart(const PluginSettings &settings);
+
+	WorkerProcessManager &worker_manager_;
+	QWidget *dock_widget_ = nullptr;
+	QTimer *refresh_timer_ = nullptr;
+	QLabel *state_value_ = nullptr;
+	QLabel *endpoint_value_ = nullptr;
+	QLabel *user_data_value_ = nullptr;
+	QLabel *logs_value_ = nullptr;
+	QLabel *ownership_value_ = nullptr;
+	QLabel *detail_value_ = nullptr;
+	QLabel *action_value_ = nullptr;
+	bool tools_menu_registered_ = false;
+};
+
+} // namespace odr::plugin

--- a/app/plugin/src/plugin-ui.hpp
+++ b/app/plugin/src/plugin-ui.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "plugin-settings.hpp"
 #include "worker-launcher.hpp"
 
 class QLabel;

--- a/app/plugin/src/worker-launcher.cpp
+++ b/app/plugin/src/worker-launcher.cpp
@@ -21,6 +21,35 @@ bool identity_changed(const WorkerProbeResult &baseline, const WorkerProbeResult
 	       (!baseline.started_at.empty() && !current.started_at.empty() && baseline.started_at != current.started_at);
 }
 
+WorkerDiagnosticState diagnostic_state_for_probe(const WorkerProbeResult &probe)
+{
+	switch (probe.status) {
+	case WorkerProbeStatus::reachable:
+		return WorkerDiagnosticState::running;
+	case WorkerProbeStatus::api_incompatible:
+		return WorkerDiagnosticState::api_incompatible;
+	case WorkerProbeStatus::runtime_root_mismatch:
+		return WorkerDiagnosticState::runtime_dir_error;
+	case WorkerProbeStatus::invalid_response:
+		return WorkerDiagnosticState::unhealthy;
+	case WorkerProbeStatus::unreachable:
+		return WorkerDiagnosticState::starting;
+	}
+	return WorkerDiagnosticState::unhealthy;
+}
+
+std::string summarize_probe(const WorkerProbeResult &probe)
+{
+	return "status=" + std::to_string(static_cast<int>(probe.status)) +
+	       " http=" + std::to_string(probe.http_status) +
+	       " api_version=" + probe.api_version +
+	       " version=" + probe.version +
+	       " instance_id=" + probe.instance_id +
+	       " pid=" + probe.pid +
+	       " started_at=" + probe.started_at +
+	       " user_data_dir=" + probe.user_data_dir;
+}
+
 #ifdef _WIN32
 
 std::vector<wchar_t> build_environment_block(const std::wstring &user_data_dir)
@@ -99,10 +128,13 @@ void WorkerProcessManager::start_async(WorkerLaunchConfig config)
 void WorkerProcessManager::start(WorkerLaunchConfig config)
 {
 	if (config.user_data_dir.empty()) {
+		update_status(WorkerDiagnosticState::config_error, config, WorkerOwnership::none,
+			      "ODR_USER_DATA_DIR is required before launching Worker");
 		blog(LOG_WARNING, "%s config_error: ODR_USER_DATA_DIR is required before launching Worker", kLogPrefix);
 		return;
 	}
 
+	update_status(WorkerDiagnosticState::starting, config, WorkerOwnership::none, "probing Worker health");
 	blog(LOG_INFO, "%s worker preflight host=%s port=%u user_data_dir=%s",
 	     kLogPrefix, to_utf8(config.endpoint.host).c_str(), config.endpoint.port,
 	     to_utf8(config.user_data_dir).c_str());
@@ -113,6 +145,7 @@ void WorkerProcessManager::start(WorkerLaunchConfig config)
 			std::lock_guard<std::mutex> lock(mutex_);
 			ownership_ = WorkerOwnership::reused_existing;
 		}
+		update_status(WorkerDiagnosticState::running, config, WorkerOwnership::reused_existing, {}, &preflight);
 		blog(LOG_INFO,
 		     "%s worker reused existing instance api_version=%s version=%s instance_id=%s pid=%s started_at=%s user_data_dir=%s",
 		     kLogPrefix, preflight.api_version.c_str(), preflight.version.c_str(),
@@ -123,6 +156,7 @@ void WorkerProcessManager::start(WorkerLaunchConfig config)
 	}
 
 	if (preflight.status != WorkerProbeStatus::unreachable) {
+		update_status(diagnostic_state_for_probe(preflight), config, WorkerOwnership::none, preflight.error, &preflight);
 		blog(LOG_WARNING,
 		     "%s worker launch blocked status=%d http=%lu error=%s api_version=%s version=%s instance_id=%s user_data_dir=%s",
 		     kLogPrefix, static_cast<int>(preflight.status), preflight.http_status,
@@ -132,11 +166,15 @@ void WorkerProcessManager::start(WorkerLaunchConfig config)
 	}
 
 	if (!spawn_worker(config)) {
+		update_status(WorkerDiagnosticState::config_error, config, WorkerOwnership::none, "Worker launch failed");
 		return;
 	}
+	update_status(WorkerDiagnosticState::starting, config, WorkerOwnership::spawned_by_plugin, "waiting for Worker readiness");
 
 	WorkerProbeResult ready_probe;
 	if (!wait_until_ready(config, ready_probe)) {
+		update_status(WorkerDiagnosticState::unhealthy, config, WorkerOwnership::spawned_by_plugin,
+			      "worker startup timeout", &ready_probe);
 		blog(LOG_WARNING, "%s worker startup timeout; terminating plugin-owned process", kLogPrefix);
 #ifdef _WIN32
 		std::lock_guard<std::mutex> lock(mutex_);
@@ -150,6 +188,7 @@ void WorkerProcessManager::start(WorkerLaunchConfig config)
 		return;
 	}
 
+	update_status(WorkerDiagnosticState::running, config, WorkerOwnership::spawned_by_plugin, {}, &ready_probe);
 	monitor_heartbeat(config, ready_probe);
 }
 
@@ -205,6 +244,8 @@ bool WorkerProcessManager::wait_until_ready(const WorkerLaunchConfig &config, Wo
 			     probe.started_at.c_str(), probe.user_data_dir.c_str());
 			return true;
 		}
+		ready_probe = probe;
+		update_status(diagnostic_state_for_probe(probe), config, current_ownership(), probe.error, &probe);
 		std::this_thread::sleep_for(std::chrono::milliseconds(250));
 	}
 
@@ -235,6 +276,11 @@ void WorkerProcessManager::monitor_heartbeat(const WorkerLaunchConfig &config, c
 			if (process_info_.hProcess) {
 				DWORD exit_code = 0;
 				if (GetExitCodeProcess(process_info_.hProcess, &exit_code) && exit_code != STILL_ACTIVE) {
+					status_.state = WorkerDiagnosticState::crashed;
+					status_.ownership = WorkerOwnership::spawned_by_plugin;
+					status_.endpoint = config.endpoint;
+					status_.user_data_dir = config.user_data_dir;
+					status_.error = "Worker exited with code " + std::to_string(exit_code);
 					blog(LOG_WARNING,
 					     "%s heartbeat crashed exit_code=%lu user_data_dir=%s instance_id=%s pid=%s started_at=%s",
 					     kLogPrefix, exit_code, to_utf8(config.user_data_dir).c_str(),
@@ -255,6 +301,7 @@ void WorkerProcessManager::monitor_heartbeat(const WorkerLaunchConfig &config, c
 			}
 			consecutive_failures = 0;
 			timeout_reported = false;
+			update_status(WorkerDiagnosticState::running, config, current_ownership(), {}, &probe);
 
 			if (!replacement_reported && identity_changed(baseline, probe)) {
 				replacement_reported = true;
@@ -268,6 +315,7 @@ void WorkerProcessManager::monitor_heartbeat(const WorkerLaunchConfig &config, c
 		}
 
 		++consecutive_failures;
+		update_status(WorkerDiagnosticState::unhealthy, config, current_ownership(), probe.error, &probe, consecutive_failures);
 		blog(LOG_WARNING,
 		     "%s heartbeat probe_failed failures=%u status=%d http=%lu error=%s user_data_dir=%s instance_id=%s pid=%s started_at=%s",
 		     kLogPrefix, consecutive_failures, static_cast<int>(probe.status), probe.http_status,
@@ -290,6 +338,34 @@ WorkerOwnership WorkerProcessManager::current_ownership() const
 	return ownership_;
 }
 
+void WorkerProcessManager::update_status(WorkerDiagnosticState state, const WorkerLaunchConfig &config,
+					 WorkerOwnership ownership, const std::string &error,
+					 const WorkerProbeResult *probe, unsigned int consecutive_failures)
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+	status_.state = state;
+	status_.ownership = ownership;
+	status_.endpoint = config.endpoint;
+	status_.user_data_dir = config.user_data_dir;
+	status_.error = error;
+	status_.consecutive_failures = consecutive_failures;
+	if (probe) {
+		status_.last_probe_summary = summarize_probe(*probe);
+		status_.http_status = probe->http_status;
+		status_.api_version = probe->api_version;
+		status_.version = probe->version;
+		status_.instance_id = probe->instance_id;
+		status_.pid = probe->pid;
+		status_.started_at = probe->started_at;
+	}
+}
+
+WorkerStatusSnapshot WorkerProcessManager::status_snapshot() const
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+	return status_;
+}
+
 void WorkerProcessManager::stop()
 {
 	stop_requested_ = true;
@@ -301,6 +377,9 @@ void WorkerProcessManager::stop()
 	if (ownership_ == WorkerOwnership::reused_existing) {
 		blog(LOG_INFO, "%s worker reused existing instance; not stopping foreign/manual process", kLogPrefix);
 		ownership_ = WorkerOwnership::none;
+		status_.state = WorkerDiagnosticState::not_started;
+		status_.ownership = WorkerOwnership::none;
+		status_.error = "Worker manager stopped; reused existing Worker left running";
 		return;
 	}
 
@@ -317,6 +396,10 @@ void WorkerProcessManager::stop()
 #endif
 
 	ownership_ = WorkerOwnership::none;
+	status_.state = WorkerDiagnosticState::not_started;
+	status_.ownership = WorkerOwnership::none;
+	status_.error = "Worker manager stopped";
+	status_.consecutive_failures = 0;
 }
 
 void WorkerProcessManager::close_process_handles()

--- a/app/plugin/src/worker-launcher.hpp
+++ b/app/plugin/src/worker-launcher.hpp
@@ -19,6 +19,17 @@ enum class WorkerOwnership {
 	reused_existing,
 };
 
+enum class WorkerDiagnosticState {
+	not_started,
+	starting,
+	running,
+	unhealthy,
+	config_error,
+	runtime_dir_error,
+	api_incompatible,
+	crashed,
+};
+
 struct WorkerLaunchConfig {
 	WorkerEndpoint endpoint;
 	std::wstring user_data_dir;
@@ -28,6 +39,22 @@ struct WorkerLaunchConfig {
 	unsigned int heartbeat_failure_threshold = 3;
 };
 
+struct WorkerStatusSnapshot {
+	WorkerDiagnosticState state = WorkerDiagnosticState::not_started;
+	WorkerOwnership ownership = WorkerOwnership::none;
+	WorkerEndpoint endpoint;
+	std::wstring user_data_dir;
+	std::string last_probe_summary;
+	std::string error;
+	std::string api_version;
+	std::string version;
+	std::string instance_id;
+	std::string pid;
+	std::string started_at;
+	unsigned long http_status = 0;
+	unsigned int consecutive_failures = 0;
+};
+
 class WorkerProcessManager {
 public:
 	WorkerProcessManager();
@@ -35,6 +62,7 @@ public:
 
 	void start_async(WorkerLaunchConfig config);
 	void stop();
+	WorkerStatusSnapshot status_snapshot() const;
 
 private:
 	void start(WorkerLaunchConfig config);
@@ -42,6 +70,9 @@ private:
 	bool wait_until_ready(const WorkerLaunchConfig &config, WorkerProbeResult &ready_probe);
 	void monitor_heartbeat(const WorkerLaunchConfig &config, const WorkerProbeResult &baseline);
 	WorkerOwnership current_ownership() const;
+	void update_status(WorkerDiagnosticState state, const WorkerLaunchConfig &config,
+			   WorkerOwnership ownership, const std::string &error,
+			   const WorkerProbeResult *probe = nullptr, unsigned int consecutive_failures = 0);
 	void close_process_handles();
 
 	LocalhostApiClient api_client_;
@@ -49,6 +80,7 @@ private:
 	std::thread worker_thread_;
 	std::atomic_bool stop_requested_{false};
 	WorkerOwnership ownership_ = WorkerOwnership::none;
+	WorkerStatusSnapshot status_;
 
 #ifdef _WIN32
 	PROCESS_INFORMATION process_info_{};

--- a/docs/architecture/v0.4-smoke.md
+++ b/docs/architecture/v0.4-smoke.md
@@ -31,6 +31,8 @@ This smoke is considered **passed** if all of the following are true:
 2. OBS launches and the plugin can be loaded without crashing OBS.
 3. The plugin produces a clear **startup** and **shutdown** lifecycle log entry.
 4. Logs are written under the canonical runtime log location (typically `user_data/logs/`).
+5. The status Dock opens and displays the Worker diagnostic state.
+6. A minimal settings save flow persists Plugin settings and restarts the Worker manager.
 
 If (2) fails (OBS crash / immediate unload), treat as a hard fail and stop.
 
@@ -46,7 +48,8 @@ Reference:
 - Confirm prerequisites are installed (documented in the plugin build instructions).
 - Build the plugin in a configuration intended for load testing (recommendation: Release).
 - Confirm the output artifact path to be used for loading in OBS.
-- Set `ODR_USER_DATA_DIR` to the runtime root used for this smoke run before starting OBS.
+- Prepare a runtime root for this smoke run.
+- Optionally set `ODR_USER_DATA_DIR` before first launch to seed the settings default.
 
 Build instructions:
 - `app/plugin/README.md`
@@ -56,22 +59,36 @@ Build instructions:
 - Start OBS.
 - Load the plugin (using the documented approach for the scaffold).
 - Confirm OBS does not crash and stays stable after the plugin is loaded.
+- Confirm the `OBS Duel Recorder` Dock is available.
 
-### C. Evidence collection (minimum)
+### C. Settings flow
+
+- Open `Tools > OBS Duel Recorder Settings` or the Dock `Settings` button.
+- Set `host`, `port`, and `user_data_dir`.
+- Save the dialog.
+- Confirm `%APPDATA%\obs-duel-recorder\plugin-settings.json` is written.
+- Confirm OBS logs show the settings save path and `apply=worker_restart`.
+
+### D. Evidence collection (minimum)
 
 Capture the minimal evidence:
 
 - OBS version and architecture (x64)
 - Plugin build command used
 - Plugin artifact path used for OBS loading
+- The persisted settings file path and relevant settings values
+- The Dock state shown (`not_started`, `starting`, `running`, `unhealthy`, `config_error`, `runtime_dir_error`, `api_incompatible`, or `crashed`)
+- The Dock endpoint, `user_data_dir`, logs path, ownership, detail, and recommended action fields
 - The log lines showing:
   - plugin startup
+  - dock registration
+  - settings save or settings load path
   - plugin shutdown
   - worker preflight or launch result
   - heartbeat baseline
   - heartbeat success, recovery, timeout, crash, or unexpected process-change evidence when observed
 - The runtime log directory path used (must not be under `app/` and must not be committed)
-- The resolved `ODR_USER_DATA_DIR`
+- The resolved `ODR_USER_DATA_DIR` or persisted `user_data_dir`
 - Whether the Worker was plugin-spawned or reused-existing
 
 ---

--- a/docs/release/v0.4-release-readiness.md
+++ b/docs/release/v0.4-release-readiness.md
@@ -38,7 +38,9 @@ Perform these checks on Windows with OBS installed:
 
 - [ ] OBS Plugin builds successfully on Windows (document toolchain prerequisites if needed).
 - [ ] Plugin loads in OBS without crashing.
-- [ ] Plugin exposes a Dock UI (even if minimal) for diagnostics / control.
+- [ ] Plugin exposes a status-first Dock UI for diagnostics.
+- [ ] Plugin settings can be saved to `%APPDATA%\obs-duel-recorder\plugin-settings.json`.
+- [ ] Saving settings restarts the Worker manager and records `apply=worker_restart` in logs.
 - [ ] Plugin can start the Worker process using the documented contract.
 - [ ] Plugin can stop the Worker process (or clearly reports why it cannot).
 - [ ] Plugin can detect Worker health via `GET /health` and surfaces status in the Dock UI.
@@ -46,7 +48,7 @@ Perform these checks on Windows with OBS installed:
   - [ ] existing `<repo>/user_data/` remains the default continuity root
   - [ ] a different configured runtime root does not trigger automatic migration
   - [ ] manual-action diagnostics are surfaced for ambiguous continuity cases
-  - [ ] resolved `ODR_USER_DATA_DIR` appears in logs / diagnostics / smoke notes
+  - [ ] resolved `ODR_USER_DATA_DIR` or persisted `user_data_dir` appears in logs / diagnostics / smoke notes
 - [ ] Heartbeat timeout behavior is documented and observable in logs / diagnostics (see `docs/architecture/worker-diagnostics.md` - Failure Evidence (minimum)).
 - [ ] Heartbeat monitoring documents rebind/baseline-reset semantics when the Worker process is replaced mid-session (planning input: #154).
 - [ ] Smoke notes record the concrete environment and evidence (see `docs/architecture/v0.4-smoke.md`).

--- a/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
+++ b/docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md
@@ -1,4 +1,4 @@
-# v0.4 OBS Plugin Skeleton — Acceptance Checklist
+# v0.4 OBS Plugin Skeleton - Acceptance Checklist
 
 This document defines the acceptance criteria for **v0.4 - OBS Plugin Skeleton** as described in:
 
@@ -24,6 +24,7 @@ v0.4 focuses on:
 - Queue Recovery System work reserved for v0.7+
 - Template Matching MVP work reserved for v0.8+
 - Upload/OAuth work reserved for v1.0+
+- Full Worker control UI in the Dock
 
 ## Terms
 
@@ -77,8 +78,13 @@ Current scaffold/build reference:
 
 ### F. Plugin Settings + Dock UI
 
-- [ ] A Plugin settings page exists for minimal configuration (host/port, user_data_dir, etc).
-- [ ] A Browser Dock UI exists and can display Worker status and key diagnostics.
+- [ ] A Plugin settings page exists for minimal configuration (`host`, `port`, `user_data_dir`).
+- [ ] Settings persistence location and format are documented.
+- [ ] Settings are persisted as JSON at `%APPDATA%\obs-duel-recorder\plugin-settings.json`.
+- [ ] Settings changes default to Worker manager restart; immediate apply is allowed only for explicitly safe future fields, and OBS restart is treated as an exception.
+- [ ] A status-first Dock UI exists and can display Worker status and key diagnostics.
+- [ ] The Dock includes at least diagnostic state, endpoint, `user_data_dir`, logs path, ownership, latest detail, recommended action, and a settings entry point.
+- [ ] The Dock remains status-first; full control UI is out of scope for v0.4.
 
 ### G. Localhost API Wrapper
 
@@ -94,10 +100,11 @@ Current scaffold/build reference:
   - [ ] plugin loads
   - [ ] worker launches
   - [ ] dock shows health
+  - [ ] settings save flow persists JSON and restarts the Worker manager
   - [ ] logs are produced under `user_data/logs/`
   - [ ] heartbeat baseline and timeout/failure evidence are recorded in logs / smoke notes
   - [ ] a second launch path reuses or rejects an existing singleton Worker instead of spawning another Worker for the same runtime root
-  - [ ] resolved `ODR_USER_DATA_DIR` is recorded in logs, diagnostics, and smoke notes
+  - [ ] resolved `ODR_USER_DATA_DIR` or persisted `user_data_dir` is recorded in logs, diagnostics, and smoke notes
   - [ ] plugin-spawned vs reused-existing Worker ownership is recorded in logs and smoke notes
 
 Reference procedure:


### PR DESCRIPTION
## Summary
- Adds a minimal persisted Plugin settings contract at `%APPDATA%\obs-duel-recorder\plugin-settings.json`.
- Adds a status-first OBS Dock with Worker diagnostic state, endpoint, user data, logs, ownership, detail, recommended action, and settings entry point.
- Wires settings save to Worker manager restart, matching the #122 admin scope decision.
- Exposes Worker status snapshots from the Worker manager without moving Worker/HTTP responsibilities into the UI.
- Updates v0.4 smoke, acceptance, release readiness, and plugin README docs.

## Scope
- Status-first Dock only; no full control UI.
- Uses Qt Widgets because OBS Frontend dock API accepts QWidget instances.
- Browser-engine/overlay UX remains out of scope for v0.4.

## Validation
- GitHub Actions run 26290749140: Docs validation succeeded.
- GitHub Actions run 26290749140: Worker unit tests succeeded.
- Local toolchain check: `where.exe cmake`, `where.exe cl`, and `where.exe qmake` did not find installed tools.

## Not run
- CMake/OBS plugin build smoke: this environment does not have `cmake`, Visual Studio C++ toolchain, OBS SDK/package files, or Qt SDK configured.
- Real OBS Dock/settings smoke: requires Windows OBS runtime.

Refs #110
Refs #122