### PR TITLE
Define v0.6 recording state readiness

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,11 +14,13 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [v0.3 release readiness checklist](release/v0.3-release-readiness.md)
 - [v0.4 release readiness checklist](release/v0.4-release-readiness.md)
 - [v0.5 release readiness checklist](release/v0.5-release-readiness.md)
+- [v0.6 release readiness checklist](release/v0.6-release-readiness.md)
 - [v0.4 release summary](release/v0.4-release-summary.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
 - [v0.3 SQLite Foundation acceptance checklist](requirements/v0.3-sqlite-foundation-acceptance.md)
 - [v0.4 OBS Plugin Skeleton acceptance checklist](requirements/v0.4-obs-plugin-skeleton-acceptance.md)
 - [v0.5 Overlay Integration acceptance checklist](requirements/v0.5-overlay-integration-acceptance.md)
+- [v0.6 Recording State Management acceptance checklist](requirements/v0.6-recording-state-management-acceptance.md)
 
 ## Architecture
 
@@ -28,8 +30,10 @@ Architecture documents describe technical behavior and responsibility boundaries
 - [Overlay architecture](architecture/overlay.md)
 - [Database design](architecture/db.md)
 - [Queue design](architecture/queue.md)
+- [Recording state machine](architecture/recording.md)
 - [Upload flow](architecture/upload.md)
 - [v0.5 OBS overlay smoke procedure](architecture/v0.5-overlay-smoke.md)
+- [v0.6 recording-state smoke procedure](architecture/v0.6-recording-state-smoke.md)
 
 ## Worker (Developer)
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -8,6 +8,7 @@ Architecture documents describe technical behavior, responsibility boundaries, a
 - [Queue State Machine](queue.md)
 - [Recording State Machine](recording.md)
 - [Upload Flow](upload.md)
+- [v0.6 Recording-State Smoke Procedure](v0.6-recording-state-smoke.md)
 
 ## Supporting Documents
 

--- a/docs/architecture/recording.md
+++ b/docs/architecture/recording.md
@@ -6,6 +6,8 @@ The OBS Plugin owns OBS recording control and lifecycle events.
 
 The Python Worker owns queue creation, recovery decisions, and persistent runtime state.
 
+v0.6 makes the Worker the authoritative owner of recording lifecycle state while the OBS Plugin remains the owner of OBS recording start/stop calls.
+
 ```mermaid
 stateDiagram-v2
     [*] --> idle
@@ -32,3 +34,54 @@ stateDiagram-v2
 - OCR must not be the primary recording trigger mechanism.
 - Interrupted recording sessions should be discarded during recovery.
 - Queue persistence is handled by the Python Worker, not the OBS Plugin.
+
+## v0.6 State Contract
+
+The v0.6 recording state contract is intentionally small and explicit.
+
+| State | Meaning |
+|---|---|
+| `idle` | No active recording session exists. |
+| `starting` | A manual or automatic command requested OBS recording start, but OBS has not confirmed active recording yet. |
+| `recording` | OBS recording is active for the current session. |
+| `stopping` | A stop command was accepted, but OBS has not confirmed final stop yet. |
+| `completed` | OBS stopped and the session can be handed to future queue creation. |
+| `interrupted` | Startup/restart found an in-progress session that must be discarded or recovered. |
+| `error` | The lifecycle entered a diagnosable failure state. |
+
+Allowed command sources:
+
+- `manual`: operator action from the Plugin/Dock or localhost API.
+- `automatic`: future detector action. v0.6 defines the shared boundary but does not implement v0.8 detection.
+- `recovery`: startup/restart recovery action.
+
+Allowed command actions:
+
+- `start`
+- `confirm_started`
+- `stop`
+- `confirm_stopped`
+- `mark_interrupted`
+- `discard_interrupted`
+- `reset`
+
+Invalid transitions must be rejected with a stable diagnostic. They must not silently mutate state.
+
+## v0.6 API Boundary
+
+The Worker should expose the authoritative state through localhost API routes:
+
+- `GET /recording/state`
+- `POST /recording/command`
+
+The Plugin should use this boundary for manual controls and OBS event synchronization. The v0.5 overlay `recording_state` display may mirror this state, but overlay display remains a consumer and not the owner.
+
+## Recovery Rules
+
+On startup, in-progress states are treated as interrupted:
+
+- `starting`
+- `recording`
+- `stopping`
+
+Recovery should move interrupted state to a documented discard/recovery outcome without deleting unrelated runtime files. Future versions may add queue handoff or media cleanup, but v0.6 must keep the behavior diagnosable and restart-safe.

--- a/docs/architecture/v0.6-recording-state-smoke.md
+++ b/docs/architecture/v0.6-recording-state-smoke.md
@@ -1,0 +1,125 @@
+# v0.6 Recording-State Smoke Procedure
+
+This document defines the minimal manual smoke procedure for **v0.6 - Recording State Management**.
+
+Use it to produce redaction-checked evidence for the v0.6 tracking issue (#247).
+
+## Preconditions
+
+- Windows host.
+- OBS Studio installed or portable OBS available.
+- Plugin built from the commit under test.
+- Worker dependencies installed.
+- Runtime root is a disposable smoke directory.
+- No credentials, tokens, videos, screenshots, databases, or logs are committed to the repository.
+
+## Environment Record
+
+Record:
+
+- repository commit SHA
+- OBS version
+- Plugin build configuration
+- Worker Python version
+- runtime root path
+- whether OBS was installed or portable
+- smoke start/end time
+
+## 1. Plugin Load And Worker Health
+
+1. Install the Plugin build into OBS.
+2. Launch OBS with the smoke runtime root.
+3. Confirm OBS loads the Plugin.
+4. Confirm the Worker starts or a healthy existing Worker is reused.
+5. Confirm `GET /health` and `GET /version` are compatible.
+6. Confirm the v0.5 overlay polling path still works.
+
+Expected evidence:
+- OBS log lines for Plugin load, Dock registration, Worker preflight, Worker running, and heartbeat.
+- Worker health response with `status=ok`.
+
+## 2. Recording State API Defaults
+
+Query the recording state endpoint.
+
+Expected:
+- state starts as `idle`
+- no active session is present
+- command source is deterministic
+- response contains enough identifiers/timestamps for smoke notes without exposing user data
+
+## 3. Manual Start
+
+Trigger manual start from the Plugin/Dock control or the equivalent localhost command route.
+
+Expected:
+- state transitions through a start path without invalid transition diagnostics
+- OBS recording start is requested when the Plugin control is used
+- overlay recording-state display changes from idle to the active recording display
+- repeated start is either idempotent or returns a stable conflict diagnostic
+
+## 4. Manual Stop
+
+Trigger manual stop from the Plugin/Dock control or the equivalent localhost command route.
+
+Expected:
+- state transitions through a stop path without invalid transition diagnostics
+- OBS recording stop is requested when the Plugin control is used
+- final state is stable and observable
+- repeated stop is either idempotent or returns a stable no-op/conflict diagnostic
+
+## 5. Automatic / Manual Synchronization Boundary
+
+Use the same command boundary with a non-manual source if implemented or API-smokeable.
+
+Expected:
+- automatic-source commands follow the same transition rules
+- no duplicate active recording session is created
+- conflict diagnostics identify the current state and requested action
+
+## 6. Interrupted Recovery / Discard
+
+Create or simulate an in-progress state and restart the Worker.
+
+Expected:
+- startup recovery detects interrupted state
+- interrupted recording is discarded or moved to the documented recovery outcome
+- unrelated runtime files are not deleted
+- diagnostics identify the recovered session and resulting state
+
+## 7. Redaction Check
+
+Before posting evidence:
+
+- remove local usernames if not needed
+- remove tokens, credentials, cookies, OAuth data, and absolute media paths if sensitive
+- do not attach runtime databases, videos, screenshots, or full logs
+- include only the log excerpts needed to prove the checks
+
+## Result Format
+
+Post a concise report to #247 and relevant child issues:
+
+```text
+Commit:
+OBS:
+Plugin build:
+Worker:
+Runtime root:
+
+Checks:
+- Plugin load:
+- Worker health:
+- Recording state default:
+- Manual start:
+- Manual stop:
+- Conflict/repeated command:
+- Overlay sync:
+- Recovery/discard:
+
+Evidence:
+- OBS log excerpt:
+- Worker/API response excerpt:
+
+Notes:
+```

--- a/docs/release/v0.6-release-readiness.md
+++ b/docs/release/v0.6-release-readiness.md
@@ -1,0 +1,75 @@
+# v0.6 Release Readiness Checklist
+
+This checklist helps contributors prepare a **v0.6.0** release for OBS Duel Recorder.
+
+Scope:
+- Documentation and verification steps for **v0.6 - Recording State Management** readiness.
+- No implementation work is performed by this checklist.
+
+Quick links:
+- Version tracking issue: #247
+- Acceptance checklist: `docs/requirements/v0.6-recording-state-management-acceptance.md`
+- Recording architecture contract: `docs/architecture/recording.md`
+- Windows OBS recording-state smoke evidence gate: TBD child issue
+
+Non-goals:
+- Creating the tag in this document.
+- Designing roadmap semantics.
+- Completing v0.7 Queue Recovery System or v0.8 Automatic Duel Recording.
+
+---
+
+## A. Milestone Readiness
+
+- [ ] Required v0.6 child issues are closed or explicitly deferred with a clear note.
+- [ ] Any deferred issues have a target version or follow-up issue.
+- [ ] Version tracking issue #247 reflects final child issue state.
+- [ ] Open v0.6 PRs are merged or explicitly deferred.
+- [ ] Superseded duplicate v0.6 tracking issues are identified for cleanup.
+
+## B. Documentation Readiness
+
+- [ ] Canonical docs are up to date:
+  - [ ] `docs/roadmap.md`
+  - [ ] `docs/requirements/requirements.md`
+  - [ ] `docs/traceability.md`
+  - [ ] `docs/requirements/v0.6-recording-state-management-acceptance.md`
+  - [ ] `docs/architecture/recording.md`
+  - [ ] v0.6 recording-state smoke procedure
+- [ ] README current development and latest release sections are ready for the release handoff.
+- [ ] Release history update is prepared.
+
+## C. Verification - Windows OBS Recording-State Smoke
+
+Perform these checks on Windows with OBS installed or portable OBS available:
+
+- [ ] Plugin builds successfully on Windows.
+- [ ] Plugin loads in OBS without crashing.
+- [ ] Existing v0.5 Worker launch, heartbeat, and overlay behavior still works.
+- [ ] Worker recording-state API starts in a deterministic idle state.
+- [ ] Manual start control requests recording start and updates recording state.
+- [ ] Manual stop control requests recording stop and updates recording state.
+- [ ] Repeated or conflicting commands produce deterministic diagnostics and do not crash OBS.
+- [ ] Recording-state overlay display follows the authoritative Worker state.
+- [ ] Interrupted or in-progress state recovery/discard behavior is exercised or explicitly deferred.
+- [ ] Smoke notes record the concrete environment and evidence.
+- [ ] A redaction-checked smoke report is posted to #247 and linked from the relevant child issues.
+
+## D. Release PR Readiness
+
+- [ ] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
+- [ ] Release PR updates persistent release docs.
+- [ ] Release PR is merged into `main`.
+- [ ] The merge commit SHA on `main` is recorded for tagging.
+
+## E. Tagging After Merge
+
+- [ ] Create tag `v0.6.0` pointing to the release merge commit SHA on `main`.
+- [ ] Do not move or overwrite existing tags.
+- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #247 and release docs.
+
+## F. Handoff
+
+- [ ] Next version tracking issue is created from `docs/roadmap.md`.
+- [ ] Next version tracking issue is linked from #247.
+- [ ] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/requirements/v0.6-recording-state-management-acceptance.md
+++ b/docs/requirements/v0.6-recording-state-management-acceptance.md
@@ -1,0 +1,95 @@
+# v0.6 Recording State Management - Acceptance Checklist
+
+This document defines the acceptance criteria for **v0.6 - Recording State Management** as described in:
+
+- `docs/roadmap.md`
+- `docs/requirements/requirements.md`
+- #247
+
+## Scope
+
+v0.6 creates the first stable recording lifecycle management layer:
+
+- recording state tracking
+- manual start and stop controls
+- automatic/manual state synchronization boundary
+- interrupted recording discard logic
+- recording recovery handling
+- Worker/Plugin diagnostics for lifecycle decisions
+
+## Non-goals
+
+- Queue Recovery System work reserved for v0.7.
+- Automatic Duel Recording and template matching work reserved for v0.8.
+- Upload/OAuth work reserved for v1.0+.
+- OCR-driven recording triggers.
+- Persisting runtime videos, screenshots, logs, databases, or generated media in the repository.
+
+## Terms
+
+- **Recording session**: one lifecycle attempt from start request through final stop, discard, or recovery.
+- **Manual command**: an operator-initiated start or stop request from the Plugin/Dock or API.
+- **Automatic command**: a future detector-initiated command. v0.6 must define the synchronization boundary without implementing v0.8 detection.
+- **Authoritative state**: the Worker-owned state exposed through the localhost API and persisted when durability is required.
+- **OBS control**: OBS recording start/stop calls owned by the Plugin.
+
+---
+
+## Acceptance Checklist
+
+### A. Recording State Model
+
+- [ ] A canonical contract defines stable v0.6 recording states.
+- [ ] Allowed transitions are documented and enforced.
+- [ ] Invalid transitions return deterministic diagnostics and do not corrupt state.
+- [ ] State responses expose enough information for Plugin/Dock display and smoke verification.
+- [ ] The model distinguishes idle, starting, recording, stopping, completed, interrupted, and error/recovery cases.
+
+### B. Manual Start And Stop Controls
+
+- [ ] Manual start can request a transition from idle to a start-pending/recording path.
+- [ ] Manual stop can request a transition from recording to a stop-pending/completed path.
+- [ ] Repeated start/stop commands are deterministic and diagnosable.
+- [ ] Plugin/Dock controls surface command success/failure without requiring users to inspect logs first.
+- [ ] Manual controls do not take ownership of v0.8 automatic detection.
+
+### C. Automatic / Manual Synchronization Boundary
+
+- [ ] Automatic and manual commands use the same state transition rules.
+- [ ] Conflicting commands cannot create duplicate recording sessions.
+- [ ] Stop commands are idempotent or produce a clear no-op/conflict diagnostic.
+- [ ] Future v0.8 detection can call the v0.6 boundary without redefining lifecycle state.
+
+### D. Interrupted Recording Discard And Recovery
+
+- [ ] Startup or restart can detect interrupted in-progress recording state.
+- [ ] Interrupted recordings have explicit discard/recovery outcomes.
+- [ ] Discard/recovery behavior is restart-safe and avoids deleting unrelated user files.
+- [ ] Runtime data safety boundaries are documented.
+- [ ] Recovery diagnostics identify the session and resulting state.
+
+### E. Worker / Plugin API Boundary
+
+- [ ] Worker exposes the recording state and command boundary through localhost API routes.
+- [ ] API payloads are validated with stable error codes.
+- [ ] Existing `/health`, `/version`, and v0.5 `/overlay/state` compatibility is preserved.
+- [ ] Overlay recording-state display can be driven from the authoritative recording state.
+- [ ] Worker tests cover state defaults, valid transitions, invalid transitions, and recovery behavior.
+
+### F. OBS Runtime Smoke
+
+- [ ] A v0.6 smoke procedure exists.
+- [ ] Smoke evidence records the tested commit SHA on `main`.
+- [ ] Smoke evidence proves Plugin load, Worker health, manual start/stop controls, recording-state API, overlay state synchronization, and recovery/discard diagnostics.
+- [ ] Smoke evidence is redaction-checked before being posted to the tracking issue.
+- [ ] OBS shutdown or harness cleanup issues are distinguished from Plugin/Worker failures.
+
+## References
+
+- #247
+- #258
+- #259
+- #260
+- #261
+- #262
+- #263

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -73,7 +73,11 @@ Goals:
 ### v0.6 - Recording State Management
 
 - Roadmap: `docs/roadmap.md` -> **v0.6 - Recording State Management**
-- Version tracking issue: `#303` - `[v0.6] Recording State Management release tracking`
+- Version tracking issue: `#247` - `[v0.6] Recording State Management release tracking`
+- Acceptance checklist: `docs/requirements/v0.6-recording-state-management-acceptance.md`
+- Release readiness checklist: `docs/release/v0.6-release-readiness.md`
+- Recording architecture contract: `docs/architecture/recording.md`
+- Smoke procedure: `docs/architecture/v0.6-recording-state-smoke.md`
 - Requirements (relevant sections):
   - `docs/requirements/requirements.md` -> Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
@@ -120,4 +124,4 @@ The version tracking issue itself is not an implementation work item.
 - Refs #288
 - Refs #291
 - Refs #296
-- Refs #303
+- Refs #247


### PR DESCRIPTION
## Summary
- add the v0.6 Recording State Management acceptance checklist
- add the v0.6 release readiness checklist and smoke procedure
- extend the recording architecture with the v0.6 state/API/recovery contract
- point traceability at #247 as the requested v0.6 tracking issue

## Verification
- OK: `powershell -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- OK: `python scripts\validate_jp_user_docs_coverage.py`

## Related Issues
- Refs #247
- Closes #262
- Closes #263
- Refs #258
- Refs #259
- Refs #260
- Refs #261