### PR TITLE
Record v0.5 release handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Major and minor release completions are tagged as `vMajor.Minor.Patch`. See [Rel
 ## Current Development
 
 Latest released version:
-- `v0.4.0` - OBS Plugin Skeleton
+- `v0.5.0` - Overlay Integration
 
 Current development target:
-- `v0.5` - Overlay Integration
-- Tracking issue: [#288](https://github.com/Tao-pyth/obs-duel-recorder/issues/288)
+- `v0.6` - Recording State Management
+- Tracking issue: [#303](https://github.com/Tao-pyth/obs-duel-recorder/issues/303)
 
 Next roadmap target:
-- `v0.6` - Recording State Management
+- `v0.7` - Queue Recovery System
 
 ---
 
@@ -52,9 +52,9 @@ Current released foundation:
 - SQLite runtime storage foundation
 - Worker runtime, health, logging, and migration foundations
 - OBS Plugin skeleton and Worker lifecycle management
+- OBS overlay Text Source integration
 
 Planned roadmap capabilities:
-- OBS overlay integration (`v0.5`)
 - Recording state management (`v0.6`)
 - Match queue management (`v0.7`)
 - Automatic duel recording (`v0.8`)
@@ -110,28 +110,26 @@ obs-duel-recorder/
 
 ### Latest Release
 
-- Version: `v0.4.0`
-- Scope: OBS Plugin Skeleton
+- Version: `v0.5.0`
+- Scope: Overlay Integration
 - Status: released
-- Intended tag target: `629f4f6d8d28d0d9dcca96381340a04077d2bb62`
-- Tracking issue: [#110](https://github.com/Tao-pyth/obs-duel-recorder/issues/110)
+- Intended tag target: `474c657fa8f3e90cfe12202105b0f69c8c9f7643`
+- Tracking issue: [#288](https://github.com/Tao-pyth/obs-duel-recorder/issues/288)
 - Release record: [docs/release-history.md](docs/release-history.md)
 
-### Completed in v0.4
+### Completed in v0.5
 
-- Loadable OBS Plugin scaffold
-- OBS Frontend API startup/shutdown integration
-- Plugin-managed Worker launch and ownership tracking
-- Worker heartbeat monitoring via localhost `/health`
-- Status-first OBS Dock diagnostics
-- Persisted Plugin settings at `%APPDATA%\obs-duel-recorder\plugin-settings.json`
-- Localhost API wrapper diagnostics for runtime-root continuity and Worker identity
-- Windows OBS smoke evidence recorded in #285
+- Fixed OBS Text Source management for overlay fields
+- Backward-compatible Plugin overlay settings defaults
+- Worker overlay state API at `/overlay/state`
+- Plugin polling and Text Source updates for deck name, sequence number, result, opponent deck, and recording-state display
+- Display-only recording-state overlay boundary; full state machine remains v0.6
+- Windows OBS overlay smoke evidence recorded in #296
 
-### Planned After v0.4
+### Planned After v0.5
 
-- `v0.5` - Overlay Integration
-- Later roadmap items include recording state management, queue recovery, template matching, upload automation, packaging, and GitHub Pages documentation.
+- `v0.6` - Recording State Management
+- Later roadmap items include queue recovery, template matching, upload automation, packaging, and GitHub Pages documentation.
 
 ---
 

--- a/app/plugin/CMakeLists.txt
+++ b/app/plugin/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-project(obs-duel-recorder-plugin VERSION 0.4.0 LANGUAGES CXX)
+project(obs-duel-recorder-plugin VERSION 0.5.0 LANGUAGES CXX)
 
 find_package(libobs REQUIRED)
 find_package(obs-frontend-api REQUIRED)

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -66,3 +66,19 @@ The version tracking issue may contain the working release summary, but finalize
 - Deferred items: Overlay Integration remains in #288; Recording State Management remains v0.6
 - Next version tracking issue: #288
 - Status: released; tag still needs maintainer/tooling creation at the intended target above
+
+### v0.5.0 - Overlay Integration
+
+- Version tracking issue: #288
+- Milestone: `v0.5` (not set)
+- Release readiness checklist: `docs/release/v0.5-release-readiness.md`
+- Tag: `v0.5.0` intended
+- Intended tag target: `474c657fa8f3e90cfe12202105b0f69c8c9f7643`
+- Release finalized at: `2026-05-23T02:00:52+09:00`
+- Release summary: `docs/release/v0.5-release-summary.md`
+- Major child issues: #290, #291, #292, #293, #294, #295, #296
+- Smoke evidence gate: #296
+- Major PRs: #297, #298, #299, #300, #301, #302
+- Deferred items: Recording State Management remains in #303; Queue Recovery System remains v0.7
+- Next version tracking issue: #303
+- Status: release record prepared; tag creation pending after release handoff PR merge

--- a/docs/release/v0.5-release-readiness.md
+++ b/docs/release/v0.5-release-readiness.md
@@ -19,56 +19,56 @@ Non-goals:
 
 ## A. Milestone Readiness
 
-- [ ] Required v0.5 child issues are closed or explicitly deferred with a clear note.
-- [ ] Any deferred issues have a target version or follow-up issue.
-- [ ] Version tracking issue #288 reflects final child issue state.
-- [ ] Open v0.5 PRs are merged or explicitly deferred.
+- [x] Required v0.5 child issues are closed or explicitly deferred with a clear note.
+- [x] Any deferred issues have a target version or follow-up issue.
+- [x] Version tracking issue #288 reflects final child issue state.
+- [x] Open v0.5 PRs are merged or explicitly deferred.
 
 ## B. Documentation Readiness
 
-- [ ] Canonical docs are up to date:
-  - [ ] `docs/roadmap.md`
-  - [ ] `docs/requirements/requirements.md`
-  - [ ] `docs/traceability.md`
-  - [ ] `docs/requirements/v0.5-overlay-integration-acceptance.md`
-  - [ ] `docs/architecture/v0.5-overlay-smoke.md`
-  - [ ] v0.5 overlay architecture/source ownership document, if separate from the smoke procedure
-- [ ] README current development and latest release sections are ready for the release handoff.
-- [ ] Release history update is prepared.
+- [x] Canonical docs are up to date:
+  - [x] `docs/roadmap.md`
+  - [x] `docs/requirements/requirements.md`
+  - [x] `docs/traceability.md`
+  - [x] `docs/requirements/v0.5-overlay-integration-acceptance.md`
+  - [x] `docs/architecture/v0.5-overlay-smoke.md`
+  - [x] v0.5 overlay architecture/source ownership document, if separate from the smoke procedure
+- [x] README current development and latest release sections are ready for the release handoff.
+- [x] Release history update is prepared.
 
 ## C. Verification - Windows OBS Overlay Smoke
 
 Perform these checks on Windows with OBS installed or portable OBS available:
 
-- [ ] Plugin builds successfully on Windows.
-- [ ] Plugin loads in OBS without crashing.
-- [ ] Existing v0.4 Worker launch and heartbeat behavior still works.
-- [ ] Overlay settings can be loaded and saved.
-- [ ] Fixed Text Sources can be created or reused according to the v0.5 contract.
-- [ ] Deck name overlay update is visible in OBS.
-- [ ] Sequence number overlay update is visible in OBS.
-- [ ] Result overlay update is visible in OBS, or a documented deferral is linked.
-- [ ] Opponent deck overlay update is visible in OBS, or a documented deferral is linked.
-- [ ] Recording-state display is visible in OBS, or a documented deferral is linked.
-- [ ] Invalid or missing source cases produce actionable diagnostics and do not crash OBS.
-- [ ] Smoke notes record the concrete environment and evidence.
-- [ ] A redaction-checked smoke report is posted to #296 and linked from #288 and the relevant child issues.
+- [x] Plugin builds successfully on Windows.
+- [x] Plugin loads in OBS without crashing.
+- [x] Existing v0.4 Worker launch and heartbeat behavior still works.
+- [x] Overlay settings can be loaded and saved.
+- [x] Fixed Text Sources can be created or reused according to the v0.5 contract.
+- [x] Deck name overlay update is visible in OBS.
+- [x] Sequence number overlay update is visible in OBS.
+- [x] Result overlay update is visible in OBS, or a documented deferral is linked.
+- [x] Opponent deck overlay update is visible in OBS, or a documented deferral is linked.
+- [x] Recording-state display is visible in OBS, or a documented deferral is linked.
+- [x] Invalid or missing source cases produce actionable diagnostics and do not crash OBS.
+- [x] Smoke notes record the concrete environment and evidence.
+- [x] A redaction-checked smoke report is posted to #296 and linked from #288 and the relevant child issues.
 
 ## D. Release PR Readiness
 
-- [ ] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
-- [ ] Release PR updates persistent release docs.
+- [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
+- [x] Release PR updates persistent release docs.
 - [ ] Release PR is merged into `main`.
-- [ ] The merge commit SHA on `main` is recorded for tagging.
+- [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## E. Tagging After Merge
 
 - [ ] Create tag `v0.5.0` pointing to the release merge commit SHA on `main`.
-- [ ] Do not move or overwrite existing tags.
-- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #288 and release docs.
+- [x] Do not move or overwrite existing tags.
+- [x] If tooling cannot create the tag, record the intended tag name and target SHA in #288 and release docs.
 
 ## F. Handoff
 
-- [ ] Next version tracking issue is created from `docs/roadmap.md`.
-- [ ] Next version tracking issue is linked from #288.
-- [ ] Deferred work is linked to follow-up issues or later version tracking.
+- [x] Next version tracking issue is created from `docs/roadmap.md`.
+- [x] Next version tracking issue is linked from #288.
+- [x] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/release/v0.5-release-summary.md
+++ b/docs/release/v0.5-release-summary.md
@@ -1,0 +1,43 @@
+# v0.5.0 Release Summary
+
+Release: `v0.5.0` - Overlay Integration
+
+## Release Point
+
+- Version tracking issue: #288
+- Intended tag: `v0.5.0`
+- Intended tag target: `474c657fa8f3e90cfe12202105b0f69c8c9f7643`
+- Release finalized at: `2026-05-23T02:00:52+09:00`
+- Release readiness checklist: `docs/release/v0.5-release-readiness.md`
+- Smoke evidence: #296
+- Next version tracking issue: #303
+
+## Completed Scope
+
+- Fixed OBS Text Source ownership and creation/reuse contract.
+- Backward-compatible Plugin overlay settings defaults under `%APPDATA%\obs-duel-recorder\plugin-settings.json`.
+- Worker overlay state API using `GET /overlay/state` and `PUT /overlay/state`.
+- Plugin polling boundary from Worker overlay state to OBS Text Sources.
+- Overlay updates for deck name, sequence number, result, opponent deck, and recording-state display.
+- Display-only recording-state boundary for `idle`, `recording`, `paused`, and `unknown`.
+- Windows OBS overlay smoke evidence posted to #296.
+
+## Major Issues And PRs
+
+- Child issues: #290, #291, #292, #293, #294, #295, #296
+- PRs: #297, #298, #299, #300, #301, #302
+
+## Verification
+
+- CI succeeded on #297, #298, #299, #300, #301, and #302.
+- Local Windows Plugin Release build succeeded for the smoke target.
+- Worker unittest discovery passed with 13 tests.
+- Markdown link validation passed.
+- Japanese user docs coverage validation passed.
+- Portable OBS 32.1.2 loaded the Plugin and created/updated the v0.5 overlay Text Sources.
+
+## Deferred Items
+
+- Recording State Management remains scoped to v0.6: #303.
+- Queue Recovery System remains scoped to v0.7.
+- Automatic Duel Recording remains scoped to v0.8.

--- a/docs/requirements/v0.5-overlay-integration-acceptance.md
+++ b/docs/requirements/v0.5-overlay-integration-acceptance.md
@@ -40,58 +40,58 @@ v0.5 focuses on OBS overlay control:
 
 ### A. Text Source Ownership And Naming
 
-- [ ] A canonical contract defines the fixed Text Source names or stable identifiers for each v0.5 field.
-- [ ] The contract covers deck name, sequence number, result, opponent deck, and recording-state display.
-- [ ] The Plugin behavior for missing sources is defined: create, reuse, or report a diagnostic.
-- [ ] The Plugin behavior for duplicated, renamed, unsupported, or incompatible sources is defined.
-- [ ] Source ownership rules avoid deleting or unexpectedly overwriting user-created unrelated OBS sources.
+- [x] A canonical contract defines the fixed Text Source names or stable identifiers for each v0.5 field.
+- [x] The contract covers deck name, sequence number, result, opponent deck, and recording-state display.
+- [x] The Plugin behavior for missing sources is defined: create, reuse, or report a diagnostic.
+- [x] The Plugin behavior for duplicated, renamed, unsupported, or incompatible sources is defined.
+- [x] Source ownership rules avoid deleting or unexpectedly overwriting user-created unrelated OBS sources.
 
 ### B. Overlay Settings
 
-- [ ] Overlay settings are persisted with a documented location and JSON shape.
-- [ ] Defaults are documented for all v0.5 overlay fields.
-- [ ] Template/default behavior is deterministic for empty or unknown values.
-- [ ] Settings changes have a documented apply boundary and do not require OBS restart unless explicitly stated.
-- [ ] Invalid settings surface actionable diagnostics without crashing OBS.
+- [x] Overlay settings are persisted with a documented location and JSON shape.
+- [x] Defaults are documented for all v0.5 overlay fields.
+- [x] Template/default behavior is deterministic for empty or unknown values.
+- [x] Settings changes have a documented apply boundary and do not require OBS restart unless explicitly stated.
+- [x] Invalid settings surface actionable diagnostics without crashing OBS.
 
 ### C. Overlay Update API
 
-- [ ] Worker and Plugin have a documented update boundary for overlay state.
-- [ ] Overlay update payloads include deck name, sequence number, result, opponent deck, and recording-state display where implemented.
-- [ ] Invalid payloads are rejected or ignored safely with diagnostics.
-- [ ] API compatibility with existing `/health` and `/version` behavior is preserved.
-- [ ] The update path is testable without requiring external services.
+- [x] Worker and Plugin have a documented update boundary for overlay state.
+- [x] Overlay update payloads include deck name, sequence number, result, opponent deck, and recording-state display where implemented.
+- [x] Invalid payloads are rejected or ignored safely with diagnostics.
+- [x] API compatibility with existing `/health` and `/version` behavior is preserved.
+- [x] The update path is testable without requiring external services.
 
 ### D. OBS Text Source Integration
 
-- [ ] Plugin can find or create the configured fixed Text Sources in OBS.
-- [ ] Plugin can update Text Source text values without crashing OBS.
-- [ ] Deck name updates are visible in OBS.
-- [ ] Sequence number updates are visible in OBS.
-- [ ] Result updates are visible in OBS, or explicitly deferred with a linked follow-up.
-- [ ] Opponent deck updates are visible in OBS, or explicitly deferred with a linked follow-up.
-- [ ] Recording-state display is visible in OBS as display-only state, or explicitly deferred with a linked follow-up.
+- [x] Plugin can find or create the configured fixed Text Sources in OBS.
+- [x] Plugin can update Text Source text values without crashing OBS.
+- [x] Deck name updates are visible in OBS.
+- [x] Sequence number updates are visible in OBS.
+- [x] Result updates are visible in OBS, or explicitly deferred with a linked follow-up.
+- [x] Opponent deck updates are visible in OBS, or explicitly deferred with a linked follow-up.
+- [x] Recording-state display is visible in OBS as display-only state, or explicitly deferred with a linked follow-up.
 
 ### E. Diagnostics And Dock Surface
 
-- [ ] Overlay source state is observable through logs and/or Dock diagnostics.
-- [ ] Source creation/reuse/update failures include enough evidence for manual diagnosis.
-- [ ] Diagnostics distinguish Worker health failures from overlay source failures.
-- [ ] The existing status-first Dock remains usable and is not replaced by a full control UI.
+- [x] Overlay source state is observable through logs and/or Dock diagnostics.
+- [x] Source creation/reuse/update failures include enough evidence for manual diagnosis.
+- [x] Diagnostics distinguish Worker health failures from overlay source failures.
+- [x] The existing status-first Dock remains usable and is not replaced by a full control UI.
 
 ### F. Recording-State Boundary
 
-- [ ] v0.5 clearly documents what recording-state display values mean.
-- [ ] v0.5 does not implement the v0.6 recording lifecycle state machine.
-- [ ] If recording-state display is deferred, the deferral target is linked from #288 and the release summary.
+- [x] v0.5 clearly documents what recording-state display values mean.
+- [x] v0.5 does not implement the v0.6 recording lifecycle state machine.
+- [x] If recording-state display is deferred, the deferral target is linked from #288 and the release summary.
 
 ### G. Developer Verification
 
-- [ ] A v0.5 smoke procedure exists.
-- [ ] Smoke evidence can prove OBS load, source creation/reuse, and overlay updates.
-- [ ] Smoke evidence records the tested commit SHA on `main`.
-- [ ] Smoke evidence is redaction-checked before being posted to the tracking issue.
-- [ ] CI covers docs links and Worker/API tests relevant to the implemented contract.
+- [x] A v0.5 smoke procedure exists.
+- [x] Smoke evidence can prove OBS load, source creation/reuse, and overlay updates.
+- [x] Smoke evidence records the tested commit SHA on `main`.
+- [x] Smoke evidence is redaction-checked before being posted to the tracking issue.
+- [x] CI covers docs links and Worker/API tests relevant to the implemented contract.
 
 ## References
 

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -70,6 +70,14 @@ Goals:
   - `docs/requirements/requirements.md` -> Overlay Rules / Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
+### v0.6 - Recording State Management
+
+- Roadmap: `docs/roadmap.md` -> **v0.6 - Recording State Management**
+- Version tracking issue: `#303` - `[v0.6] Recording State Management release tracking`
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` -> Architecture / Platform / Runtime Rules
+  - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
+
 ---
 
 ## Policy
@@ -112,3 +120,4 @@ The version tracking issue itself is not an implementation work item.
 - Refs #288
 - Refs #291
 - Refs #296
+- Refs #303


### PR DESCRIPTION
## Summary
Finalize v0.5 release documentation and hand off current development to v0.6.

## Changes
- Mark the v0.5 acceptance checklist and release readiness checklist according to merged issues/PRs and #296 smoke evidence.
- Record v0.5 release history and add `docs/release/v0.5-release-summary.md`.
- Update README latest release/current development sections for v0.5 -> v0.6 handoff.
- Bump the Plugin CMake project version to `0.5.0`.
- Add v0.6 tracking issue #303 to traceability.

## Release Point
- Intended tag: `v0.5.0`
- Intended tag target: `474c657fa8f3e90cfe12202105b0f69c8c9f7643`
- v0.5 tracking issue: #288
- v0.5 smoke evidence: #296
- Next tracking issue: #303

## Verification
- OK: `powershell -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- OK: `python scripts\validate_jp_user_docs_coverage.py`
- OK: `python -m unittest discover -s app\worker\tests` (13 tests)
- OK: `cmake --build build/plugin-v05b --config Release`

## Related Issues
- Refs #288
- Refs #296
- Refs #303