### PR TITLE
ci(plugin): validate v0.4 smoke collector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,18 @@ jobs:
         shell: powershell
         run: python scripts/validate_jp_user_docs_coverage.py --root .
 
+      - name: Validate v0.4 plugin smoke collector
+        shell: powershell
+        run: |
+          $report = Join-Path $env:TEMP "v0.4-plugin-smoke-report.md"
+          powershell -NoProfile -ExecutionPolicy Bypass -File scripts/collect_v0_4_plugin_smoke.ps1 -SkipBuild -DockState not_started -SettingsFlow ci_skipbuild -WorkerOwnership none -ReportPath $report
+          if (-not (Test-Path -LiteralPath $report)) {
+            throw "Smoke report was not generated: $report"
+          }
+          Select-String -LiteralPath $report -SimpleMatch "# v0.4 Plugin Smoke Report" -Quiet | ForEach-Object {
+            if (-not $_) { throw "Smoke report heading was not found: $report" }
+          }
+
   worker-tests:
     name: Worker unit tests
     runs-on: windows-latest

--- a/scripts/collect_v0_4_plugin_smoke.ps1
+++ b/scripts/collect_v0_4_plugin_smoke.ps1
@@ -137,7 +137,7 @@ $obsLogExists = -not [string]::IsNullOrWhiteSpace($ObsLogPath) -and (Test-Path -
 $workerLogExists = Test-Path -LiteralPath $WorkerLogDir
 $workerLogFiles = @()
 if ($workerLogExists) {
-    $workerLogFiles = Get-ChildItem -LiteralPath $WorkerLogDir -Filter "*.log" -File -ErrorAction SilentlyContinue
+    $workerLogFiles = @(Get-ChildItem -LiteralPath $WorkerLogDir -Filter "*.log" -File -ErrorAction SilentlyContinue)
 }
 
 $checks = New-Object System.Collections.Generic.List[string]


### PR DESCRIPTION
## Summary
- Adds a CI docs-job step that runs `scripts/collect_v0_4_plugin_smoke.ps1` in `-SkipBuild` mode.
- Verifies the generated Markdown report exists and contains the expected heading.
- Keeps the #110 smoke evidence collector covered even before full Windows OBS smoke can run.

## Validation
- GitHub Actions run 26291514748: Docs validation succeeded, including `Validate v0.4 plugin smoke collector`.
- GitHub Actions run 26291514748: Worker unit tests succeeded.

## Not run
- Full CMake/OBS plugin build smoke: this environment does not have `cmake`, Visual Studio C++ toolchain, OBS SDK/package files, or Qt SDK configured.
- Real OBS Dock/settings smoke: requires Windows OBS runtime.

Refs #110
Refs #283