### PR TITLE
Add v0.6 manual recording controls

### DIFF
--- a/app/plugin/README.md
+++ b/app/plugin/README.md
@@ -18,9 +18,9 @@ The Plugin must not:
 - directly manipulate SQLite
 - directly upload to YouTube
 
-## Current v0.5 Overlay Integration
+## Current v0.6 Recording State Management
 
-The current scaffold keeps the v0.4 Worker lifecycle surface and adds the first v0.5 overlay source-management layer:
+The current scaffold keeps the v0.5 overlay surface and adds v0.6 manual recording lifecycle controls:
 
 - Build a loadable OBS module.
 - Register minimal OBS Frontend API lifecycle hooks.
@@ -33,9 +33,11 @@ The current scaffold keeps the v0.4 Worker lifecycle surface and adds the first 
 - Load additive `overlay` settings with v0.5 defaults.
 - Find or create the fixed OBS Text Sources for deck name, sequence number, result, opponent deck, and recording state display.
 - Log stable overlay diagnostics for missing, duplicated, unsupported, unavailable, or failed source operations.
+- Add Dock buttons for manual OBS recording start and stop.
+- Synchronize OBS recording started/stopped frontend events through the Worker recording-state API.
 
 Current non-goals:
-- Full control UI.
+- Full control UI beyond the v0.6 manual start/stop controls.
 - Overlay UX.
 - OAuth/upload setup.
 
@@ -134,7 +136,7 @@ Behavior:
 
 The Plugin registers an `OBS Duel Recorder` Dock through the OBS Frontend API.
 
-The v0.4 Dock is status-first. It displays:
+The Dock is status-first. It displays:
 - diagnostic state (`not_started`, `starting`, `running`, `unhealthy`, `config_error`, `runtime_dir_error`, `api_incompatible`, `crashed`)
 - endpoint
 - resolved `user_data_dir`
@@ -142,8 +144,18 @@ The v0.4 Dock is status-first. It displays:
 - Worker ownership (`plugin-spawned` or `reused-existing`)
 - latest probe/detail text
 - recommended action
+- manual start/stop recording buttons
 
-The Dock intentionally does not provide full Worker controls in v0.4.
+The Dock intentionally does not provide full Worker controls beyond the v0.6 manual recording lifecycle actions.
+
+## Manual Recording Controls
+
+The Dock `Start Recording` and `Stop Recording` buttons use the v0.6 recording-state API:
+
+- `Start Recording` sends `POST /recording/command` with `{"action":"start","source":"manual"}` and then requests OBS recording start.
+- `Stop Recording` sends `POST /recording/command` with `{"action":"stop","source":"manual"}` and then requests OBS recording stop.
+- OBS `RECORDING_STARTED` and `RECORDING_STOPPED` frontend events send `confirm_started` and `confirm_stopped` commands back to the Worker.
+- Command failures are logged with stable HTTP/status evidence and do not crash OBS.
 
 ## Worker Launch Inputs
 
@@ -214,6 +226,6 @@ The script writes `build/plugin/v0.4-plugin-smoke-report.md` by default.
 
 ## Current Lifecycle Surface
 
-The scaffold registers an OBS Frontend API callback, logs lightweight lifecycle events, runs the initial Worker preflight/launch/heartbeat flow, and surfaces status-first diagnostics in a Dock.
+The scaffold registers OBS Frontend API callbacks, logs lightweight lifecycle events, runs the initial Worker preflight/launch/heartbeat flow, surfaces status-first diagnostics in a Dock, and provides v0.6 manual recording start/stop controls.
 
 Heavy work must remain outside the plugin process. Full controls, overlay UX, and upload/OAuth setup remain later-version work.

--- a/app/plugin/src/plugin-main.cpp
+++ b/app/plugin/src/plugin-main.cpp
@@ -25,6 +25,19 @@ void launch_worker()
 	worker_manager.start_async(std::move(config));
 }
 
+void log_recording_command_result(const char *action, const odr::plugin::RecordingCommandResult &result)
+{
+	if (result.accepted()) {
+		blog(LOG_INFO,
+		     "%s recording event_command=%s accepted state=%s session_id=%s source=%s last_action=%s",
+		     kLogPrefix, action, result.state.state.c_str(), result.state.session_id.c_str(),
+		     result.state.command_source.c_str(), result.state.last_action.c_str());
+		return;
+	}
+	blog(LOG_WARNING, "%s recording event_command=%s failed status=%d http=%lu error=%s",
+	     kLogPrefix, action, static_cast<int>(result.status), result.http_status, result.error.c_str());
+}
+
 void frontend_event(enum obs_frontend_event event, void *)
 {
 	switch (event) {
@@ -36,6 +49,16 @@ void frontend_event(enum obs_frontend_event event, void *)
 	case OBS_FRONTEND_EVENT_EXIT:
 		blog(LOG_INFO, "%s frontend exit", kLogPrefix);
 		worker_manager.stop();
+		break;
+	case OBS_FRONTEND_EVENT_RECORDING_STARTED:
+		log_recording_command_result(
+			"confirm_started",
+			worker_manager.send_recording_command("confirm_started", "manual"));
+		break;
+	case OBS_FRONTEND_EVENT_RECORDING_STOPPED:
+		log_recording_command_result(
+			"confirm_stopped",
+			worker_manager.send_recording_command("confirm_stopped", "manual"));
 		break;
 	default:
 		break;

--- a/app/plugin/src/plugin-ui.cpp
+++ b/app/plugin/src/plugin-ui.cpp
@@ -144,6 +144,15 @@ void PluginUiController::register_ui()
 	auto *settings_button = new QPushButton("Settings");
 	QObject::connect(settings_button, &QPushButton::clicked, [this]() { show_settings_dialog(); });
 	root->addWidget(settings_button);
+
+	auto *recording_controls = new QHBoxLayout;
+	start_button_ = new QPushButton("Start Recording");
+	stop_button_ = new QPushButton("Stop Recording");
+	QObject::connect(start_button_, &QPushButton::clicked, [this]() { request_manual_start(); });
+	QObject::connect(stop_button_, &QPushButton::clicked, [this]() { request_manual_stop(); });
+	recording_controls->addWidget(start_button_);
+	recording_controls->addWidget(stop_button_);
+	root->addLayout(recording_controls);
 	root->addStretch(1);
 
 	if (!obs_frontend_add_dock_by_id(kDockId, "OBS Duel Recorder", dock_widget_)) {
@@ -191,6 +200,13 @@ void PluginUiController::refresh()
 	ownership_value_->setText(QString::fromUtf8(ownership_name(snapshot.ownership)));
 	detail_value_->setText(qstr_utf8(snapshot.error.empty() ? snapshot.last_probe_summary : snapshot.error));
 	action_value_->setText(QString::fromUtf8(recommended_action(snapshot.state)));
+	const bool worker_running = snapshot.state == WorkerDiagnosticState::running;
+	if (start_button_) {
+		start_button_->setEnabled(worker_running);
+	}
+	if (stop_button_) {
+		stop_button_->setEnabled(worker_running);
+	}
 
 	if (snapshot.overlay_state_available &&
 	    (!overlay_state_applied_ ||
@@ -274,6 +290,58 @@ void PluginUiController::save_settings_and_restart(const PluginSettings &setting
 	worker_manager_.stop();
 	worker_manager_.start_async(make_launch_config(settings));
 	refresh();
+}
+
+void PluginUiController::request_manual_start()
+{
+	RecordingCommandResult start = worker_manager_.send_recording_command("start", "manual");
+	log_recording_command_result("start", start);
+	if (!start.accepted()) {
+		refresh();
+		return;
+	}
+
+	if (obs_frontend_recording_active()) {
+		RecordingCommandResult confirm = worker_manager_.send_recording_command("confirm_started", "manual");
+		log_recording_command_result("confirm_started", confirm);
+	} else {
+		obs_frontend_recording_start();
+		blog(LOG_INFO, "%s recording manual_start requested_obs_start", kLogPrefix);
+	}
+	refresh();
+}
+
+void PluginUiController::request_manual_stop()
+{
+	RecordingCommandResult stop = worker_manager_.send_recording_command("stop", "manual");
+	log_recording_command_result("stop", stop);
+	if (!stop.accepted()) {
+		refresh();
+		return;
+	}
+
+	if (obs_frontend_recording_active()) {
+		obs_frontend_recording_stop();
+		blog(LOG_INFO, "%s recording manual_stop requested_obs_stop", kLogPrefix);
+	} else {
+		RecordingCommandResult confirm = worker_manager_.send_recording_command("confirm_stopped", "manual");
+		log_recording_command_result("confirm_stopped", confirm);
+	}
+	refresh();
+}
+
+void PluginUiController::log_recording_command_result(const char *action, const RecordingCommandResult &result)
+{
+	if (result.accepted()) {
+		blog(LOG_INFO,
+		     "%s recording command=%s accepted state=%s session_id=%s source=%s last_action=%s",
+		     kLogPrefix, action, result.state.state.c_str(), result.state.session_id.c_str(),
+		     result.state.command_source.c_str(), result.state.last_action.c_str());
+		return;
+	}
+
+	blog(LOG_WARNING, "%s recording command=%s failed status=%d http=%lu error=%s",
+	     kLogPrefix, action, static_cast<int>(result.status), result.http_status, result.error.c_str());
 }
 
 } // namespace odr::plugin

--- a/app/plugin/src/plugin-ui.hpp
+++ b/app/plugin/src/plugin-ui.hpp
@@ -4,6 +4,7 @@
 #include "worker-launcher.hpp"
 
 class QLabel;
+class QPushButton;
 class QTimer;
 class QWidget;
 
@@ -21,6 +22,9 @@ private:
 	static void open_settings_from_menu(void *private_data);
 	void show_settings_dialog();
 	void save_settings_and_restart(const PluginSettings &settings);
+	void request_manual_start();
+	void request_manual_stop();
+	void log_recording_command_result(const char *action, const RecordingCommandResult &result);
 
 	WorkerProcessManager &worker_manager_;
 	QWidget *dock_widget_ = nullptr;
@@ -32,6 +36,8 @@ private:
 	QLabel *ownership_value_ = nullptr;
 	QLabel *detail_value_ = nullptr;
 	QLabel *action_value_ = nullptr;
+	QPushButton *start_button_ = nullptr;
+	QPushButton *stop_button_ = nullptr;
 	OverlayStatePayload last_applied_overlay_state_;
 	bool overlay_state_applied_ = false;
 	bool tools_menu_registered_ = false;

--- a/app/plugin/src/worker-api.cpp
+++ b/app/plugin/src/worker-api.cpp
@@ -56,7 +56,21 @@ struct HttpResponse {
 	std::string error;
 };
 
+HttpResponse http_request(const WorkerEndpoint &endpoint, const wchar_t *method, const wchar_t *path,
+			  const std::string &request_body);
+
 HttpResponse http_get(const WorkerEndpoint &endpoint, const wchar_t *path)
+{
+	return http_request(endpoint, L"GET", path, {});
+}
+
+HttpResponse http_post_json(const WorkerEndpoint &endpoint, const wchar_t *path, const std::string &body)
+{
+	return http_request(endpoint, L"POST", path, body);
+}
+
+HttpResponse http_request(const WorkerEndpoint &endpoint, const wchar_t *method, const wchar_t *path,
+			  const std::string &request_body)
 {
 	HttpResponse response;
 	HINTERNET session = WinHttpOpen(L"OBS Duel Recorder Plugin/0.4",
@@ -77,7 +91,7 @@ HttpResponse http_get(const WorkerEndpoint &endpoint, const wchar_t *path)
 		return response;
 	}
 
-	HINTERNET request = WinHttpOpenRequest(connection, L"GET", path, nullptr,
+	HINTERNET request = WinHttpOpenRequest(connection, method, path, nullptr,
 					      WINHTTP_NO_REFERER,
 					      WINHTTP_DEFAULT_ACCEPT_TYPES, 0);
 	if (!request) {
@@ -87,8 +101,14 @@ HttpResponse http_get(const WorkerEndpoint &endpoint, const wchar_t *path)
 		return response;
 	}
 
-	if (!WinHttpSendRequest(request, WINHTTP_NO_ADDITIONAL_HEADERS, 0,
-				WINHTTP_NO_REQUEST_DATA, 0, 0, 0) ||
+	const wchar_t *headers = request_body.empty() ? WINHTTP_NO_ADDITIONAL_HEADERS : L"Content-Type: application/json";
+	const DWORD headers_length = request_body.empty() ? 0 : static_cast<DWORD>(-1L);
+	LPVOID body_data = request_body.empty() ? WINHTTP_NO_REQUEST_DATA :
+					    const_cast<char *>(request_body.data());
+	const DWORD body_size = static_cast<DWORD>(request_body.size());
+
+	if (!WinHttpSendRequest(request, headers, headers_length,
+				body_data, body_size, body_size, 0) ||
 	    !WinHttpReceiveResponse(request, nullptr)) {
 		response.error = "Worker API did not respond";
 		WinHttpCloseHandle(request);
@@ -264,6 +284,61 @@ OverlayFetchResult LocalhostApiClient::fetch_overlay_state(const WorkerEndpoint 
 #else
 	result.status = OverlayFetchStatus::unavailable;
 	result.error = "Overlay state probing is only implemented on Windows";
+	return result;
+#endif
+}
+
+RecordingCommandResult LocalhostApiClient::send_recording_command(const WorkerEndpoint &endpoint,
+								  const std::string &action,
+								  const std::string &source) const
+{
+	RecordingCommandResult result;
+
+#ifdef _WIN32
+	const std::string body = "{\"action\":\"" + action + "\",\"source\":\"" + source + "\"}";
+	const HttpResponse response = http_post_json(endpoint, L"/recording/command", body);
+	result.http_status = response.status;
+	result.body = response.body;
+
+	if (!response.ok) {
+		result.status = RecordingCommandStatus::unavailable;
+		result.error = response.error;
+		return result;
+	}
+
+	if (response.status == 400 || response.status == 409) {
+		result.status = RecordingCommandStatus::rejected;
+		result.error = extract_json_string(response.body, "message");
+		if (result.error.empty()) {
+			result.error = "POST /recording/command rejected command";
+		}
+		return result;
+	}
+
+	if (response.status != 200) {
+		result.status = RecordingCommandStatus::invalid_response;
+		result.error = "POST /recording/command returned non-200 status";
+		return result;
+	}
+
+	result.state.state = extract_json_string(response.body, "state");
+	result.state.session_id = extract_json_string(response.body, "session_id");
+	result.state.command_source = extract_json_string(response.body, "command_source");
+	result.state.last_action = extract_json_string(response.body, "last_action");
+	result.state.reason = extract_json_string(response.body, "reason");
+	result.state.updated_at = extract_json_string(response.body, "updated_at");
+
+	if (result.state.state.empty() || result.state.updated_at.empty()) {
+		result.status = RecordingCommandStatus::invalid_response;
+		result.error = "POST /recording/command response is missing required fields";
+		return result;
+	}
+
+	result.status = RecordingCommandStatus::accepted;
+	return result;
+#else
+	result.status = RecordingCommandStatus::unavailable;
+	result.error = "Recording commands are only implemented on Windows";
 	return result;
 #endif
 }

--- a/app/plugin/src/worker-api.hpp
+++ b/app/plugin/src/worker-api.hpp
@@ -58,12 +58,43 @@ struct OverlayFetchResult {
 	std::string body;
 };
 
+enum class RecordingCommandStatus {
+	accepted,
+	unavailable,
+	rejected,
+	invalid_response,
+};
+
+struct RecordingStatePayload {
+	std::string state;
+	std::string session_id;
+	std::string command_source;
+	std::string last_action;
+	std::string reason;
+	std::string updated_at;
+};
+
+struct RecordingCommandResult {
+	RecordingCommandStatus status = RecordingCommandStatus::unavailable;
+	unsigned long http_status = 0;
+	RecordingStatePayload state;
+	std::string error;
+	std::string body;
+
+	bool accepted() const
+	{
+		return status == RecordingCommandStatus::accepted;
+	}
+};
+
 class LocalhostApiClient {
 public:
 	explicit LocalhostApiClient(std::string expected_api_version, std::string expected_worker_version);
 
 	WorkerProbeResult probe_health(const WorkerEndpoint &endpoint, const std::wstring &expected_user_data_dir) const;
 	OverlayFetchResult fetch_overlay_state(const WorkerEndpoint &endpoint) const;
+	RecordingCommandResult send_recording_command(const WorkerEndpoint &endpoint, const std::string &action,
+						      const std::string &source) const;
 
 private:
 	std::string expected_api_version_;

--- a/app/plugin/src/worker-launcher.cpp
+++ b/app/plugin/src/worker-launcher.cpp
@@ -376,6 +376,22 @@ WorkerStatusSnapshot WorkerProcessManager::status_snapshot() const
 	return status_;
 }
 
+RecordingCommandResult WorkerProcessManager::send_recording_command(const std::string &action, const std::string &source)
+{
+	WorkerEndpoint endpoint;
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+		endpoint = status_.endpoint;
+		if (status_.state != WorkerDiagnosticState::running) {
+			RecordingCommandResult result;
+			result.status = RecordingCommandStatus::unavailable;
+			result.error = "Worker is not running";
+			return result;
+		}
+	}
+	return api_client_.send_recording_command(endpoint, action, source);
+}
+
 void WorkerProcessManager::stop()
 {
 	stop_requested_ = true;

--- a/app/plugin/src/worker-launcher.hpp
+++ b/app/plugin/src/worker-launcher.hpp
@@ -67,6 +67,7 @@ public:
 	void start_async(WorkerLaunchConfig config);
 	void stop();
 	WorkerStatusSnapshot status_snapshot() const;
+	RecordingCommandResult send_recording_command(const std::string &action, const std::string &source);
 
 private:
 	void start(WorkerLaunchConfig config);


### PR DESCRIPTION
## Summary
- add Dock `Start Recording` / `Stop Recording` buttons
- send manual recording commands to the Worker v0.6 recording-state API
- request OBS recording start/stop from the Plugin
- synchronize OBS recording started/stopped frontend events back to the Worker with confirm commands
- document the v0.6 manual lifecycle surface in `app/plugin/README.md`

## Verification
- OK: `python -m unittest discover -s app\worker\tests` (20 tests)
- OK: `powershell -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- OK: `python scripts\validate_jp_user_docs_coverage.py`
- OK: CMake configure/build with VS BuildTools and OBS/Qt smoke dependencies -> `build\plugin-v06-manual2\Release\obs-duel-recorder.dll`

## Build note
The shell had duplicate `PATH`/`Path` environment keys; the successful CMake command removed the duplicate `PATH` key inside that command process before invoking VS BuildTools.

## Related Issues
- Refs #247
- Closes #259
- Refs #258
- Refs #260
- Refs #261