### PR TITLE
Apply deck and sequence overlay updates

### DIFF
--- a/app/plugin/src/overlay-sources.cpp
+++ b/app/plugin/src/overlay-sources.cpp
@@ -118,6 +118,36 @@ void create_source(OverlaySourceEnsureResult &result, const OverlayField &field,
 	obs_source_release(source);
 }
 
+std::string display_or_default(const std::string &value, const OverlayFieldSettings &settings)
+{
+	return value.empty() ? settings.default_text : value;
+}
+
+void update_text_source(OverlaySourceEnsureResult &result, const OverlayField &field, const std::string &text,
+			bool used_default)
+{
+	obs_source_t *source = obs_get_source_by_name(field.settings.source_name.c_str());
+	if (!source) {
+		add_diagnostic(result, "overlay_source_missing", field, "update", "source_not_found");
+		return;
+	}
+	if (!is_supported_text_source(source)) {
+		const char *id = obs_source_get_id(source);
+		add_diagnostic(result, "overlay_source_unsupported", field, "skip", id ? id : "unknown_source_kind");
+		obs_source_release(source);
+		return;
+	}
+
+	obs_data_t *data = obs_data_create();
+	obs_data_set_string(data, "text", text.c_str());
+	obs_source_update(source, data);
+	obs_data_release(data);
+	obs_source_release(source);
+
+	blog(LOG_INFO, "%s overlay update applied field=%s source=%s action=update value=%s", kLogPrefix, field.key,
+	     field.settings.source_name.c_str(), used_default ? "default" : "payload");
+}
+
 void ensure_field(OverlaySourceEnsureResult &result, const OverlayField &field, bool auto_create_sources)
 {
 	SourceNameCount count{field.settings.source_name};
@@ -217,6 +247,23 @@ void log_overlay_source_result(const OverlaySourceEnsureResult &result)
 		     diagnostic.code.c_str(), diagnostic.field.c_str(), diagnostic.source_name.c_str(),
 		     diagnostic.action.c_str(), diagnostic.reason.c_str());
 	}
+}
+
+OverlaySourceEnsureResult update_deck_sequence_overlay_sources(const OverlaySettings &settings,
+							       const OverlayStatePayload &state)
+{
+	OverlaySourceEnsureResult result;
+	if (!settings.enabled) {
+		return result;
+	}
+
+	const OverlayField deck_name{"deck_name", settings.deck_name};
+	const OverlayField sequence_number{"sequence_number", settings.sequence_number};
+	const std::string deck_text = display_or_default(state.deck_name, settings.deck_name);
+	const std::string sequence_text = display_or_default(state.sequence_number, settings.sequence_number);
+	update_text_source(result, deck_name, deck_text, state.deck_name.empty());
+	update_text_source(result, sequence_number, sequence_text, state.sequence_number.empty());
+	return result;
 }
 
 } // namespace odr::plugin

--- a/app/plugin/src/overlay-sources.hpp
+++ b/app/plugin/src/overlay-sources.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "plugin-settings.hpp"
+#include "worker-api.hpp"
 
 #include <string>
 #include <vector>
@@ -21,6 +22,8 @@ struct OverlaySourceEnsureResult {
 };
 
 OverlaySourceEnsureResult ensure_overlay_text_sources(const OverlaySettings &settings);
+OverlaySourceEnsureResult update_deck_sequence_overlay_sources(const OverlaySettings &settings,
+							       const OverlayStatePayload &state);
 void log_overlay_source_result(const OverlaySourceEnsureResult &result);
 
 } // namespace odr::plugin

--- a/app/plugin/src/plugin-ui.cpp
+++ b/app/plugin/src/plugin-ui.cpp
@@ -191,6 +191,16 @@ void PluginUiController::refresh()
 	ownership_value_->setText(QString::fromUtf8(ownership_name(snapshot.ownership)));
 	detail_value_->setText(qstr_utf8(snapshot.error.empty() ? snapshot.last_probe_summary : snapshot.error));
 	action_value_->setText(QString::fromUtf8(recommended_action(snapshot.state)));
+
+	if (snapshot.overlay_state_available &&
+	    (!overlay_state_applied_ ||
+	     snapshot.overlay_state.deck_name != last_applied_overlay_state_.deck_name ||
+	     snapshot.overlay_state.sequence_number != last_applied_overlay_state_.sequence_number)) {
+		const PluginSettings settings = load_plugin_settings();
+		log_overlay_source_result(update_deck_sequence_overlay_sources(settings.overlay, snapshot.overlay_state));
+		last_applied_overlay_state_ = snapshot.overlay_state;
+		overlay_state_applied_ = true;
+	}
 }
 
 void PluginUiController::open_settings_from_menu(void *private_data)
@@ -257,6 +267,7 @@ void PluginUiController::save_settings_and_restart(const PluginSettings &setting
 	     settings.endpoint.port, to_utf8(settings.user_data_dir).c_str());
 
 	log_overlay_source_result(ensure_overlay_text_sources(settings.overlay));
+	overlay_state_applied_ = false;
 	worker_manager_.stop();
 	worker_manager_.start_async(make_launch_config(settings));
 	refresh();

--- a/app/plugin/src/plugin-ui.hpp
+++ b/app/plugin/src/plugin-ui.hpp
@@ -32,6 +32,8 @@ private:
 	QLabel *ownership_value_ = nullptr;
 	QLabel *detail_value_ = nullptr;
 	QLabel *action_value_ = nullptr;
+	OverlayStatePayload last_applied_overlay_state_;
+	bool overlay_state_applied_ = false;
 	bool tools_menu_registered_ = false;
 };
 

--- a/app/plugin/src/worker-launcher.cpp
+++ b/app/plugin/src/worker-launcher.cpp
@@ -301,7 +301,8 @@ void WorkerProcessManager::monitor_heartbeat(const WorkerLaunchConfig &config, c
 			}
 			consecutive_failures = 0;
 			timeout_reported = false;
-			update_status(WorkerDiagnosticState::running, config, current_ownership(), {}, &probe);
+			OverlayFetchResult overlay = api_client_.fetch_overlay_state(config.endpoint);
+			update_status(WorkerDiagnosticState::running, config, current_ownership(), {}, &probe, 0, &overlay);
 
 			if (!replacement_reported && identity_changed(baseline, probe)) {
 				replacement_reported = true;
@@ -340,7 +341,8 @@ WorkerOwnership WorkerProcessManager::current_ownership() const
 
 void WorkerProcessManager::update_status(WorkerDiagnosticState state, const WorkerLaunchConfig &config,
 					 WorkerOwnership ownership, const std::string &error,
-					 const WorkerProbeResult *probe, unsigned int consecutive_failures)
+					 const WorkerProbeResult *probe, unsigned int consecutive_failures,
+					 const OverlayFetchResult *overlay)
 {
 	std::lock_guard<std::mutex> lock(mutex_);
 	status_.state = state;
@@ -357,6 +359,14 @@ void WorkerProcessManager::update_status(WorkerDiagnosticState state, const Work
 		status_.instance_id = probe->instance_id;
 		status_.pid = probe->pid;
 		status_.started_at = probe->started_at;
+	}
+	if (overlay) {
+		status_.overlay_http_status = overlay->http_status;
+		status_.overlay_error = overlay->error;
+		status_.overlay_state_available = overlay->status == OverlayFetchStatus::reachable;
+		if (status_.overlay_state_available) {
+			status_.overlay_state = overlay->state;
+		}
 	}
 }
 

--- a/app/plugin/src/worker-launcher.hpp
+++ b/app/plugin/src/worker-launcher.hpp
@@ -43,16 +43,20 @@ struct WorkerStatusSnapshot {
 	WorkerDiagnosticState state = WorkerDiagnosticState::not_started;
 	WorkerOwnership ownership = WorkerOwnership::none;
 	WorkerEndpoint endpoint;
+	OverlayStatePayload overlay_state;
 	std::wstring user_data_dir;
 	std::string last_probe_summary;
 	std::string error;
+	std::string overlay_error;
 	std::string api_version;
 	std::string version;
 	std::string instance_id;
 	std::string pid;
 	std::string started_at;
 	unsigned long http_status = 0;
+	unsigned long overlay_http_status = 0;
 	unsigned int consecutive_failures = 0;
+	bool overlay_state_available = false;
 };
 
 class WorkerProcessManager {
@@ -72,7 +76,8 @@ private:
 	WorkerOwnership current_ownership() const;
 	void update_status(WorkerDiagnosticState state, const WorkerLaunchConfig &config,
 			   WorkerOwnership ownership, const std::string &error,
-			   const WorkerProbeResult *probe = nullptr, unsigned int consecutive_failures = 0);
+			   const WorkerProbeResult *probe = nullptr, unsigned int consecutive_failures = 0,
+			   const OverlayFetchResult *overlay = nullptr);
 	void close_process_handles();
 
 	LocalhostApiClient api_client_;


### PR DESCRIPTION
## Summary
Apply the #293 overlay state boundary to the first concrete v0.5 fields: deck name and sequence number.

## Changes
- Poll Worker overlay state during the existing Worker heartbeat path and store the latest reachable state in the Plugin status snapshot.
- Apply changed `deck_name` and `sequence_number` values to their configured OBS Text Sources from the UI thread.
- Use configured field defaults for empty deck/sequence values.
- Log successful deck/sequence update application without logging runtime content values.
- Re-apply overlay state after settings save so changed source names/defaults are picked up.

## Related Issues
- Closes #294
- Refs #288
- Refs #292
- Refs #293
- Refs #296

## Verification
- OK: `cmake --build build/plugin-v05b --config Release`
- OK: `python -m unittest discover -s app\worker\tests` (13 tests)
- OK: `powershell -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- OK: `python scripts\validate_jp_user_docs_coverage.py`

## Scope Notes
- This PR only updates deck name and sequence number fields.
- Result, opponent deck, and recording-state display remain scoped to #295.
- Full Windows OBS runtime smoke evidence remains scoped to #296.