### PR TITLE
docs(v0.4): link OBS smoke evidence gate

### DIFF
--- a/docs/architecture/v0.4-smoke.md
+++ b/docs/architecture/v0.4-smoke.md
@@ -5,6 +5,7 @@ This document defines the **minimal manual smoke procedure** for v0.4 (**OBS Plu
 Goal:
 - Make the meaning of "plugin can be built and loaded in OBS" consistent across contributors.
 - Provide a stable handoff from `#119` (plugin scaffold) to v0.4 acceptance and release readiness.
+- Keep the final Windows OBS evidence gate explicit in `#285` before `#110` is closed.
 
 Non-goals:
 - Packaging / installer design
@@ -33,6 +34,7 @@ This smoke is considered **passed** if all of the following are true:
 4. Logs are written under the canonical runtime log location (typically `user_data/logs/`).
 5. The status Dock opens and displays the Worker diagnostic state.
 6. A minimal settings save flow persists Plugin settings and restarts the Worker manager.
+7. The redaction-checked smoke report is posted to `#285` and linked from `#110`.
 
 If (2) fails (OBS crash / immediate unload), treat as a hard fail and stop.
 
@@ -106,7 +108,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File scripts\collect_v0_4_plugin_
   -WorkerOwnership "plugin-spawned"
 ```
 
-The script writes `build/plugin/v0.4-plugin-smoke-report.md` by default. Attach or paste the report into `#110` or the relevant child issue only after checking it for secrets and local paths that should be redacted.
+The script writes `build/plugin/v0.4-plugin-smoke-report.md` by default. Attach or paste the report into `#285` only after checking it for secrets and local paths that should be redacted, then link the accepted evidence from `#110` and the relevant child issues.
 
 Use `-SkipBuild` only when the plugin build was performed separately and the script is being used to collect manual evidence.
 
@@ -117,6 +119,7 @@ Use `-SkipBuild` only when the plugin build was performed separately and the scr
 - This document is the canonical smoke procedure referenced from:
   - `docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md`
   - `docs/release/v0.4-release-readiness.md`
+- `#285` is the authoritative remaining evidence gate before closing `#119`, `#120`, `#121`, `#122`, `#123`, `#144`, or `#110`.
 - If contributors find gaps that block consistent verification, raise them in:
   - `#133` (smoke environment contract)
   - `#119` (plugin scaffold acceptance clarification)

--- a/docs/release/v0.4-release-readiness.md
+++ b/docs/release/v0.4-release-readiness.md
@@ -6,6 +6,10 @@ Scope:
 - Documentation and verification steps for **v0.4 - OBS Plugin Skeleton** readiness.
 - No implementation work is performed by this checklist.
 
+Quick links:
+- Version tracking issue: #110
+- Windows OBS smoke evidence gate: #285
+
 Non-goals:
 - Creating the tag in this document.
 - Designing roadmap semantics.
@@ -52,7 +56,7 @@ Perform these checks on Windows with OBS installed:
 - [ ] Heartbeat timeout behavior is documented and observable in logs / diagnostics (see `docs/architecture/worker-diagnostics.md` - Failure Evidence (minimum)).
 - [ ] Heartbeat monitoring documents rebind/baseline-reset semantics when the Worker process is replaced mid-session (planning input: #154).
 - [ ] Smoke notes record the concrete environment and evidence (see `docs/architecture/v0.4-smoke.md`).
-- [ ] A redaction-checked smoke report from `scripts/collect_v0_4_plugin_smoke.ps1` is posted to `#110` or linked from the relevant child issues.
+- [ ] A redaction-checked smoke report from `scripts/collect_v0_4_plugin_smoke.ps1` is posted to #285 and linked from #110 and the relevant child issues.
 
 ## D. Release PR readiness
 

--- a/scripts/collect_v0_4_plugin_smoke.ps1
+++ b/scripts/collect_v0_4_plugin_smoke.ps1
@@ -226,7 +226,7 @@ if ($workerLogFiles.Count -eq 0) {
 $lines.Add("")
 $lines.Add("## Next Action")
 $lines.Add("")
-$lines.Add("Paste this report into #110 or the relevant child issue only after confirming no secrets or local-only paths need redaction.")
+$lines.Add("Paste this report into #285, then link the accepted smoke evidence from #110 and the relevant child issues after confirming no secrets or local-only paths need redaction.")
 
 Set-Content -LiteralPath $ReportPath -Value $lines -Encoding UTF8
 Write-Host "Wrote smoke report: $ReportPath"


### PR DESCRIPTION
## Summary
- Directs v0.4 smoke report submission to #285, the explicit Windows OBS smoke evidence gate.
- Updates the manual smoke procedure and release readiness checklist to link #285 back to #110 and child issue closure.
- Updates the collector report's next action so smoke evidence is posted to #285 before being linked from tracking issues.

## Validation
- GitHub Actions run 26293836423: Docs validation succeeded, including `Validate v0.4 plugin smoke collector`.
- GitHub Actions run 26293836423: Worker unit tests succeeded.

## Not run
- Full Windows OBS smoke verification; tracked separately by #285.

Refs #110
Refs #285