### PR TITLE
Log plugin shutdown before OBS frontend cleanup

### DIFF
--- a/app/plugin/src/plugin-main.cpp
+++ b/app/plugin/src/plugin-main.cpp
@@ -51,10 +51,10 @@ bool obs_module_load(void)
 
 void obs_module_unload(void)
 {
+	blog(LOG_INFO, "%s plugin shutdown", kLogPrefix);
 	ui_controller.unregister_ui();
 	worker_manager.stop();
 	obs_frontend_remove_event_callback(frontend_event, nullptr);
-	blog(LOG_INFO, "%s plugin shutdown", kLogPrefix);
 }
 
 const char *obs_module_description(void)


### PR DESCRIPTION
## Summary
- move the plugin shutdown log to the start of `obs_module_unload`
- preserves the existing cleanup order after the log so smoke evidence records shutdown even when OBS frontend cleanup emits late shutdown warnings

## Verification
- Built plugin locally with OBS Studio 32.1.2 / Qt 6.8.3 / MSVC Build Tools.
- Ran Windows OBS portable smoke locally; OBS log contains plugin startup, dock registration, worker preflight/spawn/running, heartbeat baseline, settings save with `apply=worker_restart`, frontend exit, worker stop, and `OBS Duel Recorder plugin shutdown`.
- Generated smoke report: `build/plugin-manual3/v0.4-plugin-smoke-report.md` with all evidence checks passing.

Supports #285 and #110.