### PR TITLE
Add v0.5 overlay update API

### DIFF
--- a/app/plugin/src/worker-api.cpp
+++ b/app/plugin/src/worker-api.cpp
@@ -226,4 +226,46 @@ WorkerProbeResult LocalhostApiClient::probe_health(const WorkerEndpoint &endpoin
 #endif
 }
 
+OverlayFetchResult LocalhostApiClient::fetch_overlay_state(const WorkerEndpoint &endpoint) const
+{
+	OverlayFetchResult result;
+
+#ifdef _WIN32
+	const HttpResponse response = http_get(endpoint, L"/overlay/state");
+	result.http_status = response.status;
+	result.body = response.body;
+
+	if (!response.ok) {
+		result.status = OverlayFetchStatus::unavailable;
+		result.error = response.error;
+		return result;
+	}
+	if (response.status != 200) {
+		result.status = OverlayFetchStatus::invalid_response;
+		result.error = "GET /overlay/state returned non-200 status";
+		return result;
+	}
+
+	result.state.deck_name = extract_json_string(response.body, "deck_name");
+	result.state.sequence_number = extract_json_string(response.body, "sequence_number");
+	result.state.result = extract_json_string(response.body, "result");
+	result.state.opponent_deck = extract_json_string(response.body, "opponent_deck");
+	result.state.recording_state = extract_json_string(response.body, "recording_state");
+
+	if (result.state.result.empty() || result.state.opponent_deck.empty() ||
+	    result.state.recording_state.empty()) {
+		result.status = OverlayFetchStatus::invalid_response;
+		result.error = "GET /overlay/state response is missing required fields";
+		return result;
+	}
+
+	result.status = OverlayFetchStatus::reachable;
+	return result;
+#else
+	result.status = OverlayFetchStatus::unavailable;
+	result.error = "Overlay state probing is only implemented on Windows";
+	return result;
+#endif
+}
+
 } // namespace odr::plugin

--- a/app/plugin/src/worker-api.hpp
+++ b/app/plugin/src/worker-api.hpp
@@ -36,11 +36,34 @@ struct WorkerProbeResult {
 	}
 };
 
+enum class OverlayFetchStatus {
+	reachable,
+	unavailable,
+	invalid_response,
+};
+
+struct OverlayStatePayload {
+	std::string deck_name;
+	std::string sequence_number;
+	std::string result;
+	std::string opponent_deck;
+	std::string recording_state;
+};
+
+struct OverlayFetchResult {
+	OverlayFetchStatus status = OverlayFetchStatus::unavailable;
+	unsigned long http_status = 0;
+	OverlayStatePayload state;
+	std::string error;
+	std::string body;
+};
+
 class LocalhostApiClient {
 public:
 	explicit LocalhostApiClient(std::string expected_api_version, std::string expected_worker_version);
 
 	WorkerProbeResult probe_health(const WorkerEndpoint &endpoint, const std::wstring &expected_user_data_dir) const;
+	OverlayFetchResult fetch_overlay_state(const WorkerEndpoint &endpoint) const;
 
 private:
 	std::string expected_api_version_;

--- a/app/worker/odr_worker/api.py
+++ b/app/worker/odr_worker/api.py
@@ -10,6 +10,7 @@ from .config import LoadedWorkerConfig, get_repo_root
 from .db import DbInfo
 from .health import API_VERSION, PID, STARTED_AT, WorkerDb, WorkerPaths, build_health_payload
 from .identity import INSTANCE_ID
+from .overlay import OverlayPayloadError, OverlayState, apply_overlay_update
 from .runtime_dirs import RuntimeDirs
 from .version import __version__
 
@@ -36,6 +37,7 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
 
     app.state.paths = worker_paths
     app.state.config_loaded = loaded_config.config_loaded
+    app.state.overlay_state = OverlayState()
 
     app.state.db = None
     if db_info is not None:
@@ -58,6 +60,31 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
             "pid": PID,
             "started_at": STARTED_AT,
         }
+
+    @app.get("/overlay/state")
+    def get_overlay_state() -> dict[str, str]:
+        return app.state.overlay_state.as_payload()
+
+    @app.put("/overlay/state")
+    async def put_overlay_state(request: Request):
+        try:
+            payload = await request.json()
+            app.state.overlay_state = apply_overlay_update(app.state.overlay_state, payload)
+        except OverlayPayloadError as exc:
+            return JSONResponse(
+                status_code=400,
+                content=_error_payload(
+                    code="overlay_payload_invalid",
+                    message="Overlay payload is invalid",
+                    details=exc.details,
+                ),
+            )
+        except ValueError:
+            return JSONResponse(
+                status_code=400,
+                content=_error_payload(code="overlay_payload_invalid", message="Overlay payload must be JSON object"),
+            )
+        return app.state.overlay_state.as_payload()
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception):

--- a/app/worker/odr_worker/overlay.py
+++ b/app/worker/odr_worker/overlay.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+from typing import Any
+
+
+ALLOWED_RECORDING_STATES = {"idle", "recording", "paused", "unknown"}
+OVERLAY_FIELDS = ("deck_name", "sequence_number", "result", "opponent_deck", "recording_state")
+MAX_OVERLAY_VALUE_LENGTH = 256
+
+
+class OverlayPayloadError(ValueError):
+    def __init__(self, details: dict[str, str]) -> None:
+        super().__init__("Invalid overlay payload")
+        self.details = details
+
+
+@dataclass(frozen=True)
+class OverlayState:
+    deck_name: str = ""
+    sequence_number: str = ""
+    result: str = "unknown"
+    opponent_deck: str = "unknown"
+    recording_state: str = "idle"
+
+    def as_payload(self) -> dict[str, str]:
+        return asdict(self)
+
+
+def apply_overlay_update(current: OverlayState, payload: Any) -> OverlayState:
+    if not isinstance(payload, dict):
+        raise OverlayPayloadError({"payload": "must_be_object"})
+
+    updates: dict[str, str] = {}
+    errors: dict[str, str] = {}
+    for key, value in payload.items():
+        if key not in OVERLAY_FIELDS:
+            errors[str(key)] = "unknown_field"
+            continue
+        if not isinstance(value, str):
+            errors[key] = "must_be_string"
+            continue
+        if len(value) > MAX_OVERLAY_VALUE_LENGTH:
+            errors[key] = "too_long"
+            continue
+        if key == "recording_state" and value not in ALLOWED_RECORDING_STATES:
+            errors[key] = "unknown_recording_state"
+            continue
+        updates[key] = value
+
+    if errors:
+        raise OverlayPayloadError(errors)
+    return replace(current, **updates)

--- a/app/worker/tests/test_overlay.py
+++ b/app/worker/tests/test_overlay.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+WORKER_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(WORKER_ROOT))
+
+
+class OverlayStateApiTests(unittest.TestCase):
+    def _client(self):
+        from fastapi.testclient import TestClient
+
+        from odr_worker.api import create_app
+        from odr_worker.config import LoadedWorkerConfig, WorkerConfig
+        from odr_worker.runtime_dirs import ensure_runtime_dirs
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        user_data_dir = Path(tmp.name)
+        runtime_dirs = ensure_runtime_dirs(user_data_dir=user_data_dir)
+        loaded_config = LoadedWorkerConfig(
+            config=WorkerConfig(),
+            config_path=runtime_dirs.config_dir / "worker.toml",
+            config_loaded=False,
+        )
+        return TestClient(create_app(runtime_dirs=runtime_dirs, loaded_config=loaded_config))
+
+    def test_overlay_state_defaults_are_available(self) -> None:
+        client = self._client()
+
+        resp = client.get("/overlay/state")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp.json(),
+            {
+                "deck_name": "",
+                "sequence_number": "",
+                "result": "unknown",
+                "opponent_deck": "unknown",
+                "recording_state": "idle",
+            },
+        )
+
+    def test_overlay_state_update_preserves_missing_fields(self) -> None:
+        client = self._client()
+
+        resp = client.put(
+            "/overlay/state",
+            json={
+                "deck_name": "Sample Deck",
+                "sequence_number": "001",
+                "recording_state": "recording",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["deck_name"], "Sample Deck")
+        self.assertEqual(resp.json()["sequence_number"], "001")
+        self.assertEqual(resp.json()["result"], "unknown")
+        self.assertEqual(resp.json()["opponent_deck"], "unknown")
+        self.assertEqual(resp.json()["recording_state"], "recording")
+
+        second = client.get("/overlay/state")
+        self.assertEqual(second.json(), resp.json())
+
+    def test_overlay_state_rejects_invalid_payload(self) -> None:
+        client = self._client()
+
+        resp = client.put(
+            "/overlay/state",
+            json={"recording_state": "starting", "deck_name": 123, "extra": "value"},
+        )
+        self.assertEqual(resp.status_code, 400)
+        body = resp.json()
+        self.assertEqual(body["code"], "overlay_payload_invalid")
+        self.assertEqual(body["details"]["recording_state"], "unknown_recording_state")
+        self.assertEqual(body["details"]["deck_name"], "must_be_string")
+        self.assertEqual(body["details"]["extra"], "unknown_field")
+
+    def test_overlay_state_rejects_overlong_value(self) -> None:
+        client = self._client()
+
+        resp = client.put("/overlay/state", json={"deck_name": "x" * 257})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json()["details"]["deck_name"], "too_long")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/architecture/overlay.md
+++ b/docs/architecture/overlay.md
@@ -120,6 +120,19 @@ Field behavior:
 - overlong value: truncate or reject with a diagnostic; do not crash OBS
 - unknown enum-like value: display `unknown` or a configured default and log a diagnostic
 
+## Worker API Boundary
+
+The Worker stores the current overlay state in memory and exposes it over the existing localhost API.
+
+Routes:
+
+- `GET /overlay/state`: returns the current overlay state payload.
+- `PUT /overlay/state`: validates and applies a partial overlay state update, then returns the full current state.
+
+`PUT /overlay/state` accepts any subset of the overlay fields. Missing fields preserve the previous value. Unknown fields, non-string values, overlong values, and unknown `recording_state` values return `400` with `code: "overlay_payload_invalid"`.
+
+The Plugin polls `GET /overlay/state` through its Worker API client. Actual Text Source writes are handled by the Plugin; the Worker does not call OBS APIs and does not own recording lifecycle decisions.
+
 ## Recording-State Boundary
 
 v0.5 may display recording-state text, but it must not become the owner of recording lifecycle decisions.


### PR DESCRIPTION
## Summary
Add the minimal v0.5 Worker/Plugin overlay update API boundary for #293.

## Changes
- Add Worker in-memory overlay state with `GET /overlay/state` and `PUT /overlay/state`.
- Validate overlay update payloads for known fields, string values, length, and display-only `recording_state` values.
- Return stable `overlay_payload_invalid` diagnostics for invalid Worker API payloads.
- Add Plugin Worker API client support for polling `GET /overlay/state`.
- Document the Worker API boundary in `docs/architecture/overlay.md`.

## Related Issues
- Closes #293
- Refs #288
- Refs #291
- Refs #294
- Refs #295

## Verification
- OK: `python -m unittest discover -s app\worker\tests` (13 tests)
- OK: `powershell -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- OK: `python scripts\validate_jp_user_docs_coverage.py`
- OK: `cmake --build build/plugin-v05b --config Release`

## Scope Notes
- This PR establishes the API and polling boundary only.
- Writing polled values into OBS Text Sources remains scoped to #294/#295.