### PR TITLE
Apply remaining v0.5 overlay field updates

### DIFF
--- a/app/plugin/src/overlay-sources.cpp
+++ b/app/plugin/src/overlay-sources.cpp
@@ -123,6 +123,26 @@ std::string display_or_default(const std::string &value, const OverlayFieldSetti
 	return value.empty() ? settings.default_text : value;
 }
 
+std::string recording_state_display_or_default(const std::string &value, const OverlayFieldSettings &settings)
+{
+	if (value.empty()) {
+		return settings.default_text;
+	}
+	if (value == "idle") {
+		return "Idle";
+	}
+	if (value == "recording") {
+		return "Recording";
+	}
+	if (value == "paused") {
+		return "Paused";
+	}
+	if (value == "unknown") {
+		return "Unknown";
+	}
+	return settings.default_text;
+}
+
 void update_text_source(OverlaySourceEnsureResult &result, const OverlayField &field, const std::string &text,
 			bool used_default)
 {
@@ -263,6 +283,26 @@ OverlaySourceEnsureResult update_deck_sequence_overlay_sources(const OverlaySett
 	const std::string sequence_text = display_or_default(state.sequence_number, settings.sequence_number);
 	update_text_source(result, deck_name, deck_text, state.deck_name.empty());
 	update_text_source(result, sequence_number, sequence_text, state.sequence_number.empty());
+	return result;
+}
+
+OverlaySourceEnsureResult update_overlay_sources(const OverlaySettings &settings, const OverlayStatePayload &state)
+{
+	OverlaySourceEnsureResult result = update_deck_sequence_overlay_sources(settings, state);
+	if (!settings.enabled) {
+		return result;
+	}
+
+	const OverlayField result_field{"result", settings.result};
+	const OverlayField opponent_deck{"opponent_deck", settings.opponent_deck};
+	const OverlayField recording_state{"recording_state", settings.recording_state};
+	const std::string result_text = display_or_default(state.result, settings.result);
+	const std::string opponent_text = display_or_default(state.opponent_deck, settings.opponent_deck);
+	const std::string recording_text = recording_state_display_or_default(state.recording_state,
+									      settings.recording_state);
+	update_text_source(result, result_field, result_text, state.result.empty());
+	update_text_source(result, opponent_deck, opponent_text, state.opponent_deck.empty());
+	update_text_source(result, recording_state, recording_text, state.recording_state.empty());
 	return result;
 }
 

--- a/app/plugin/src/overlay-sources.hpp
+++ b/app/plugin/src/overlay-sources.hpp
@@ -22,6 +22,7 @@ struct OverlaySourceEnsureResult {
 };
 
 OverlaySourceEnsureResult ensure_overlay_text_sources(const OverlaySettings &settings);
+OverlaySourceEnsureResult update_overlay_sources(const OverlaySettings &settings, const OverlayStatePayload &state);
 OverlaySourceEnsureResult update_deck_sequence_overlay_sources(const OverlaySettings &settings,
 							       const OverlayStatePayload &state);
 void log_overlay_source_result(const OverlaySourceEnsureResult &result);

--- a/app/plugin/src/plugin-ui.cpp
+++ b/app/plugin/src/plugin-ui.cpp
@@ -195,9 +195,12 @@ void PluginUiController::refresh()
 	if (snapshot.overlay_state_available &&
 	    (!overlay_state_applied_ ||
 	     snapshot.overlay_state.deck_name != last_applied_overlay_state_.deck_name ||
-	     snapshot.overlay_state.sequence_number != last_applied_overlay_state_.sequence_number)) {
+	     snapshot.overlay_state.sequence_number != last_applied_overlay_state_.sequence_number ||
+	     snapshot.overlay_state.result != last_applied_overlay_state_.result ||
+	     snapshot.overlay_state.opponent_deck != last_applied_overlay_state_.opponent_deck ||
+	     snapshot.overlay_state.recording_state != last_applied_overlay_state_.recording_state)) {
 		const PluginSettings settings = load_plugin_settings();
-		log_overlay_source_result(update_deck_sequence_overlay_sources(settings.overlay, snapshot.overlay_state));
+		log_overlay_source_result(update_overlay_sources(settings.overlay, snapshot.overlay_state));
 		last_applied_overlay_state_ = snapshot.overlay_state;
 		overlay_state_applied_ = true;
 	}

--- a/docs/architecture/overlay.md
+++ b/docs/architecture/overlay.md
@@ -146,6 +146,15 @@ Allowed v0.5 states:
 
 The v0.6 state machine may later replace or refine these values. v0.5 should treat them as display inputs only.
 
+The v0.5 Plugin display mapping is intentionally narrow:
+
+- `idle` -> `Idle`
+- `recording` -> `Recording`
+- `paused` -> `Paused`
+- `unknown` -> `Unknown`
+
+The Plugin writes this display text only to the configured recording-state Text Source. It does not start, stop, pause, resume, infer, or persist recording lifecycle state.
+
 ## Diagnostics
 
 Overlay diagnostics should use stable names in logs and Dock/status evidence where practical:


### PR DESCRIPTION
## Summary
Complete the remaining v0.5 overlay display fields for #295: result, opponent deck, and recording-state display.

## Changes
- Extend Plugin overlay updates from deck/sequence to all five v0.5 fields.
- Apply result and opponent deck values with configured defaults for empty values.
- Map recording-state display inputs narrowly: `idle`, `recording`, `paused`, `unknown`.
- Document that the recording-state field is display-only and does not own the v0.6 lifecycle state machine.

## Related Issues
- Closes #295
- Refs #288
- Refs #292
- Refs #293
- Refs #294
- Refs #296

## Verification
- OK: `cmake --build build/plugin-v05b --config Release`
- OK: `python -m unittest discover -s app\worker\tests` (13 tests)
- OK: `powershell -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- OK: `python scripts\validate_jp_user_docs_coverage.py`

## Scope Notes
- This PR keeps recording-state display separate from v0.6 recording lifecycle management.
- Full Windows OBS runtime smoke evidence remains scoped to #296.