### PR TITLE
Record v0.5 tag creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ obs-duel-recorder/
 - Version: `v0.5.0`
 - Scope: Overlay Integration
 - Status: released
-- Intended tag target: `474c657fa8f3e90cfe12202105b0f69c8c9f7643`
+- Tag target: `474c657fa8f3e90cfe12202105b0f69c8c9f7643`
 - Tracking issue: [#288](https://github.com/Tao-pyth/obs-duel-recorder/issues/288)
 - Release record: [docs/release-history.md](docs/release-history.md)
 

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -72,13 +72,14 @@ The version tracking issue may contain the working release summary, but finalize
 - Version tracking issue: #288
 - Milestone: `v0.5` (not set)
 - Release readiness checklist: `docs/release/v0.5-release-readiness.md`
-- Tag: `v0.5.0` intended
-- Intended tag target: `474c657fa8f3e90cfe12202105b0f69c8c9f7643`
+- Tag: `v0.5.0`
+- Tag target: `474c657fa8f3e90cfe12202105b0f69c8c9f7643`
 - Release finalized at: `2026-05-23T02:00:52+09:00`
+- Tag finalized at: `2026-05-23T02:08:53+09:00`
 - Release summary: `docs/release/v0.5-release-summary.md`
 - Major child issues: #290, #291, #292, #293, #294, #295, #296
 - Smoke evidence gate: #296
 - Major PRs: #297, #298, #299, #300, #301, #302
 - Deferred items: Recording State Management remains in #303; Queue Recovery System remains v0.7
 - Next version tracking issue: #303
-- Status: release record prepared; tag creation pending after release handoff PR merge
+- Status: released

--- a/docs/release/v0.5-release-readiness.md
+++ b/docs/release/v0.5-release-readiness.md
@@ -58,12 +58,12 @@ Perform these checks on Windows with OBS installed or portable OBS available:
 
 - [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
 - [x] Release PR updates persistent release docs.
-- [ ] Release PR is merged into `main`.
+- [x] Release PR is merged into `main`.
 - [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## E. Tagging After Merge
 
-- [ ] Create tag `v0.5.0` pointing to the release merge commit SHA on `main`.
+- [x] Create tag `v0.5.0` pointing to the release merge commit SHA on `main`.
 - [x] Do not move or overwrite existing tags.
 - [x] If tooling cannot create the tag, record the intended tag name and target SHA in #288 and release docs.
 

--- a/docs/release/v0.5-release-summary.md
+++ b/docs/release/v0.5-release-summary.md
@@ -5,9 +5,10 @@ Release: `v0.5.0` - Overlay Integration
 ## Release Point
 
 - Version tracking issue: #288
-- Intended tag: `v0.5.0`
-- Intended tag target: `474c657fa8f3e90cfe12202105b0f69c8c9f7643`
+- Tag: `v0.5.0`
+- Tag target: `474c657fa8f3e90cfe12202105b0f69c8c9f7643`
 - Release finalized at: `2026-05-23T02:00:52+09:00`
+- Tag finalized at: `2026-05-23T02:08:53+09:00`
 - Release readiness checklist: `docs/release/v0.5-release-readiness.md`
 - Smoke evidence: #296
 - Next version tracking issue: #303


### PR DESCRIPTION
## Summary
Update release docs after creating the `v0.5.0` tag.

## Changes
- Replace intended/pending tag wording with finalized tag wording.
- Mark the v0.5 release readiness tag checkbox complete.
- Record `v0.5.0` tag finalized time.

## Release Point
- Tag: `v0.5.0`
- Tag target: `474c657fa8f3e90cfe12202105b0f69c8c9f7643`

## Verification
- OK: `powershell -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- OK: `python scripts\validate_jp_user_docs_coverage.py`
- OK: `python -m unittest discover -s app\worker\tests` (13 tests)

## Related Issues
- Refs #288