### PR TITLE
Record v0.4 release handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Major and minor release completions are tagged as `vMajor.Minor.Patch`. See [Rel
 ## Current Development
 
 Latest released version:
-- `v0.3.0` - SQLite Foundation
+- `v0.4.0` - OBS Plugin Skeleton
 
 Current development target:
-- `v0.4` - OBS Plugin Skeleton
-- Tracking issue: [#110](https://github.com/Tao-pyth/obs-duel-recorder/issues/110)
+- `v0.5` - Overlay Integration
+- Tracking issue: [#288](https://github.com/Tao-pyth/obs-duel-recorder/issues/288)
 
 Next roadmap target:
-- `v0.5` - Overlay Integration
+- `v0.6` - Recording State Management
 
 ---
 
@@ -51,12 +51,14 @@ Status note: This list includes current foundations and planned roadmap capabili
 Current released foundation:
 - SQLite runtime storage foundation
 - Worker runtime, health, logging, and migration foundations
+- OBS Plugin skeleton and Worker lifecycle management
 
 Planned roadmap capabilities:
-- Automatic duel recording (`v0.8`)
-- Match queue management (`v0.7`)
-- YouTube archive upload (`v1.0`)
 - OBS overlay integration (`v0.5`)
+- Recording state management (`v0.6`)
+- Match queue management (`v0.7`)
+- Automatic duel recording (`v0.8`)
+- YouTube archive upload (`v1.0`)
 - Match memo support (`v1.1`)
 - Upload retry / recovery support (`v0.7`)
 - GitHub Actions based packaging (`v1.4+`)
@@ -108,26 +110,28 @@ obs-duel-recorder/
 
 ### Latest Release
 
-- Version: `v0.3.0`
-- Scope: SQLite Foundation
+- Version: `v0.4.0`
+- Scope: OBS Plugin Skeleton
 - Status: released
-- Tag target: `5a31a55b76f5cd2d3e2a64cbf1d4cfed04642dd0`
-- Tracking issue: [#88](https://github.com/Tao-pyth/obs-duel-recorder/issues/88)
+- Intended tag target: `629f4f6d8d28d0d9dcca96381340a04077d2bb62`
+- Tracking issue: [#110](https://github.com/Tao-pyth/obs-duel-recorder/issues/110)
 - Release record: [docs/release-history.md](docs/release-history.md)
 
-### Completed in v0.3
+### Completed in v0.4
 
-- SQLite initialization under runtime data (`user_data/`)
-- Schema version management
-- Minimal migration framework
-- Initial tables (`matches`, `upload_queue`)
-- Restart-safe, idempotent startup behavior
-- Worker runtime and package metadata version aligned to `0.3.0`
+- Loadable OBS Plugin scaffold
+- OBS Frontend API startup/shutdown integration
+- Plugin-managed Worker launch and ownership tracking
+- Worker heartbeat monitoring via localhost `/health`
+- Status-first OBS Dock diagnostics
+- Persisted Plugin settings at `%APPDATA%\obs-duel-recorder\plugin-settings.json`
+- Localhost API wrapper diagnostics for runtime-root continuity and Worker identity
+- Windows OBS smoke evidence recorded in #285
 
-### Planned After v0.3
+### Planned After v0.4
 
-- `v0.4` - OBS Plugin skeleton and Worker lifecycle management
-- Later roadmap items include overlay integration, queue recovery, template matching, upload automation, packaging, and GitHub Pages documentation.
+- `v0.5` - Overlay Integration
+- Later roadmap items include recording state management, queue recovery, template matching, upload automation, packaging, and GitHub Pages documentation.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [v0.2 release readiness checklist](release/v0.2-release-readiness.md)
 - [v0.3 release readiness checklist](release/v0.3-release-readiness.md)
 - [v0.4 release readiness checklist](release/v0.4-release-readiness.md)
+- [v0.4 release summary](release/v0.4-release-summary.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
 - [v0.3 SQLite Foundation acceptance checklist](requirements/v0.3-sqlite-foundation-acceptance.md)
 - [v0.4 OBS Plugin Skeleton acceptance checklist](requirements/v0.4-obs-plugin-skeleton-acceptance.md)

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -48,3 +48,21 @@ The version tracking issue may contain the working release summary, but finalize
 - Version PRs: #112, #118
 - Next version tracking issue: #110
 - Status: released
+
+### v0.4.0 - OBS Plugin Skeleton
+
+- Version tracking issue: #110
+- Milestone: `v0.4` (not set)
+- Release readiness checklist: `docs/release/v0.4-release-readiness.md`
+- Tag: `v0.4.0` intended; tag creation tooling was unavailable in this run
+- Intended tag target: `629f4f6d8d28d0d9dcca96381340a04077d2bb62`
+- Release finalized at: `2026-05-23T00:24:03+09:00`
+- Release summary: `docs/release/v0.4-release-summary.md`
+- Major child issues: #119, #120, #121, #122, #123, #144
+- Smoke evidence gate: #285
+- Major PRs: #244, #245, #251, #282, #287
+- Validation PRs: #283, #284, #286
+- Documentation/design PRs: #128, #131, #132, #134, #136, #138, #143, #146, #150
+- Deferred items: Overlay Integration remains in #288; Recording State Management remains v0.6
+- Next version tracking issue: #288
+- Status: released; tag still needs maintainer/tooling creation at the intended target above

--- a/docs/release/v0.4-release-summary.md
+++ b/docs/release/v0.4-release-summary.md
@@ -1,0 +1,93 @@
+# v0.4.0 Release Summary - OBS Plugin Skeleton
+
+## Release Point
+
+- Version tracking issue: #110
+- Release readiness checklist: `docs/release/v0.4-release-readiness.md`
+- Tag: `v0.4.0` intended; tag creation tooling was unavailable in this run
+- Intended tag target: `629f4f6d8d28d0d9dcca96381340a04077d2bb62`
+- Finalized at: `2026-05-23T00:24:03+09:00`
+- Next version tracking issue: #288
+
+## Scope Completed
+
+v0.4 established the OBS Plugin Skeleton release boundary:
+
+- Loadable OBS Plugin scaffold.
+- OBS Frontend API startup/shutdown integration.
+- Plugin-managed Worker launch path.
+- Worker ownership tracking for plugin-spawned and reused-existing cases.
+- Worker heartbeat monitoring through localhost `/health`.
+- Status-first OBS Dock diagnostics.
+- Persisted Plugin settings flow.
+- Localhost API wrapper diagnostics for runtime-root continuity and Worker identity.
+- Smoke evidence collection script and CI validation for the smoke collector.
+
+## Required Child Issues
+
+- #119 OBS Plugin scaffold + Frontend API integration
+- #120 Plugin->Worker process launch contract
+- #121 Worker heartbeat monitoring + failure handling
+- #122 Plugin settings page + Browser Dock integration
+- #123 localhost API wrapper for plugin<->worker integration
+- #144 Track singleton Worker and instance_id diagnostic adoption
+
+All required child issues were closed after #285 accepted Windows OBS smoke evidence.
+
+## Smoke Evidence
+
+Authoritative smoke gate: #285
+
+Windows OBS smoke verification completed on 2026-05-23 JST with:
+
+- OBS Studio portable 32.1.2
+- Qt runtime/build 6.8.3
+- CMake 3.31.8
+- MSVC Build Tools 19.44.35227
+- Worker 0.3.0
+- Release x64 plugin DLL
+
+Accepted evidence included:
+
+- Plugin startup and shutdown logs.
+- Dock registration and visible status Dock evidence.
+- Worker launch, healthy `/health`, and heartbeat baseline.
+- Settings Save flow with `apply=worker_restart`.
+- Plugin-owned Worker stop/spawn/running sequence after settings save.
+- Runtime-root continuity via `ODR_USER_DATA_DIR` / `user_data_dir` diagnostics.
+- Plugin-owned Worker stop during OBS shutdown.
+
+## Major PRs
+
+- #244 feat(plugin): add minimal OBS plugin scaffold
+- #245 feat(plugin): launch Worker via localhost health
+- #251 feat(plugin): monitor Worker heartbeat via health
+- #282 feat(plugin): add status dock and persisted settings
+- #287 fix(plugin): log plugin shutdown before OBS frontend cleanup
+
+## Documentation And Validation PRs
+
+- #128 docs(v0.4): acceptance + release readiness checklists
+- #131 docs(v0.4): document plugin->worker launch contract
+- #132 docs(v0.4): clarify single-instance / port-collision handling
+- #134 docs(v0.4): add canonical manual smoke procedure
+- #136 feat(worker): add /version endpoint for plugin integration
+- #138 docs(v0.4): clarify compatibility surface for /health and /version
+- #143 feat(worker): expose instance_id for localhost correlation
+- #146 docs(v0.4): adopt singleton Worker instance model
+- #150 docs(v0.4): define minimal failure evidence bundle for heartbeat/timeout
+- #283 test(plugin): add v0.4 smoke evidence collector
+- #284 ci(plugin): validate v0.4 smoke collector
+- #286 docs(v0.4): link OBS smoke evidence gate
+
+## Deferred Items
+
+- Overlay Integration remains reserved for v0.5 and is tracked by #288.
+- Recording State Management remains reserved for v0.6.
+- Queue Recovery System remains reserved for v0.7.
+- Template Matching MVP remains reserved for v0.8.
+- Upload/OAuth remains reserved for v1.0+.
+
+## Notes
+
+The release target SHA records the implementation boundary. Because the available GitHub connector did not expose tag creation and local `gh` credentials were invalid, `v0.4.0` tag creation is recorded as a maintainer/tooling follow-up at the intended target SHA above.

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -39,6 +39,7 @@ Goals:
 - Version tracking issue: `#88` - `[v0.3] SQLite Foundation release tracking`
 - Acceptance checklist: `docs/requirements/v0.3-sqlite-foundation-acceptance.md`
 - Release readiness checklist: `docs/release/v0.3-release-readiness.md`
+- Release record: `docs/release-history.md`; detailed summary: `docs/release/v0.3-release-summary.md`
 - Requirements (relevant sections):
   - `docs/requirements/requirements.md` -> Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
@@ -49,9 +50,21 @@ Goals:
 - Version tracking issue: `#110` - `[v0.4] OBS Plugin Skeleton release tracking`
 - Acceptance checklist: `docs/requirements/v0.4-obs-plugin-skeleton-acceptance.md`
 - Release readiness checklist: `docs/release/v0.4-release-readiness.md`
+- Release record: `docs/release-history.md`; detailed summary: `docs/release/v0.4-release-summary.md`
 - Plugin scaffold/build notes: `app/plugin/README.md`
+- Smoke evidence gate: `#285`
 - Requirements (relevant sections):
   - `docs/requirements/requirements.md` -> Architecture / Platform / Runtime Rules
+  - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
+
+### v0.5 - Overlay Integration
+
+- Roadmap: `docs/roadmap.md` -> **v0.5 - Overlay Integration**
+- Version tracking issue: `#288` - `[v0.5] Overlay Integration release tracking`
+- Acceptance checklist: TBD
+- Release readiness checklist: TBD
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` -> Overlay Rules / Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
 ---
@@ -93,3 +106,4 @@ The version tracking issue itself is not an implementation work item.
 - Refs #72
 - Refs #88
 - Refs #110
+- Refs #288


### PR DESCRIPTION
## Summary
- record the v0.4 OBS Plugin Skeleton release outcome in release history and a dedicated release summary
- update README and traceability for the v0.5 handoff to #288
- document the intended v0.4.0 tag target because available tooling cannot create the tag in this run

## Verification
- Documentation-only change; CI docs validation should cover links.

Closes release-record requirements for #110.