### PR TITLE
Record v0.5 duplicate issue cleanup

### DIFF
--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -80,6 +80,8 @@ The version tracking issue may contain the working release summary, but finalize
 - Major child issues: #290, #291, #292, #293, #294, #295, #296
 - Smoke evidence gate: #296
 - Major PRs: #297, #298, #299, #300, #301, #302
+- Release documentation PRs: #304, #305
+- Superseded duplicate planning issues: #246, #252, #253, #254, #255, #256, #257
 - Deferred items: Recording State Management remains in #303; Queue Recovery System remains v0.7
 - Next version tracking issue: #303
 - Status: released

--- a/docs/release/v0.5-release-readiness.md
+++ b/docs/release/v0.5-release-readiness.md
@@ -23,6 +23,7 @@ Non-goals:
 - [x] Any deferred issues have a target version or follow-up issue.
 - [x] Version tracking issue #288 reflects final child issue state.
 - [x] Open v0.5 PRs are merged or explicitly deferred.
+- [x] Superseded duplicate v0.5 planning issues are identified for cleanup: #246, #252, #253, #254, #255, #256, #257.
 
 ## B. Documentation Readiness
 
@@ -59,6 +60,7 @@ Perform these checks on Windows with OBS installed or portable OBS available:
 - [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
 - [x] Release PR updates persistent release docs.
 - [x] Release PR is merged into `main`.
+- [x] Tag finalization docs are merged into `main`.
 - [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## E. Tagging After Merge

--- a/docs/release/v0.5-release-summary.md
+++ b/docs/release/v0.5-release-summary.md
@@ -26,11 +26,13 @@ Release: `v0.5.0` - Overlay Integration
 ## Major Issues And PRs
 
 - Child issues: #290, #291, #292, #293, #294, #295, #296
-- PRs: #297, #298, #299, #300, #301, #302
+- Implementation and acceptance PRs: #297, #298, #299, #300, #301, #302
+- Release documentation PRs: #304, #305
+- Superseded duplicate planning issues: #246, #252, #253, #254, #255, #256, #257
 
 ## Verification
 
-- CI succeeded on #297, #298, #299, #300, #301, and #302.
+- CI succeeded on #297, #298, #299, #300, #301, #302, #304, and #305.
 - Local Windows Plugin Release build succeeded for the smoke target.
 - Worker unittest discovery passed with 13 tests.
 - Markdown link validation passed.


### PR DESCRIPTION
## Summary
- record the superseded #246/#252-#257 v0.5 planning issues in release docs
- include #304/#305 release documentation PRs in the v0.5 release summary
- mark the v0.5 readiness checklist as covering duplicate issue cleanup and tag-finalization docs

## Verification
- OK: `powershell -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- OK: `python scripts\validate_jp_user_docs_coverage.py`

## Related Issues
- Refs #288
- Refs #246
- Refs #252
- Refs #253
- Refs #254
- Refs #255
- Refs #256
- Refs #257