### PR TITLE
Record v0.6 release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ obs-duel-recorder/
 
 - Version: `v0.6.0`
 - Scope: Recording State Management
-- Status: release finalization in progress
-- Tag target: to be recorded after the v0.6 release PR merge
+- Status: released
+- Tag target: `0654f2b78a75426ab17310c3a58689a72be5c816`
 - Tracking issue: [#247](https://github.com/Tao-pyth/obs-duel-recorder/issues/247)
 - Release record: [docs/release-history.md](docs/release-history.md)
 

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -91,9 +91,10 @@ The version tracking issue may contain the working release summary, but finalize
 - Version tracking issue: #247
 - Milestone: `v0.6` (not set)
 - Release readiness checklist: `docs/release/v0.6-release-readiness.md`
-- Tag: `v0.6.0` intended; tag target will be finalized after the v0.6 release PR merge
-- Intended tag target: release merge commit on `main`
-- Release finalized at: pending release PR merge
+- Tag: `v0.6.0`
+- Tag target: `0654f2b78a75426ab17310c3a58689a72be5c816`
+- Release finalized at: `2026-05-23T03:03:08+09:00`
+- Tag finalized at: `2026-05-23T03:03:52+09:00`
 - Release summary: `docs/release/v0.6-release-summary.md`
 - Major child issues: #258, #259, #260, #261, #262, #263, #310
 - Smoke evidence gate: #310
@@ -101,4 +102,4 @@ The version tracking issue may contain the working release summary, but finalize
 - Superseded duplicate planning issue: #303
 - Deferred items: Queue Recovery System remains in #248; Automatic Duel Recording remains v0.8
 - Next version tracking issue: #248
-- Status: release finalization in progress
+- Status: released

--- a/docs/release/v0.6-release-readiness.md
+++ b/docs/release/v0.6-release-readiness.md
@@ -23,7 +23,7 @@ Non-goals:
 
 - [x] Required v0.6 child issues are closed or explicitly deferred with a clear note.
 - [x] Any deferred issues have a target version or follow-up issue.
-- [ ] Version tracking issue #247 reflects final child issue state.
+- [x] Version tracking issue #247 reflects final child issue state.
 - [x] Open v0.6 PRs are merged or explicitly deferred.
 - [x] Superseded duplicate v0.6 tracking issues are identified for cleanup.
 
@@ -59,17 +59,17 @@ Perform these checks on Windows with OBS installed or portable OBS available:
 
 - [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
 - [x] Release PR updates persistent release docs.
-- [ ] Release PR is merged into `main`.
-- [ ] The merge commit SHA on `main` is recorded for tagging.
+- [x] Release PR is merged into `main`.
+- [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## E. Tagging After Merge
 
-- [ ] Create tag `v0.6.0` pointing to the release merge commit SHA on `main`.
-- [ ] Do not move or overwrite existing tags.
-- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #247 and release docs.
+- [x] Create tag `v0.6.0` pointing to the release merge commit SHA on `main`.
+- [x] Do not move or overwrite existing tags.
+- [x] If tooling cannot create the tag, record the intended tag name and target SHA in #247 and release docs.
 
 ## F. Handoff
 
 - [x] Next version tracking issue is created from `docs/roadmap.md`.
-- [ ] Next version tracking issue is linked from #247.
+- [x] Next version tracking issue is linked from #247.
 - [x] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/release/v0.6-release-summary.md
+++ b/docs/release/v0.6-release-summary.md
@@ -4,9 +4,10 @@
 
 - Version tracking issue: #247
 - Release readiness checklist: `docs/release/v0.6-release-readiness.md`
-- Tag: `v0.6.0` intended
-- Intended tag target: release merge commit on `main`
-- Release finalized at: pending release PR merge
+- Tag: `v0.6.0`
+- Tag target: `0654f2b78a75426ab17310c3a58689a72be5c816`
+- Release finalized at: `2026-05-23T03:03:08+09:00`
+- Tag finalized at: `2026-05-23T03:03:52+09:00`
 - Next version tracking issue: #248
 
 ## Completed Scope


### PR DESCRIPTION
## Summary
- record the finalized `v0.6.0` tag target and timestamps
- mark v0.6 release readiness gates complete
- update README/latest release status from finalization to released

## Verification
- `python scripts\validate_markdown_links.py`
- `python scripts\validate_jp_user_docs_coverage.py`

Refs #247
Refs #310