### PR TITLE
Define v0.5 overlay acceptance and readiness

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,10 +13,12 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [v0.2 release readiness checklist](release/v0.2-release-readiness.md)
 - [v0.3 release readiness checklist](release/v0.3-release-readiness.md)
 - [v0.4 release readiness checklist](release/v0.4-release-readiness.md)
+- [v0.5 release readiness checklist](release/v0.5-release-readiness.md)
 - [v0.4 release summary](release/v0.4-release-summary.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
 - [v0.3 SQLite Foundation acceptance checklist](requirements/v0.3-sqlite-foundation-acceptance.md)
 - [v0.4 OBS Plugin Skeleton acceptance checklist](requirements/v0.4-obs-plugin-skeleton-acceptance.md)
+- [v0.5 Overlay Integration acceptance checklist](requirements/v0.5-overlay-integration-acceptance.md)
 
 ## Architecture
 
@@ -26,6 +28,7 @@ Architecture documents describe technical behavior and responsibility boundaries
 - [Database design](architecture/db.md)
 - [Queue design](architecture/queue.md)
 - [Upload flow](architecture/upload.md)
+- [v0.5 OBS overlay smoke procedure](architecture/v0.5-overlay-smoke.md)
 
 ## Worker (Developer)
 

--- a/docs/architecture/v0.5-overlay-smoke.md
+++ b/docs/architecture/v0.5-overlay-smoke.md
@@ -1,0 +1,136 @@
+# v0.5 OBS Overlay Smoke Procedure
+
+This document defines the minimal manual smoke procedure for v0.5 Overlay Integration.
+
+Tracking issue: #288
+Smoke evidence issue: #296
+
+## Preconditions
+
+Use a real Windows OBS runtime. Record the exact environment before posting evidence:
+
+- tested commit SHA on `main`
+- Windows version
+- OBS Studio version and architecture
+- CMake version
+- Visual Studio C++ toolchain version
+- Qt version used to build the plugin
+- Worker package version
+- runtime root / `ODR_USER_DATA_DIR`
+
+Do not commit logs, screenshots, videos, databases, runtime config, secrets, or generated media.
+
+## Build And Load
+
+1. Build the Plugin in Release x64.
+2. Install or copy the Plugin artifact into the OBS plugin directory used for smoke.
+3. Launch OBS.
+4. Confirm OBS logs include Plugin startup.
+5. Confirm the v0.4 Worker launch/heartbeat baseline still works.
+
+Minimum evidence:
+
+- Plugin artifact path
+- OBS log path
+- `OBS Duel Recorder plugin startup`
+- Worker preflight or launch log
+- heartbeat baseline log
+
+## Overlay Source Setup
+
+Verify the fixed Text Source behavior defined by the v0.5 source ownership contract:
+
+1. Start with a clean OBS scene or a known smoke scene collection.
+2. Trigger Plugin source setup, either automatically or through the documented settings/action flow.
+3. Confirm each implemented overlay source exists:
+   - deck name
+   - sequence number
+   - result
+   - opponent deck
+   - recording-state display
+4. For fields intentionally deferred, record the linked follow-up issue.
+
+Minimum evidence:
+
+- source names or stable identifiers
+- whether each source was created or reused
+- any missing/duplicate/unsupported source diagnostics
+
+## Overlay Update Flow
+
+Exercise the overlay update API or equivalent v0.5 update boundary:
+
+1. Send or trigger a sample overlay state:
+   - deck name: `Sample Deck`
+   - sequence number: `001`
+   - result: `unknown`
+   - opponent deck: `Unknown Opponent`
+   - recording state: `idle`
+2. Confirm the implemented Text Sources show the expected values.
+3. Send or trigger a second sample overlay state:
+   - deck name: `Second Deck`
+   - sequence number: `002`
+   - result: `win`
+   - opponent deck: `Sample Opponent`
+   - recording state: `recording`
+4. Confirm the implemented Text Sources update without restarting OBS.
+
+Minimum evidence:
+
+- request or trigger used for the update
+- log lines or diagnostics for successful update
+- observed Text Source values
+- any deferred fields and their follow-up issues
+
+## Settings Flow
+
+Verify overlay settings and template/default behavior:
+
+1. Open Plugin settings.
+2. Confirm overlay settings path and persisted shape are documented.
+3. Change a safe overlay setting or default value.
+4. Save settings.
+5. Confirm the setting is persisted and subsequent overlay updates use the new behavior.
+
+Minimum evidence:
+
+- settings file path
+- redacted settings excerpt
+- log line or diagnostic showing settings save/apply behavior
+
+## Negative / Diagnostic Checks
+
+Exercise at least one diagnostic scenario when practical:
+
+- missing Text Source
+- duplicate Text Source
+- unsupported source type
+- invalid overlay update payload
+- empty/unknown overlay values
+
+Expected result:
+
+- OBS does not crash.
+- Plugin/Worker reports an actionable diagnostic.
+- The diagnostic distinguishes overlay failure from Worker health failure.
+
+If a diagnostic scenario cannot be exercised in the smoke environment, record why and create or link a follow-up issue.
+
+## Report
+
+Post a redaction-checked report to #296.
+
+The report should include:
+
+- environment
+- tested commit SHA
+- build result
+- OBS load result
+- Worker health/heartbeat result
+- source setup result
+- overlay update result
+- settings result
+- diagnostic/negative-path result
+- deferred items and follow-up issues
+
+After #296 evidence is accepted, link it from #288 and the relevant child issues before closing them.

--- a/docs/release/v0.5-release-readiness.md
+++ b/docs/release/v0.5-release-readiness.md
@@ -1,0 +1,74 @@
+# v0.5 Release Readiness Checklist
+
+This checklist helps contributors prepare a **v0.5.0** release for OBS Duel Recorder.
+
+Scope:
+- Documentation and verification steps for **v0.5 - Overlay Integration** readiness.
+- No implementation work is performed by this checklist.
+
+Quick links:
+- Version tracking issue: #288
+- Acceptance checklist: `docs/requirements/v0.5-overlay-integration-acceptance.md`
+- Windows OBS overlay smoke evidence gate: #296
+
+Non-goals:
+- Creating the tag in this document.
+- Designing roadmap semantics.
+
+---
+
+## A. Milestone Readiness
+
+- [ ] Required v0.5 child issues are closed or explicitly deferred with a clear note.
+- [ ] Any deferred issues have a target version or follow-up issue.
+- [ ] Version tracking issue #288 reflects final child issue state.
+- [ ] Open v0.5 PRs are merged or explicitly deferred.
+
+## B. Documentation Readiness
+
+- [ ] Canonical docs are up to date:
+  - [ ] `docs/roadmap.md`
+  - [ ] `docs/requirements/requirements.md`
+  - [ ] `docs/traceability.md`
+  - [ ] `docs/requirements/v0.5-overlay-integration-acceptance.md`
+  - [ ] `docs/architecture/v0.5-overlay-smoke.md`
+  - [ ] v0.5 overlay architecture/source ownership document, if separate from the smoke procedure
+- [ ] README current development and latest release sections are ready for the release handoff.
+- [ ] Release history update is prepared.
+
+## C. Verification - Windows OBS Overlay Smoke
+
+Perform these checks on Windows with OBS installed or portable OBS available:
+
+- [ ] Plugin builds successfully on Windows.
+- [ ] Plugin loads in OBS without crashing.
+- [ ] Existing v0.4 Worker launch and heartbeat behavior still works.
+- [ ] Overlay settings can be loaded and saved.
+- [ ] Fixed Text Sources can be created or reused according to the v0.5 contract.
+- [ ] Deck name overlay update is visible in OBS.
+- [ ] Sequence number overlay update is visible in OBS.
+- [ ] Result overlay update is visible in OBS, or a documented deferral is linked.
+- [ ] Opponent deck overlay update is visible in OBS, or a documented deferral is linked.
+- [ ] Recording-state display is visible in OBS, or a documented deferral is linked.
+- [ ] Invalid or missing source cases produce actionable diagnostics and do not crash OBS.
+- [ ] Smoke notes record the concrete environment and evidence.
+- [ ] A redaction-checked smoke report is posted to #296 and linked from #288 and the relevant child issues.
+
+## D. Release PR Readiness
+
+- [ ] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
+- [ ] Release PR updates persistent release docs.
+- [ ] Release PR is merged into `main`.
+- [ ] The merge commit SHA on `main` is recorded for tagging.
+
+## E. Tagging After Merge
+
+- [ ] Create tag `v0.5.0` pointing to the release merge commit SHA on `main`.
+- [ ] Do not move or overwrite existing tags.
+- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #288 and release docs.
+
+## F. Handoff
+
+- [ ] Next version tracking issue is created from `docs/roadmap.md`.
+- [ ] Next version tracking issue is linked from #288.
+- [ ] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/requirements/v0.5-overlay-integration-acceptance.md
+++ b/docs/requirements/v0.5-overlay-integration-acceptance.md
@@ -1,0 +1,105 @@
+# v0.5 Overlay Integration - Acceptance Checklist
+
+This document defines the acceptance criteria for **v0.5 - Overlay Integration** as described in:
+
+- `docs/roadmap.md`
+- `docs/requirements/requirements.md`
+- #288
+
+## Scope
+
+v0.5 focuses on OBS overlay control:
+
+- fixed OBS Text Source management
+- deck name overlay
+- sequence number overlay
+- overlay template/settings defaults
+- overlay update API between Worker and Plugin
+- result and opponent deck overlay fields from the stable overlay requirement set
+- recording-state display boundary without taking ownership of the v0.6 recording state machine
+
+## Non-goals
+
+- Recording State Management implementation, except for display-only overlay state.
+- Queue Recovery System work reserved for v0.7.
+- Template Matching MVP work reserved for v0.8.
+- Upload/OAuth work reserved for v1.0+.
+- Full visual template designer.
+- Shipping game assets or generated runtime media.
+
+## Terms
+
+- **Overlay source**: an OBS Text Source owned or reused by the Plugin for a fixed overlay field.
+- **Overlay state**: the current text values to display in the overlay sources.
+- **Template setting**: persisted formatting/default text applied before a value is written to OBS.
+- **Recording-state display**: a display-only value such as `idle`, `recording`, or `unknown`; the authoritative state machine remains v0.6 scope.
+
+---
+
+## Acceptance Checklist
+
+### A. Text Source Ownership And Naming
+
+- [ ] A canonical contract defines the fixed Text Source names or stable identifiers for each v0.5 field.
+- [ ] The contract covers deck name, sequence number, result, opponent deck, and recording-state display.
+- [ ] The Plugin behavior for missing sources is defined: create, reuse, or report a diagnostic.
+- [ ] The Plugin behavior for duplicated, renamed, unsupported, or incompatible sources is defined.
+- [ ] Source ownership rules avoid deleting or unexpectedly overwriting user-created unrelated OBS sources.
+
+### B. Overlay Settings
+
+- [ ] Overlay settings are persisted with a documented location and JSON shape.
+- [ ] Defaults are documented for all v0.5 overlay fields.
+- [ ] Template/default behavior is deterministic for empty or unknown values.
+- [ ] Settings changes have a documented apply boundary and do not require OBS restart unless explicitly stated.
+- [ ] Invalid settings surface actionable diagnostics without crashing OBS.
+
+### C. Overlay Update API
+
+- [ ] Worker and Plugin have a documented update boundary for overlay state.
+- [ ] Overlay update payloads include deck name, sequence number, result, opponent deck, and recording-state display where implemented.
+- [ ] Invalid payloads are rejected or ignored safely with diagnostics.
+- [ ] API compatibility with existing `/health` and `/version` behavior is preserved.
+- [ ] The update path is testable without requiring external services.
+
+### D. OBS Text Source Integration
+
+- [ ] Plugin can find or create the configured fixed Text Sources in OBS.
+- [ ] Plugin can update Text Source text values without crashing OBS.
+- [ ] Deck name updates are visible in OBS.
+- [ ] Sequence number updates are visible in OBS.
+- [ ] Result updates are visible in OBS, or explicitly deferred with a linked follow-up.
+- [ ] Opponent deck updates are visible in OBS, or explicitly deferred with a linked follow-up.
+- [ ] Recording-state display is visible in OBS as display-only state, or explicitly deferred with a linked follow-up.
+
+### E. Diagnostics And Dock Surface
+
+- [ ] Overlay source state is observable through logs and/or Dock diagnostics.
+- [ ] Source creation/reuse/update failures include enough evidence for manual diagnosis.
+- [ ] Diagnostics distinguish Worker health failures from overlay source failures.
+- [ ] The existing status-first Dock remains usable and is not replaced by a full control UI.
+
+### F. Recording-State Boundary
+
+- [ ] v0.5 clearly documents what recording-state display values mean.
+- [ ] v0.5 does not implement the v0.6 recording lifecycle state machine.
+- [ ] If recording-state display is deferred, the deferral target is linked from #288 and the release summary.
+
+### G. Developer Verification
+
+- [ ] A v0.5 smoke procedure exists.
+- [ ] Smoke evidence can prove OBS load, source creation/reuse, and overlay updates.
+- [ ] Smoke evidence records the tested commit SHA on `main`.
+- [ ] Smoke evidence is redaction-checked before being posted to the tracking issue.
+- [ ] CI covers docs links and Worker/API tests relevant to the implemented contract.
+
+## References
+
+- #288
+- #290
+- #291
+- #292
+- #293
+- #294
+- #295
+- #296

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -61,8 +61,10 @@ Goals:
 
 - Roadmap: `docs/roadmap.md` -> **v0.5 - Overlay Integration**
 - Version tracking issue: `#288` - `[v0.5] Overlay Integration release tracking`
-- Acceptance checklist: TBD
-- Release readiness checklist: TBD
+- Acceptance checklist: `docs/requirements/v0.5-overlay-integration-acceptance.md`
+- Release readiness checklist: `docs/release/v0.5-release-readiness.md`
+- Smoke procedure: `docs/architecture/v0.5-overlay-smoke.md`
+- Smoke evidence gate: `#296`
 - Requirements (relevant sections):
   - `docs/requirements/requirements.md` -> Overlay Rules / Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
@@ -107,3 +109,4 @@ The version tracking issue itself is not an implementation work item.
 - Refs #88
 - Refs #110
 - Refs #288
+- Refs #296


### PR DESCRIPTION
## Summary
- add v0.5 Overlay Integration acceptance checklist
- add v0.5 release readiness checklist
- add Windows OBS overlay smoke procedure
- link v0.5 docs from docs index and traceability

## Verification
- Documentation-only change; CI docs validation should cover links.

Supports #288 and closes #290.