### PR TITLE
Implement v0.5 overlay source management

### DIFF
--- a/app/plugin/CMakeLists.txt
+++ b/app/plugin/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(obs-frontend-api REQUIRED)
 find_package(Qt6 REQUIRED COMPONENTS Widgets)
 
 add_library(obs-duel-recorder MODULE
+  src/overlay-sources.cpp
   src/plugin-main.cpp
   src/plugin-settings.cpp
   src/plugin-ui.cpp

--- a/app/plugin/README.md
+++ b/app/plugin/README.md
@@ -18,9 +18,9 @@ The Plugin must not:
 - directly manipulate SQLite
 - directly upload to YouTube
 
-## Current v0.4 Scaffold
+## Current v0.5 Overlay Integration
 
-The current scaffold is intentionally minimal for #119/#120/#121/#122/#123/#144:
+The current scaffold keeps the v0.4 Worker lifecycle surface and adds the first v0.5 overlay source-management layer:
 
 - Build a loadable OBS module.
 - Register minimal OBS Frontend API lifecycle hooks.
@@ -30,6 +30,9 @@ The current scaffold is intentionally minimal for #119/#120/#121/#122/#123/#144:
 - Reuse a healthy singleton Worker for the same `ODR_USER_DATA_DIR`.
 - Monitor Worker heartbeat through `GET /health`.
 - Register a status-first OBS Dock for Worker diagnostics.
+- Load additive `overlay` settings with v0.5 defaults.
+- Find or create the fixed OBS Text Sources for deck name, sequence number, result, opponent deck, and recording state display.
+- Log stable overlay diagnostics for missing, duplicated, unsupported, unavailable, or failed source operations.
 
 Current non-goals:
 - Full control UI.
@@ -77,11 +80,30 @@ Current keys:
   "host": "127.0.0.1",
   "port": 8787,
   "user_data_dir": "C:/path/to/user_data",
-  "restart_worker_on_change": true
+  "restart_worker_on_change": true,
+  "overlay": {
+    "enabled": true,
+    "auto_create_sources": true,
+    "sources": {
+      "deck_name": "ODR Deck Name",
+      "sequence_number": "ODR Sequence",
+      "result": "ODR Result",
+      "opponent_deck": "ODR Opponent Deck",
+      "recording_state": "ODR Recording State"
+    },
+    "defaults": {
+      "deck_name": "Deck: -",
+      "sequence_number": "#---",
+      "result": "Result: unknown",
+      "opponent_deck": "Opponent: unknown",
+      "recording_state": "Idle"
+    }
+  }
 }
 ```
 
 `ODR_USER_DATA_DIR` remains a compatibility fallback for initial defaults. Once the settings file is saved, `user_data_dir` in the JSON file is the Plugin launch input.
+Missing `overlay` settings are loaded with defaults so existing v0.4 settings files remain valid.
 
 Settings flow:
 - Open `Tools > OBS Duel Recorder Settings` or the `Settings` button in the Dock.
@@ -89,7 +111,24 @@ Settings flow:
 - Save the dialog.
 - The Plugin persists the JSON file and restarts the Worker manager with the saved settings.
 
-v0.4 treats settings changes conservatively: saving settings restarts the Worker manager. Immediate apply is reserved for explicitly safe future fields. OBS restart is an exception path, not the default.
+v0.5 treats settings changes conservatively: saving settings restarts the Worker manager and re-runs overlay source management. OBS restart is an exception path, not the default.
+
+## Overlay Text Sources
+
+On OBS frontend ready and after settings are saved, the Plugin checks the configured overlay sources.
+
+Default source names:
+- `ODR Deck Name`
+- `ODR Sequence`
+- `ODR Result`
+- `ODR Opponent Deck`
+- `ODR Recording State`
+
+Behavior:
+- Existing supported OBS Text Sources are reused.
+- Missing sources are created in the current scene when `overlay.auto_create_sources` is true.
+- Unsupported, duplicate, unavailable, and failed operations are logged with stable diagnostic names from `docs/architecture/overlay.md`.
+- The Plugin does not delete or replace unrelated user-created sources.
 
 ## Status Dock
 

--- a/app/plugin/src/overlay-sources.cpp
+++ b/app/plugin/src/overlay-sources.cpp
@@ -1,0 +1,222 @@
+#include "overlay-sources.hpp"
+
+#include <obs-frontend-api.h>
+#include <obs-module.h>
+
+#include <array>
+#include <cstring>
+#include <string>
+
+namespace odr::plugin {
+namespace {
+
+constexpr const char *kLogPrefix = "OBS Duel Recorder";
+
+struct OverlayField {
+	const char *key;
+	OverlayFieldSettings settings;
+};
+
+struct SourceNameCount {
+	std::string name;
+	size_t count = 0;
+};
+
+bool enum_source_name_count(void *param, obs_source_t *source)
+{
+	auto *context = static_cast<SourceNameCount *>(param);
+	const char *name = obs_source_get_name(source);
+	if (name && context->name == name) {
+		++context->count;
+	}
+	return true;
+}
+
+bool starts_with(const char *value, const char *prefix)
+{
+	return value && std::strncmp(value, prefix, std::strlen(prefix)) == 0;
+}
+
+bool is_supported_text_source_id(const char *id)
+{
+	return starts_with(id, "text_gdiplus") || starts_with(id, "text_ft2_source");
+}
+
+bool is_supported_text_source(obs_source_t *source)
+{
+	const char *id = obs_source_get_id(source);
+	const char *unversioned_id = obs_source_get_unversioned_id(source);
+	return is_supported_text_source_id(id) || is_supported_text_source_id(unversioned_id);
+}
+
+std::string find_available_text_source_kind()
+{
+	const char *id = nullptr;
+	const char *unversioned_id = nullptr;
+	for (size_t index = 0; obs_enum_input_types2(index, &id, &unversioned_id); ++index) {
+		if (is_supported_text_source_id(id)) {
+			return id;
+		}
+		if (is_supported_text_source_id(unversioned_id) && id) {
+			return id;
+		}
+	}
+	for (size_t index = 0; obs_enum_input_types(index, &id); ++index) {
+		if (is_supported_text_source_id(id)) {
+			return id;
+		}
+	}
+	return {};
+}
+
+void add_diagnostic(OverlaySourceEnsureResult &result, const char *code, const OverlayField &field, const char *action,
+		    const char *reason)
+{
+	result.success = false;
+	result.diagnostics.push_back(
+		OverlaySourceDiagnostic{code, field.key, field.settings.source_name, action, reason});
+}
+
+bool add_to_current_scene(obs_source_t *source)
+{
+	obs_source_t *scene_source = obs_frontend_get_current_scene();
+	if (!scene_source) {
+		return false;
+	}
+	obs_scene_t *scene = obs_scene_from_source(scene_source);
+	if (!scene) {
+		obs_source_release(scene_source);
+		return false;
+	}
+	obs_sceneitem_t *item = obs_scene_add(scene, source);
+	if (item) {
+		obs_sceneitem_release(item);
+	}
+	obs_source_release(scene_source);
+	return item != nullptr;
+}
+
+void create_source(OverlaySourceEnsureResult &result, const OverlayField &field, const std::string &source_kind)
+{
+	obs_data_t *data = obs_data_create();
+	obs_data_set_string(data, "text", field.settings.default_text.c_str());
+	obs_source_t *source = obs_source_create(source_kind.c_str(), field.settings.source_name.c_str(), data, nullptr);
+	obs_data_release(data);
+
+	if (!source) {
+		add_diagnostic(result, "overlay_update_failed", field, "create", "obs_source_create_failed");
+		return;
+	}
+	if (!add_to_current_scene(source)) {
+		obs_source_release(source);
+		add_diagnostic(result, "overlay_update_failed", field, "create", "current_scene_add_failed");
+		return;
+	}
+
+	blog(LOG_INFO, "%s overlay source ready field=%s source=%s action=create kind=%s", kLogPrefix, field.key,
+	     field.settings.source_name.c_str(), source_kind.c_str());
+	obs_source_release(source);
+}
+
+void ensure_field(OverlaySourceEnsureResult &result, const OverlayField &field, bool auto_create_sources)
+{
+	SourceNameCount count{field.settings.source_name};
+	obs_enum_sources(enum_source_name_count, &count);
+	if (count.count > 1) {
+		add_diagnostic(result, "overlay_source_duplicate", field, "skip", "duplicate_source_name");
+		return;
+	}
+
+	obs_source_t *source = obs_get_source_by_name(field.settings.source_name.c_str());
+	if (source) {
+		const bool supported = is_supported_text_source(source);
+		const char *id = obs_source_get_id(source);
+		if (supported) {
+			blog(LOG_INFO, "%s overlay source ready field=%s source=%s action=reuse kind=%s", kLogPrefix,
+			     field.key, field.settings.source_name.c_str(), id ? id : "unknown");
+		} else {
+			add_diagnostic(result, "overlay_source_unsupported", field, "skip",
+				       id ? id : "unknown_source_kind");
+		}
+		obs_source_release(source);
+		return;
+	}
+
+	if (!auto_create_sources) {
+		add_diagnostic(result, "overlay_source_missing", field, "skip", "source_not_found");
+	}
+}
+
+std::array<OverlayField, 5> fields_from_settings(const OverlaySettings &settings)
+{
+	return {{{"deck_name", settings.deck_name},
+		 {"sequence_number", settings.sequence_number},
+		 {"result", settings.result},
+		 {"opponent_deck", settings.opponent_deck},
+		 {"recording_state", settings.recording_state}}};
+}
+
+} // namespace
+
+OverlaySourceEnsureResult ensure_overlay_text_sources(const OverlaySettings &settings)
+{
+	OverlaySourceEnsureResult result;
+	if (!settings.enabled) {
+		blog(LOG_INFO, "%s overlay sources skipped reason=disabled", kLogPrefix);
+		return result;
+	}
+
+	const std::array<OverlayField, 5> fields = fields_from_settings(settings);
+	for (const OverlayField &field : fields) {
+		if (field.settings.source_name.empty()) {
+			add_diagnostic(result, "overlay_settings_invalid", field, "skip", "empty_source_name");
+			continue;
+		}
+		ensure_field(result, field, settings.auto_create_sources);
+	}
+
+	if (!settings.auto_create_sources) {
+		return result;
+	}
+
+	const std::string source_kind = find_available_text_source_kind();
+	if (source_kind.empty()) {
+		for (const OverlayField &field : fields) {
+			if (field.settings.source_name.empty()) {
+				continue;
+			}
+			obs_source_t *source = obs_get_source_by_name(field.settings.source_name.c_str());
+			if (!source) {
+				add_diagnostic(result, "overlay_text_source_unavailable", field, "create",
+					       "text_source_kind_not_found");
+			} else {
+				obs_source_release(source);
+			}
+		}
+		return result;
+	}
+
+	for (const OverlayField &field : fields) {
+		if (field.settings.source_name.empty()) {
+			continue;
+		}
+		obs_source_t *source = obs_get_source_by_name(field.settings.source_name.c_str());
+		if (source) {
+			obs_source_release(source);
+			continue;
+		}
+		create_source(result, field, source_kind);
+	}
+	return result;
+}
+
+void log_overlay_source_result(const OverlaySourceEnsureResult &result)
+{
+	for (const OverlaySourceDiagnostic &diagnostic : result.diagnostics) {
+		blog(LOG_WARNING, "%s overlay diagnostic=%s field=%s source=%s action=%s reason=%s", kLogPrefix,
+		     diagnostic.code.c_str(), diagnostic.field.c_str(), diagnostic.source_name.c_str(),
+		     diagnostic.action.c_str(), diagnostic.reason.c_str());
+	}
+}
+
+} // namespace odr::plugin

--- a/app/plugin/src/overlay-sources.hpp
+++ b/app/plugin/src/overlay-sources.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "plugin-settings.hpp"
+
+#include <string>
+#include <vector>
+
+namespace odr::plugin {
+
+struct OverlaySourceDiagnostic {
+	std::string code;
+	std::string field;
+	std::string source_name;
+	std::string action;
+	std::string reason;
+};
+
+struct OverlaySourceEnsureResult {
+	bool success = true;
+	std::vector<OverlaySourceDiagnostic> diagnostics;
+};
+
+OverlaySourceEnsureResult ensure_overlay_text_sources(const OverlaySettings &settings);
+void log_overlay_source_result(const OverlaySourceEnsureResult &result);
+
+} // namespace odr::plugin

--- a/app/plugin/src/plugin-main.cpp
+++ b/app/plugin/src/plugin-main.cpp
@@ -1,6 +1,7 @@
 #include <obs-frontend-api.h>
 #include <obs-module.h>
 
+#include "overlay-sources.hpp"
 #include "plugin-settings.hpp"
 #include "plugin-ui.hpp"
 #include "worker-launcher.hpp"
@@ -19,6 +20,7 @@ odr::plugin::PluginUiController ui_controller(worker_manager);
 void launch_worker()
 {
 	odr::plugin::PluginSettings settings = odr::plugin::load_plugin_settings();
+	odr::plugin::log_overlay_source_result(odr::plugin::ensure_overlay_text_sources(settings.overlay));
 	odr::plugin::WorkerLaunchConfig config = odr::plugin::make_launch_config(settings);
 	worker_manager.start_async(std::move(config));
 }

--- a/app/plugin/src/plugin-settings.cpp
+++ b/app/plugin/src/plugin-settings.cpp
@@ -18,6 +18,10 @@ constexpr uint16_t kDefaultPort = 8787;
 constexpr const wchar_t *kSettingsDirectory = L"obs-duel-recorder";
 constexpr const wchar_t *kSettingsFile = L"plugin-settings.json";
 
+constexpr const char *kOverlayKey = "overlay";
+constexpr const char *kOverlaySourcesKey = "sources";
+constexpr const char *kOverlayDefaultsKey = "defaults";
+
 std::wstring from_utf8(const char *value)
 {
 	if (!value || value[0] == '\0') {
@@ -88,6 +92,125 @@ void apply_defaults(obs_data_t *data)
 	obs_data_set_default_bool(data, "restart_worker_on_change", true);
 }
 
+void apply_overlay_sources_defaults(obs_data_t *sources)
+{
+	const OverlaySettings defaults;
+	obs_data_set_default_string(sources, "deck_name", defaults.deck_name.source_name.c_str());
+	obs_data_set_default_string(sources, "sequence_number", defaults.sequence_number.source_name.c_str());
+	obs_data_set_default_string(sources, "result", defaults.result.source_name.c_str());
+	obs_data_set_default_string(sources, "opponent_deck", defaults.opponent_deck.source_name.c_str());
+	obs_data_set_default_string(sources, "recording_state", defaults.recording_state.source_name.c_str());
+}
+
+void apply_overlay_text_defaults(obs_data_t *defaults_data)
+{
+	const OverlaySettings defaults;
+	obs_data_set_default_string(defaults_data, "deck_name", defaults.deck_name.default_text.c_str());
+	obs_data_set_default_string(defaults_data, "sequence_number", defaults.sequence_number.default_text.c_str());
+	obs_data_set_default_string(defaults_data, "result", defaults.result.default_text.c_str());
+	obs_data_set_default_string(defaults_data, "opponent_deck", defaults.opponent_deck.default_text.c_str());
+	obs_data_set_default_string(defaults_data, "recording_state", defaults.recording_state.default_text.c_str());
+}
+
+void apply_overlay_defaults(obs_data_t *overlay)
+{
+	obs_data_set_default_bool(overlay, "enabled", true);
+	obs_data_set_default_bool(overlay, "auto_create_sources", true);
+
+	obs_data_t *sources = obs_data_create();
+	apply_overlay_sources_defaults(sources);
+	obs_data_set_default_obj(overlay, kOverlaySourcesKey, sources);
+	obs_data_release(sources);
+
+	obs_data_t *defaults_data = obs_data_create();
+	apply_overlay_text_defaults(defaults_data);
+	obs_data_set_default_obj(overlay, kOverlayDefaultsKey, defaults_data);
+	obs_data_release(defaults_data);
+}
+
+std::string read_string(obs_data_t *data, const char *key, const std::string &fallback, const char *section)
+{
+	const char *value = obs_data_get_string(data, key);
+	if (!value || value[0] == '\0') {
+		blog(LOG_WARNING, "OBS Duel Recorder overlay diagnostic=overlay_settings_invalid field=%s action=load reason=empty_%s",
+		     key, section);
+		return fallback;
+	}
+	return value;
+}
+
+void load_overlay_field(obs_data_t *sources, obs_data_t *defaults_data, const char *key, OverlayFieldSettings &field)
+{
+	field.source_name = read_string(sources, key, field.source_name, "source_name");
+	field.default_text = read_string(defaults_data, key, field.default_text, "default_text");
+}
+
+OverlaySettings load_overlay_settings(obs_data_t *data)
+{
+	OverlaySettings settings;
+	obs_data_t *overlay = obs_data_get_obj(data, kOverlayKey);
+	if (!overlay) {
+		overlay = obs_data_create();
+	}
+	apply_overlay_defaults(overlay);
+
+	settings.enabled = obs_data_get_bool(overlay, "enabled");
+	settings.auto_create_sources = obs_data_get_bool(overlay, "auto_create_sources");
+
+	obs_data_t *sources = obs_data_get_obj(overlay, kOverlaySourcesKey);
+	if (!sources) {
+		sources = obs_data_create();
+	}
+	apply_overlay_sources_defaults(sources);
+
+	obs_data_t *defaults_data = obs_data_get_obj(overlay, kOverlayDefaultsKey);
+	if (!defaults_data) {
+		defaults_data = obs_data_create();
+	}
+	apply_overlay_text_defaults(defaults_data);
+
+	load_overlay_field(sources, defaults_data, "deck_name", settings.deck_name);
+	load_overlay_field(sources, defaults_data, "sequence_number", settings.sequence_number);
+	load_overlay_field(sources, defaults_data, "result", settings.result);
+	load_overlay_field(sources, defaults_data, "opponent_deck", settings.opponent_deck);
+	load_overlay_field(sources, defaults_data, "recording_state", settings.recording_state);
+
+	obs_data_release(defaults_data);
+	obs_data_release(sources);
+	obs_data_release(overlay);
+	return settings;
+}
+
+void save_overlay_field(obs_data_t *sources, obs_data_t *defaults_data, const char *key,
+			const OverlayFieldSettings &field)
+{
+	obs_data_set_string(sources, key, field.source_name.c_str());
+	obs_data_set_string(defaults_data, key, field.default_text.c_str());
+}
+
+void save_overlay_settings(obs_data_t *data, const OverlaySettings &settings)
+{
+	obs_data_t *overlay = obs_data_create();
+	obs_data_set_bool(overlay, "enabled", settings.enabled);
+	obs_data_set_bool(overlay, "auto_create_sources", settings.auto_create_sources);
+
+	obs_data_t *sources = obs_data_create();
+	obs_data_t *defaults_data = obs_data_create();
+	save_overlay_field(sources, defaults_data, "deck_name", settings.deck_name);
+	save_overlay_field(sources, defaults_data, "sequence_number", settings.sequence_number);
+	save_overlay_field(sources, defaults_data, "result", settings.result);
+	save_overlay_field(sources, defaults_data, "opponent_deck", settings.opponent_deck);
+	save_overlay_field(sources, defaults_data, "recording_state", settings.recording_state);
+
+	obs_data_set_obj(overlay, kOverlaySourcesKey, sources);
+	obs_data_set_obj(overlay, kOverlayDefaultsKey, defaults_data);
+	obs_data_set_obj(data, kOverlayKey, overlay);
+
+	obs_data_release(defaults_data);
+	obs_data_release(sources);
+	obs_data_release(overlay);
+}
+
 } // namespace
 
 std::wstring default_plugin_settings_path()
@@ -119,6 +242,7 @@ PluginSettings load_plugin_settings()
 	settings.endpoint.port = clamp_port(obs_data_get_int(data, "port"));
 	settings.user_data_dir = from_utf8(obs_data_get_string(data, "user_data_dir"));
 	settings.restart_worker_on_change = obs_data_get_bool(data, "restart_worker_on_change");
+	settings.overlay = load_overlay_settings(data);
 
 	obs_data_release(data);
 	return settings;
@@ -137,6 +261,7 @@ bool save_plugin_settings(const PluginSettings &settings)
 	obs_data_set_int(data, "port", settings.endpoint.port);
 	obs_data_set_string(data, "user_data_dir", to_utf8(settings.user_data_dir).c_str());
 	obs_data_set_bool(data, "restart_worker_on_change", settings.restart_worker_on_change);
+	save_overlay_settings(data, settings.overlay);
 
 	const bool saved = obs_data_save_json_safe(data, to_utf8(settings.settings_path).c_str(), "tmp", "bak");
 	obs_data_release(data);

--- a/app/plugin/src/plugin-settings.hpp
+++ b/app/plugin/src/plugin-settings.hpp
@@ -2,10 +2,28 @@
 
 #include "worker-launcher.hpp"
 
+#include <string>
+
 namespace odr::plugin {
+
+struct OverlayFieldSettings {
+	std::string source_name;
+	std::string default_text;
+};
+
+struct OverlaySettings {
+	bool enabled = true;
+	bool auto_create_sources = true;
+	OverlayFieldSettings deck_name{"ODR Deck Name", "Deck: -"};
+	OverlayFieldSettings sequence_number{"ODR Sequence", "#---"};
+	OverlayFieldSettings result{"ODR Result", "Result: unknown"};
+	OverlayFieldSettings opponent_deck{"ODR Opponent Deck", "Opponent: unknown"};
+	OverlayFieldSettings recording_state{"ODR Recording State", "Idle"};
+};
 
 struct PluginSettings {
 	WorkerEndpoint endpoint;
+	OverlaySettings overlay;
 	std::wstring user_data_dir;
 	std::wstring settings_path;
 	bool restart_worker_on_change = true;

--- a/app/plugin/src/plugin-ui.cpp
+++ b/app/plugin/src/plugin-ui.cpp
@@ -1,5 +1,6 @@
 #include "plugin-ui.hpp"
 
+#include "overlay-sources.hpp"
 #include "plugin-settings.hpp"
 
 #include <obs-frontend-api.h>
@@ -255,6 +256,7 @@ void PluginUiController::save_settings_and_restart(const PluginSettings &setting
 	     kLogPrefix, to_utf8(settings.settings_path).c_str(), to_utf8(settings.endpoint.host).c_str(),
 	     settings.endpoint.port, to_utf8(settings.user_data_dir).c_str());
 
+	log_overlay_source_result(ensure_overlay_text_sources(settings.overlay));
 	worker_manager_.stop();
 	worker_manager_.start_async(make_launch_config(settings));
 	refresh();


### PR DESCRIPTION
## Summary
Implement the first v0.5 Plugin-side overlay source management layer for #292.

## Changes
- Add additive `overlay` settings defaults to `plugin-settings.json` while preserving v0.4 settings compatibility.
- Add an `overlay-sources` Plugin helper that finds/reuses supported OBS Text Sources or creates the fixed v0.5 sources in the current scene.
- Log stable overlay diagnostics for invalid settings, missing sources, unsupported source kinds, unavailable text source kinds, and create failures.
- Run source management on OBS frontend readiness and after Plugin settings are saved.
- Document the v0.5 source-management behavior in `app/plugin/README.md`.

## Related Issues
- Closes #292
- Refs #288
- Refs #291
- Refs #296

## Verification
- OK: `cmake -S app/plugin -B build/plugin-v05b -G "Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH="C:/PG/obs-duel-recorder/_smoke/tools/obs-studio-src/build_x64;C:/PG/obs-duel-recorder/_smoke/tools/obs-studio-src/build_x64/frontend/api;C:/PG/obs-duel-recorder/_smoke/tools/obs-studio-src/build_x64/deps/w32-pthreads;C:/PG/obs-duel-recorder/_smoke/tools/obs-studio-src/.deps/obs-deps-2025-08-23-x64;C:/PG/obs-duel-recorder/_smoke/tools/Qt/6.8.3/msvc2022_64" -DCMAKE_MODULE_PATH="C:/PG/obs-duel-recorder/_smoke/tools/obs-studio-src/cmake/finders"`
- OK: `cmake --build build/plugin-v05b --config Release`
- OK: `powershell -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- OK: `python scripts\validate_jp_user_docs_coverage.py`
- OK: `python -m unittest discover -s app\worker\tests`
- Note: `python -m pytest app\worker\tests` could not run locally because pytest is not installed in this runtime; unittest discovery covers the checked-in Worker tests.