### PR TITLE
Add v0.6 recording state API

### DIFF
--- a/app/worker/README.md
+++ b/app/worker/README.md
@@ -37,6 +37,18 @@ Health check:
 Invoke-WebRequest http://127.0.0.1:8787/health | Select-Object -ExpandProperty Content
 ```
 
+Recording state check:
+
+```powershell
+Invoke-WebRequest http://127.0.0.1:8787/recording/state | Select-Object -ExpandProperty Content
+```
+
+Manual recording command example:
+
+```powershell
+Invoke-WebRequest http://127.0.0.1:8787/recording/command -Method Post -ContentType "application/json" -Body '{"action":"start","source":"manual"}' | Select-Object -ExpandProperty Content
+```
+
 Configuration scaffold (v0.2):
 - default config path: `user_data/config/worker.toml`
 - docs: `docs/architecture/worker-config.md`

--- a/app/worker/odr_worker/api.py
+++ b/app/worker/odr_worker/api.py
@@ -11,6 +11,14 @@ from .db import DbInfo
 from .health import API_VERSION, PID, STARTED_AT, WorkerDb, WorkerPaths, build_health_payload
 from .identity import INSTANCE_ID
 from .overlay import OverlayPayloadError, OverlayState, apply_overlay_update
+from .recording import (
+    RecordingCommandError,
+    apply_recording_command,
+    initialize_recording_state,
+    overlay_recording_state,
+    recording_state_path,
+    save_recording_state,
+)
 from .runtime_dirs import RuntimeDirs
 from .version import __version__
 
@@ -38,6 +46,12 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
     app.state.paths = worker_paths
     app.state.config_loaded = loaded_config.config_loaded
     app.state.overlay_state = OverlayState()
+    app.state.recording_state_path = recording_state_path(runtime_dirs.data_dir)
+    app.state.recording_state = initialize_recording_state(app.state.recording_state_path)
+    app.state.overlay_state = apply_overlay_update(
+        app.state.overlay_state,
+        {"recording_state": overlay_recording_state(app.state.recording_state)},
+    )
 
     app.state.db = None
     if db_info is not None:
@@ -85,6 +99,37 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
                 content=_error_payload(code="overlay_payload_invalid", message="Overlay payload must be JSON object"),
             )
         return app.state.overlay_state.as_payload()
+
+    @app.get("/recording/state")
+    def get_recording_state() -> dict[str, str]:
+        return app.state.recording_state.as_payload()
+
+    @app.post("/recording/command")
+    async def post_recording_command(request: Request):
+        try:
+            payload = await request.json()
+            app.state.recording_state = apply_recording_command(app.state.recording_state, payload)
+            save_recording_state(app.state.recording_state_path, app.state.recording_state)
+            app.state.overlay_state = apply_overlay_update(
+                app.state.overlay_state,
+                {"recording_state": overlay_recording_state(app.state.recording_state)},
+            )
+        except RecordingCommandError as exc:
+            status_code = 409 if exc.code == "recording_transition_invalid" else 400
+            return JSONResponse(
+                status_code=status_code,
+                content=_error_payload(
+                    code=exc.code,
+                    message="Recording command is invalid",
+                    details=exc.details,
+                ),
+            )
+        except ValueError:
+            return JSONResponse(
+                status_code=400,
+                content=_error_payload(code="recording_command_invalid", message="Recording command must be JSON object"),
+            )
+        return app.state.recording_state.as_payload()
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception):

--- a/app/worker/odr_worker/recording.py
+++ b/app/worker/odr_worker/recording.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import uuid
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any
+
+
+RECORDING_STATES = {
+    "idle",
+    "starting",
+    "recording",
+    "stopping",
+    "completed",
+    "interrupted",
+    "error",
+}
+ACTIVE_STATES = {"starting", "recording", "stopping"}
+COMMAND_ACTIONS = {
+    "start",
+    "confirm_started",
+    "stop",
+    "confirm_stopped",
+    "mark_interrupted",
+    "discard_interrupted",
+    "reset",
+}
+COMMAND_SOURCES = {"manual", "automatic", "recovery"}
+MAX_REASON_LENGTH = 256
+
+
+class RecordingCommandError(ValueError):
+    def __init__(self, *, code: str, details: dict[str, str]) -> None:
+        super().__init__(code)
+        self.code = code
+        self.details = details
+
+
+@dataclass(frozen=True)
+class RecordingState:
+    state: str = "idle"
+    session_id: str = ""
+    command_source: str = "recovery"
+    last_action: str = "init"
+    reason: str = ""
+    updated_at: str = ""
+
+    def normalized(self) -> "RecordingState":
+        if self.updated_at:
+            return self
+        return replace(self, updated_at=_utc_now_iso())
+
+    def as_payload(self) -> dict[str, str]:
+        return asdict(self.normalized())
+
+
+def recording_state_path(data_dir: Path) -> Path:
+    return (data_dir / "recording-state.json").resolve()
+
+
+def _utc_now_iso() -> str:
+    return _dt.datetime.now(tz=_dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _new_session_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _coerce_state(payload: Any) -> RecordingState:
+    if not isinstance(payload, dict):
+        return RecordingState(state="idle").normalized()
+
+    state = str(payload.get("state", "idle"))
+    if state not in RECORDING_STATES:
+        state = "error"
+
+    return RecordingState(
+        state=state,
+        session_id=str(payload.get("session_id", "")),
+        command_source=str(payload.get("command_source", "recovery")),
+        last_action=str(payload.get("last_action", "loaded")),
+        reason=str(payload.get("reason", "")),
+        updated_at=str(payload.get("updated_at", "")),
+    ).normalized()
+
+
+def load_recording_state(path: Path) -> RecordingState:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return RecordingState().normalized()
+    except (OSError, json.JSONDecodeError):
+        return RecordingState(state="error", last_action="load_failed", reason="recording_state_load_failed").normalized()
+    return _coerce_state(payload)
+
+
+def save_recording_state(path: Path, state: RecordingState) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(state.as_payload(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def recover_recording_state(state: RecordingState) -> RecordingState:
+    if state.state not in ACTIVE_STATES:
+        return state.normalized()
+    return replace(
+        state,
+        state="interrupted",
+        command_source="recovery",
+        last_action="startup_recovery",
+        reason="interrupted_active_recording_discard_required",
+        updated_at=_utc_now_iso(),
+    )
+
+
+def initialize_recording_state(path: Path) -> RecordingState:
+    state = recover_recording_state(load_recording_state(path))
+    save_recording_state(path, state)
+    return state
+
+
+def overlay_recording_state(state: RecordingState) -> str:
+    if state.state in {"starting", "recording", "stopping"}:
+        return "recording"
+    if state.state in {"idle", "completed"}:
+        return "idle"
+    return "unknown"
+
+
+def apply_recording_command(current: RecordingState, payload: Any) -> RecordingState:
+    if not isinstance(payload, dict):
+        raise RecordingCommandError(code="recording_command_invalid", details={"payload": "must_be_object"})
+
+    action = payload.get("action")
+    source = payload.get("source", "manual")
+    reason = payload.get("reason", "")
+    errors: dict[str, str] = {}
+
+    if not isinstance(action, str) or action not in COMMAND_ACTIONS:
+        errors["action"] = "unknown_action"
+    if not isinstance(source, str) or source not in COMMAND_SOURCES:
+        errors["source"] = "unknown_source"
+    if not isinstance(reason, str):
+        errors["reason"] = "must_be_string"
+    elif len(reason) > MAX_REASON_LENGTH:
+        errors["reason"] = "too_long"
+
+    if errors:
+        raise RecordingCommandError(code="recording_command_invalid", details=errors)
+
+    assert isinstance(action, str)
+    assert isinstance(source, str)
+    assert isinstance(reason, str)
+
+    next_state = _transition(current.normalized(), action=action, source=source, reason=reason)
+    return next_state
+
+
+def _transition(current: RecordingState, *, action: str, source: str, reason: str) -> RecordingState:
+    now = _utc_now_iso()
+
+    def changed(state: str, *, session_id: str | None = None, note: str = "") -> RecordingState:
+        return RecordingState(
+            state=state,
+            session_id=current.session_id if session_id is None else session_id,
+            command_source=source,
+            last_action=action,
+            reason=reason or note,
+            updated_at=now,
+        )
+
+    if action == "start":
+        if current.state in {"idle", "completed"}:
+            return changed("starting", session_id=_new_session_id())
+        raise RecordingCommandError(
+            code="recording_transition_invalid",
+            details={"state": current.state, "action": action, "reason": "active_or_unrecoverable_session_exists"},
+        )
+
+    if action == "confirm_started":
+        if current.state == "starting":
+            return changed("recording")
+        if current.state == "recording":
+            return changed("recording", note="already_recording")
+        raise RecordingCommandError(
+            code="recording_transition_invalid",
+            details={"state": current.state, "action": action, "reason": "start_not_pending"},
+        )
+
+    if action == "stop":
+        if current.state == "recording":
+            return changed("stopping")
+        raise RecordingCommandError(
+            code="recording_transition_invalid",
+            details={"state": current.state, "action": action, "reason": "recording_not_active"},
+        )
+
+    if action == "confirm_stopped":
+        if current.state == "stopping":
+            return changed("completed")
+        if current.state == "completed":
+            return changed("completed", note="already_completed")
+        raise RecordingCommandError(
+            code="recording_transition_invalid",
+            details={"state": current.state, "action": action, "reason": "stop_not_pending"},
+        )
+
+    if action == "mark_interrupted":
+        if current.state in ACTIVE_STATES:
+            return changed("interrupted", note="recording_interrupted")
+        raise RecordingCommandError(
+            code="recording_transition_invalid",
+            details={"state": current.state, "action": action, "reason": "no_active_recording"},
+        )
+
+    if action == "discard_interrupted":
+        if current.state == "interrupted":
+            return changed("idle", session_id="", note="interrupted_recording_discarded")
+        raise RecordingCommandError(
+            code="recording_transition_invalid",
+            details={"state": current.state, "action": action, "reason": "recording_not_interrupted"},
+        )
+
+    if action == "reset":
+        return changed("idle", session_id="", note="recording_state_reset")
+
+    raise RecordingCommandError(code="recording_command_invalid", details={"action": "unknown_action"})

--- a/app/worker/tests/test_recording.py
+++ b/app/worker/tests/test_recording.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+WORKER_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(WORKER_ROOT))
+
+
+class RecordingStateApiTests(unittest.TestCase):
+    def _client(self):
+        from fastapi.testclient import TestClient
+
+        from odr_worker.api import create_app
+        from odr_worker.config import LoadedWorkerConfig, WorkerConfig
+        from odr_worker.runtime_dirs import ensure_runtime_dirs
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        user_data_dir = Path(tmp.name)
+        runtime_dirs = ensure_runtime_dirs(user_data_dir=user_data_dir)
+        loaded_config = LoadedWorkerConfig(
+            config=WorkerConfig(),
+            config_path=runtime_dirs.config_dir / "worker.toml",
+            config_loaded=False,
+        )
+        return TestClient(create_app(runtime_dirs=runtime_dirs, loaded_config=loaded_config)), runtime_dirs
+
+    def test_recording_state_defaults_to_idle(self) -> None:
+        client, _ = self._client()
+
+        resp = client.get("/recording/state")
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["state"], "idle")
+        self.assertEqual(body["session_id"], "")
+        self.assertEqual(body["command_source"], "recovery")
+        self.assertEqual(body["last_action"], "init")
+        self.assertTrue(body["updated_at"].endswith("Z"))
+
+    def test_manual_start_confirm_stop_flow(self) -> None:
+        client, _ = self._client()
+
+        start = client.post("/recording/command", json={"action": "start", "source": "manual"})
+        self.assertEqual(start.status_code, 200)
+        start_body = start.json()
+        self.assertEqual(start_body["state"], "starting")
+        self.assertEqual(start_body["command_source"], "manual")
+        self.assertEqual(start_body["last_action"], "start")
+        self.assertNotEqual(start_body["session_id"], "")
+
+        overlay_start = client.get("/overlay/state")
+        self.assertEqual(overlay_start.json()["recording_state"], "recording")
+
+        confirmed = client.post("/recording/command", json={"action": "confirm_started", "source": "manual"})
+        self.assertEqual(confirmed.status_code, 200)
+        self.assertEqual(confirmed.json()["state"], "recording")
+        self.assertEqual(confirmed.json()["session_id"], start_body["session_id"])
+
+        stopping = client.post("/recording/command", json={"action": "stop", "source": "manual"})
+        self.assertEqual(stopping.status_code, 200)
+        self.assertEqual(stopping.json()["state"], "stopping")
+
+        completed = client.post("/recording/command", json={"action": "confirm_stopped", "source": "manual"})
+        self.assertEqual(completed.status_code, 200)
+        self.assertEqual(completed.json()["state"], "completed")
+        self.assertEqual(completed.json()["session_id"], start_body["session_id"])
+
+        overlay_completed = client.get("/overlay/state")
+        self.assertEqual(overlay_completed.json()["recording_state"], "idle")
+
+    def test_conflicting_commands_return_stable_diagnostics(self) -> None:
+        client, _ = self._client()
+
+        stop = client.post("/recording/command", json={"action": "stop", "source": "manual"})
+
+        self.assertEqual(stop.status_code, 409)
+        body = stop.json()
+        self.assertEqual(body["code"], "recording_transition_invalid")
+        self.assertEqual(body["details"]["state"], "idle")
+        self.assertEqual(body["details"]["action"], "stop")
+
+    def test_payload_validation_returns_stable_diagnostics(self) -> None:
+        client, _ = self._client()
+
+        resp = client.post(
+            "/recording/command",
+            json={"action": "bad", "source": "operator", "reason": 123},
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        body = resp.json()
+        self.assertEqual(body["code"], "recording_command_invalid")
+        self.assertEqual(body["details"]["action"], "unknown_action")
+        self.assertEqual(body["details"]["source"], "unknown_source")
+        self.assertEqual(body["details"]["reason"], "must_be_string")
+
+    def test_automatic_commands_use_same_boundary(self) -> None:
+        client, _ = self._client()
+
+        resp = client.post("/recording/command", json={"action": "start", "source": "automatic"})
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["state"], "starting")
+        self.assertEqual(body["command_source"], "automatic")
+
+    def test_interrupted_state_recovers_on_startup(self) -> None:
+        client, runtime_dirs = self._client()
+
+        started = client.post("/recording/command", json={"action": "start", "source": "manual"})
+        self.assertEqual(started.status_code, 200)
+        state_path = runtime_dirs.data_dir / "recording-state.json"
+        self.assertTrue(state_path.exists())
+
+        second_client, _ = self._client_for_runtime(runtime_dirs)
+        recovered = second_client.get("/recording/state")
+
+        self.assertEqual(recovered.status_code, 200)
+        body = recovered.json()
+        self.assertEqual(body["state"], "interrupted")
+        self.assertEqual(body["command_source"], "recovery")
+        self.assertEqual(body["last_action"], "startup_recovery")
+        self.assertEqual(body["session_id"], started.json()["session_id"])
+
+        overlay = second_client.get("/overlay/state")
+        self.assertEqual(overlay.json()["recording_state"], "unknown")
+
+    def test_discard_interrupted_returns_to_idle(self) -> None:
+        client, runtime_dirs = self._client()
+        state_path = runtime_dirs.data_dir / "recording-state.json"
+        state_path.write_text(
+            json.dumps(
+                {
+                    "state": "recording",
+                    "session_id": "session-1",
+                    "command_source": "manual",
+                    "last_action": "confirm_started",
+                    "reason": "",
+                    "updated_at": "2026-05-23T00:00:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+        recovered_client, _ = self._client_for_runtime(runtime_dirs)
+
+        discarded = recovered_client.post(
+            "/recording/command",
+            json={"action": "discard_interrupted", "source": "recovery"},
+        )
+
+        self.assertEqual(discarded.status_code, 200)
+        self.assertEqual(discarded.json()["state"], "idle")
+        self.assertEqual(discarded.json()["session_id"], "")
+
+    def _client_for_runtime(self, runtime_dirs):
+        from fastapi.testclient import TestClient
+
+        from odr_worker.api import create_app
+        from odr_worker.config import LoadedWorkerConfig, WorkerConfig
+
+        loaded_config = LoadedWorkerConfig(
+            config=WorkerConfig(),
+            config_path=runtime_dirs.config_dir / "worker.toml",
+            config_loaded=False,
+        )
+        return TestClient(create_app(runtime_dirs=runtime_dirs, loaded_config=loaded_config)), runtime_dirs
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/architecture/recording.md
+++ b/docs/architecture/recording.md
@@ -69,7 +69,7 @@ Invalid transitions must be rejected with a stable diagnostic. They must not sil
 
 ## v0.6 API Boundary
 
-The Worker should expose the authoritative state through localhost API routes:
+The Worker exposes the authoritative state through localhost API routes:
 
 - `GET /recording/state`
 - `POST /recording/command`

--- a/docs/architecture/worker-api.md
+++ b/docs/architecture/worker-api.md
@@ -39,3 +39,47 @@ Compatibility rules for `api_version` live in:
 
 Canonical v0.2 acceptance criteria:
 - `docs/requirements/v0.2-worker-core-api-acceptance.md`
+
+---
+
+## v0.6 Recording State Endpoints
+
+v0.6 adds a recording lifecycle boundary while preserving `/health`, `/version`, and `/overlay/state` compatibility.
+
+### `GET /recording/state`
+
+Purpose:
+- Return the Worker-owned authoritative recording lifecycle state.
+- Provide enough state for Plugin/Dock display and smoke verification.
+- Support restart recovery diagnostics.
+
+Response fields:
+
+- `state`: one of `idle`, `starting`, `recording`, `stopping`, `completed`, `interrupted`, or `error`
+- `session_id`: active or most recent recording session identifier, or empty when none exists
+- `command_source`: `manual`, `automatic`, or `recovery`
+- `last_action`: last accepted lifecycle command
+- `reason`: optional diagnostic reason
+- `updated_at`: UTC ISO 8601 timestamp
+
+### `POST /recording/command`
+
+Purpose:
+- Apply one lifecycle command through the same boundary for manual, automatic, and recovery sources.
+- Reject invalid transitions without mutating state.
+
+Request fields:
+
+- `action`: one of `start`, `confirm_started`, `stop`, `confirm_stopped`, `mark_interrupted`, `discard_interrupted`, or `reset`
+- `source`: optional; one of `manual`, `automatic`, or `recovery`; defaults to `manual`
+- `reason`: optional diagnostic string
+
+Error behavior:
+
+- Invalid payloads return HTTP 400 with `code=recording_command_invalid`.
+- Invalid transitions return HTTP 409 with `code=recording_transition_invalid`.
+- Error details include at least the current state and requested action when transition validation fails.
+
+The v0.6 recording API is defined by:
+- `docs/architecture/recording.md`
+- `docs/requirements/v0.6-recording-state-management-acceptance.md`


### PR DESCRIPTION
## Summary
- add Worker-owned recording lifecycle state with JSON persistence under the runtime data directory
- add `GET /recording/state` and `POST /recording/command`
- validate invalid payloads and invalid transitions with stable error codes
- recover active states as `interrupted` on Worker startup and support discard/reset commands
- mirror authoritative recording state into the existing v0.5 overlay `recording_state` display

## Verification
- OK: `python -m unittest discover -s app\worker\tests` (20 tests)
- OK: `powershell -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- OK: `python scripts\validate_jp_user_docs_coverage.py`

## Related Issues
- Refs #247
- Closes #258
- Closes #260
- Closes #261
- Refs #259