### PR TITLE
test(plugin): add v0.4 smoke evidence collector

### DIFF
--- a/app/plugin/README.md
+++ b/app/plugin/README.md
@@ -158,6 +158,21 @@ For #119/#120/#121/#122/#123/#144, the minimum passing evidence is:
   - Worker ownership (`plugin-spawned` or `reused-existing`)
 - The Dock displays the Worker diagnostic state and settings entry point.
 
+After manual smoke, collect a redaction-ready report with:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts\collect_v0_4_plugin_smoke.ps1 `
+  -ObsPrefix "C:\Path\To\obs-studio-or-sdk" `
+  -QtPrefix "C:\Path\To\Qt\6.x.x\msvc2022_64" `
+  -UserDataDir "C:\Path\To\user_data" `
+  -ObsLogPath "$env:APPDATA\obs-studio\logs\<obs-log>.txt" `
+  -DockState "running" `
+  -SettingsFlow "saved host/port/user_data_dir; apply=worker_restart observed" `
+  -WorkerOwnership "plugin-spawned"
+```
+
+The script writes `build/plugin/v0.4-plugin-smoke-report.md` by default.
+
 ## Current Lifecycle Surface
 
 The scaffold registers an OBS Frontend API callback, logs lightweight lifecycle events, runs the initial Worker preflight/launch/heartbeat flow, and surfaces status-first diagnostics in a Dock.

--- a/docs/architecture/v0.4-smoke.md
+++ b/docs/architecture/v0.4-smoke.md
@@ -91,6 +91,25 @@ Capture the minimal evidence:
 - The resolved `ODR_USER_DATA_DIR` or persisted `user_data_dir`
 - Whether the Worker was plugin-spawned or reused-existing
 
+### E. Optional collector script
+
+After the manual smoke run, generate a redaction-ready Markdown report with:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts\collect_v0_4_plugin_smoke.ps1 `
+  -ObsPrefix "C:\Path\To\obs-studio-or-sdk" `
+  -QtPrefix "C:\Path\To\Qt\6.x.x\msvc2022_64" `
+  -UserDataDir "C:\Path\To\user_data" `
+  -ObsLogPath "$env:APPDATA\obs-studio\logs\<obs-log>.txt" `
+  -DockState "running" `
+  -SettingsFlow "saved host/port/user_data_dir; apply=worker_restart observed" `
+  -WorkerOwnership "plugin-spawned"
+```
+
+The script writes `build/plugin/v0.4-plugin-smoke-report.md` by default. Attach or paste the report into `#110` or the relevant child issue only after checking it for secrets and local paths that should be redacted.
+
+Use `-SkipBuild` only when the plugin build was performed separately and the script is being used to collect manual evidence.
+
 ---
 
 ## Notes / Handoff

--- a/docs/release/v0.4-release-readiness.md
+++ b/docs/release/v0.4-release-readiness.md
@@ -52,6 +52,7 @@ Perform these checks on Windows with OBS installed:
 - [ ] Heartbeat timeout behavior is documented and observable in logs / diagnostics (see `docs/architecture/worker-diagnostics.md` - Failure Evidence (minimum)).
 - [ ] Heartbeat monitoring documents rebind/baseline-reset semantics when the Worker process is replaced mid-session (planning input: #154).
 - [ ] Smoke notes record the concrete environment and evidence (see `docs/architecture/v0.4-smoke.md`).
+- [ ] A redaction-checked smoke report from `scripts/collect_v0_4_plugin_smoke.ps1` is posted to `#110` or linked from the relevant child issues.
 
 ## D. Release PR readiness
 

--- a/scripts/collect_v0_4_plugin_smoke.ps1
+++ b/scripts/collect_v0_4_plugin_smoke.ps1
@@ -1,0 +1,232 @@
+param(
+    [string]$ObsPrefix = "",
+    [string]$QtPrefix = "",
+    [string]$UserDataDir = "",
+    [string]$BuildDir = "",
+    [ValidateSet("Debug", "Release", "RelWithDebInfo")]
+    [string]$Configuration = "Release",
+    [string]$ObsLogPath = "",
+    [string]$WorkerLogDir = "",
+    [string]$ReportPath = "",
+    [string]$DockState = "",
+    [string]$SettingsFlow = "",
+    [string]$WorkerOwnership = "",
+    [switch]$SkipBuild
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Resolve-RepoPath {
+    param([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return ""
+    }
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $Path
+    }
+    return Join-Path (Get-Location) $Path
+}
+
+function Get-CommandPath {
+    param([string]$Name)
+    $command = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($null -eq $command) {
+        return ""
+    }
+    return $command.Source
+}
+
+function Invoke-LoggedCommand {
+    param(
+        [string]$FilePath,
+        [string[]]$Arguments
+    )
+    $display = "$FilePath $($Arguments -join ' ')"
+    Write-Host "Running: $display"
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code $LASTEXITCODE`: $display"
+    }
+}
+
+function Test-FileContains {
+    param(
+        [string]$Path,
+        [string]$Needle
+    )
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path -LiteralPath $Path)) {
+        return $false
+    }
+    return Select-String -LiteralPath $Path -SimpleMatch $Needle -Quiet
+}
+
+function Add-CheckLine {
+    param(
+        [System.Collections.Generic.List[string]]$Lines,
+        [string]$Label,
+        [bool]$Passed
+    )
+    $mark = if ($Passed) { "x" } else { " " }
+    $Lines.Add("- [$mark] $Label")
+}
+
+$repoRoot = Get-Location
+if ([string]::IsNullOrWhiteSpace($UserDataDir)) {
+    $UserDataDir = Join-Path $repoRoot "user_data"
+}
+if ([string]::IsNullOrWhiteSpace($BuildDir)) {
+    $BuildDir = Join-Path $repoRoot "build/plugin"
+}
+if ([string]::IsNullOrWhiteSpace($WorkerLogDir)) {
+    $WorkerLogDir = Join-Path $UserDataDir "logs"
+}
+if ([string]::IsNullOrWhiteSpace($ReportPath)) {
+    $ReportPath = Join-Path $BuildDir "v0.4-plugin-smoke-report.md"
+}
+
+$UserDataDir = Resolve-RepoPath $UserDataDir
+$BuildDir = Resolve-RepoPath $BuildDir
+$WorkerLogDir = Resolve-RepoPath $WorkerLogDir
+$ReportPath = Resolve-RepoPath $ReportPath
+
+$cmake = Get-CommandPath "cmake"
+$cl = Get-CommandPath "cl"
+$qmake = Get-CommandPath "qmake"
+$obs64 = Get-CommandPath "obs64"
+
+$configureSucceeded = $false
+$buildSucceeded = $false
+$artifactPath = Join-Path $BuildDir "$Configuration/obs-duel-recorder.dll"
+
+if (-not $SkipBuild) {
+    if ([string]::IsNullOrWhiteSpace($cmake)) {
+        throw "cmake was not found. Install CMake 3.24+ or rerun with -SkipBuild to collect manual evidence only."
+    }
+
+    $prefixes = New-Object System.Collections.Generic.List[string]
+    if (-not [string]::IsNullOrWhiteSpace($ObsPrefix)) {
+        $prefixes.Add($ObsPrefix)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($QtPrefix)) {
+        $prefixes.Add($QtPrefix)
+    }
+
+    $configureArgs = @(
+        "-S", "app/plugin",
+        "-B", $BuildDir,
+        "-G", "Visual Studio 17 2022",
+        "-A", "x64"
+    )
+    if ($prefixes.Count -gt 0) {
+        $configureArgs += "-DCMAKE_PREFIX_PATH=$($prefixes -join ';')"
+    }
+
+    Invoke-LoggedCommand -FilePath $cmake -Arguments $configureArgs
+    $configureSucceeded = $true
+
+    Invoke-LoggedCommand -FilePath $cmake -Arguments @("--build", $BuildDir, "--config", $Configuration)
+    $buildSucceeded = $true
+}
+
+$artifactExists = Test-Path -LiteralPath $artifactPath
+$settingsPath = Join-Path $env:APPDATA "obs-duel-recorder/plugin-settings.json"
+$settingsExists = Test-Path -LiteralPath $settingsPath
+
+$obsLogExists = -not [string]::IsNullOrWhiteSpace($ObsLogPath) -and (Test-Path -LiteralPath $ObsLogPath)
+$workerLogExists = Test-Path -LiteralPath $WorkerLogDir
+$workerLogFiles = @()
+if ($workerLogExists) {
+    $workerLogFiles = Get-ChildItem -LiteralPath $WorkerLogDir -Filter "*.log" -File -ErrorAction SilentlyContinue
+}
+
+$checks = New-Object System.Collections.Generic.List[string]
+Add-CheckLine $checks "CMake configure succeeded or build was skipped intentionally" ($configureSucceeded -or $SkipBuild)
+Add-CheckLine $checks "Plugin build succeeded or build was skipped intentionally" ($buildSucceeded -or $SkipBuild)
+Add-CheckLine $checks "Plugin artifact exists at $artifactPath" $artifactExists
+Add-CheckLine $checks "Settings file exists at $settingsPath" $settingsExists
+Add-CheckLine $checks "OBS log path was provided and exists" $obsLogExists
+Add-CheckLine $checks "Worker log directory exists at $WorkerLogDir" $workerLogExists
+Add-CheckLine $checks "OBS log contains plugin startup" (Test-FileContains $ObsLogPath "OBS Duel Recorder plugin startup")
+Add-CheckLine $checks "OBS log contains dock registration" (Test-FileContains $ObsLogPath "dock registered")
+Add-CheckLine $checks "OBS log contains settings save and worker restart evidence" (Test-FileContains $ObsLogPath "apply=worker_restart")
+Add-CheckLine $checks "OBS log contains worker preflight or launch evidence" (Test-FileContains $ObsLogPath "worker preflight")
+Add-CheckLine $checks "OBS log contains heartbeat baseline" (Test-FileContains $ObsLogPath "heartbeat baseline")
+Add-CheckLine $checks "OBS log contains plugin shutdown" (Test-FileContains $ObsLogPath "OBS Duel Recorder plugin shutdown")
+Add-CheckLine $checks "Dock state was recorded" (-not [string]::IsNullOrWhiteSpace($DockState))
+Add-CheckLine $checks "Settings flow result was recorded" (-not [string]::IsNullOrWhiteSpace($SettingsFlow))
+Add-CheckLine $checks "Worker ownership was recorded" (-not [string]::IsNullOrWhiteSpace($WorkerOwnership))
+
+$reportDir = Split-Path -Parent $ReportPath
+if (-not [string]::IsNullOrWhiteSpace($reportDir)) {
+    New-Item -ItemType Directory -Path $reportDir -Force | Out-Null
+}
+
+$lines = New-Object System.Collections.Generic.List[string]
+$lines.Add("# v0.4 Plugin Smoke Report")
+$lines.Add("")
+$lines.Add("Generated: $(Get-Date -Format o)")
+$lines.Add("")
+$lines.Add("## Environment")
+$lines.Add("")
+$lines.Add("- OS: $([System.Environment]::OSVersion.VersionString)")
+$lines.Add("- PowerShell: $($PSVersionTable.PSVersion)")
+$lines.Add("- Repository: $repoRoot")
+$lines.Add("- cmake: $cmake")
+$lines.Add("- cl: $cl")
+$lines.Add("- qmake: $qmake")
+$lines.Add("- obs64: $obs64")
+$lines.Add("- OBS prefix: $ObsPrefix")
+$lines.Add("- Qt prefix: $QtPrefix")
+$lines.Add("- User data dir: $UserDataDir")
+$lines.Add("- Worker log dir: $WorkerLogDir")
+$lines.Add("- OBS log path: $ObsLogPath")
+$lines.Add("")
+$lines.Add("## Build")
+$lines.Add("")
+$lines.Add("- Configuration: $Configuration")
+$lines.Add("- Build dir: $BuildDir")
+$lines.Add("- Artifact: $artifactPath")
+$lines.Add("- Configure succeeded: $configureSucceeded")
+$lines.Add("- Build succeeded: $buildSucceeded")
+$lines.Add("- Artifact exists: $artifactExists")
+$lines.Add("")
+$lines.Add("## Manual Observations")
+$lines.Add("")
+$lines.Add("- Dock state: $DockState")
+$lines.Add("- Settings flow: $SettingsFlow")
+$lines.Add("- Worker ownership: $WorkerOwnership")
+$lines.Add("")
+$lines.Add("## Evidence Checks")
+$lines.Add("")
+foreach ($check in $checks) {
+    $lines.Add($check)
+}
+$lines.Add("")
+$lines.Add("## Settings")
+$lines.Add("")
+$lines.Add("- Settings path: $settingsPath")
+$lines.Add("- Settings exists: $settingsExists")
+if ($settingsExists) {
+    $lines.Add("")
+    $lines.Add('```json')
+    $lines.Add((Get-Content -LiteralPath $settingsPath -Raw).Trim())
+    $lines.Add('```')
+}
+$lines.Add("")
+$lines.Add("## Worker Logs")
+$lines.Add("")
+if ($workerLogFiles.Count -eq 0) {
+    $lines.Add("- No Worker log files found.")
+} else {
+    foreach ($file in $workerLogFiles) {
+        $lines.Add("- $($file.FullName)")
+    }
+}
+$lines.Add("")
+$lines.Add("## Next Action")
+$lines.Add("")
+$lines.Add("Paste this report into #110 or the relevant child issue only after confirming no secrets or local-only paths need redaction.")
+
+Set-Content -LiteralPath $ReportPath -Value $lines -Encoding UTF8
+Write-Host "Wrote smoke report: $ReportPath"


### PR DESCRIPTION
## Summary
- Adds `scripts/collect_v0_4_plugin_smoke.ps1` to build or collect v0.4 OBS Plugin smoke evidence into Markdown.
- Updates the v0.4 smoke procedure, release readiness checklist, and plugin README with the collector command.
- Makes the remaining #110 blocker easier to verify consistently on a Windows + OBS environment.

## Validation
- Local syntax/execution check: `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\collect_v0_4_plugin_smoke.ps1 -SkipBuild -DockState not_started -SettingsFlow not_run -WorkerOwnership none` succeeded and wrote `build/plugin/v0.4-plugin-smoke-report.md`.
- GitHub Actions run 26291211095: Docs validation succeeded.
- GitHub Actions run 26291211095: Worker unit tests succeeded.

## Not run
- Full CMake/OBS plugin build smoke: this environment does not have `cmake`, Visual Studio C++ toolchain, OBS SDK/package files, or Qt SDK configured.
- Real OBS Dock/settings smoke: requires Windows OBS runtime.

Refs #110
Refs #119
Refs #121
Refs #122