### PR TITLE
Record v0.7 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Major and minor release completions are tagged as `vMajor.Minor.Patch`. See [Rel
 ## Current Development
 
 Latest released version:
-- `v0.6.0` - Recording State Management
+- `v0.7.0` - Queue Recovery System
 
 Current development target:
-- `v0.7` - Queue Recovery System
-- Tracking issue: [#248](https://github.com/Tao-pyth/obs-duel-recorder/issues/248)
+- `v0.8` - Template Matching MVP
+- Tracking issue: [#249](https://github.com/Tao-pyth/obs-duel-recorder/issues/249)
 
 Next roadmap target:
-- `v0.8` - Automatic Duel Recording
+- `v0.9` - Screenshot System
 
 ---
 
@@ -55,11 +55,10 @@ Current released foundation:
 - OBS overlay Text Source integration
 
 Planned roadmap capabilities:
-- Match queue management (`v0.7`)
 - Automatic duel recording (`v0.8`)
+- Screenshot capture and linkage (`v0.9`)
 - YouTube archive upload (`v1.0`)
 - Match memo support (`v1.1`)
-- Upload retry / recovery support (`v0.7`)
 - GitHub Actions based packaging (`v1.4+`)
 
 ---
@@ -109,27 +108,26 @@ obs-duel-recorder/
 
 ### Latest Release
 
-- Version: `v0.6.0`
-- Scope: Recording State Management
+- Version: `v0.7.0`
+- Scope: Queue Recovery System
 - Status: released
-- Tag target: `0654f2b78a75426ab17310c3a58689a72be5c816`
-- Tracking issue: [#247](https://github.com/Tao-pyth/obs-duel-recorder/issues/247)
+- Tag target: `b0a262ac9500a6ec0ee43f9091ad0fee0e79f0dd`
+- Tracking issue: [#248](https://github.com/Tao-pyth/obs-duel-recorder/issues/248)
 - Release record: [docs/release-history.md](docs/release-history.md)
 
-### Completed in v0.6
+### Completed in v0.7
 
-- Worker-owned recording lifecycle state model
-- Recording state API at `/recording/state` and `/recording/command`
-- Manual OBS Dock start/stop controls
-- OBS frontend recording event synchronization
-- Interrupted recording recovery and discard handling
-- Overlay recording-state display driven from authoritative Worker state
-- Windows OBS recording-state smoke evidence recorded in #310
+- Recovery-safe upload queue schema migration
+- Worker queue API at `/queue/items` and `/queue/items/{id}/command`
+- Startup reconciliation for interrupted `uploading` items
+- Retry, retry-limit, and `quota_waiting` state handling
+- `need_manual_review` runtime state and manual adjudication evidence
+- Queue recovery acceptance and release readiness documentation
 
-### Planned After v0.6
+### Planned After v0.7
 
-- `v0.7` - Queue Recovery System
-- Later roadmap items include queue recovery, template matching, upload automation, packaging, and GitHub Pages documentation.
+- `v0.8` - Template Matching MVP
+- Later roadmap items include template matching, screenshot capture, upload automation, packaging, and GitHub Pages documentation.
 
 ---
 

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -103,3 +103,19 @@ The version tracking issue may contain the working release summary, but finalize
 - Deferred items: Queue Recovery System remains in #248; Automatic Duel Recording remains v0.8
 - Next version tracking issue: #248
 - Status: released
+
+### v0.7.0 - Queue Recovery System
+
+- Version tracking issue: #248
+- Milestone: `v0.7` (not set)
+- Release readiness checklist: `docs/release/v0.7-release-readiness.md`
+- Tag: `v0.7.0`
+- Tag target: `b0a262ac9500a6ec0ee43f9091ad0fee0e79f0dd`
+- Release finalized at: `2026-05-23T03:21:37+09:00`
+- Tag finalized at: `2026-05-23T03:22:11+09:00`
+- Release summary: `docs/release/v0.7-release-summary.md`
+- Major child issues: #237, #264, #265, #266, #267, #268, #269
+- Major PRs: #313
+- Deferred items: Template Matching MVP remains in #249; Screenshot System remains v0.9
+- Next version tracking issue: #249
+- Status: released

--- a/docs/release/v0.7-release-readiness.md
+++ b/docs/release/v0.7-release-readiness.md
@@ -20,11 +20,11 @@ Non-goals:
 
 ## A. Milestone Readiness
 
-- [ ] Required v0.7 child issues are closed or explicitly deferred with a clear note.
-- [ ] Any deferred issues have a target version or follow-up issue.
-- [ ] Version tracking issue #248 reflects final child issue state.
-- [ ] Open v0.7 PRs are merged or explicitly deferred.
-- [ ] Superseded duplicate v0.7 tracking issues are identified for cleanup.
+- [x] Required v0.7 child issues are closed or explicitly deferred with a clear note.
+- [x] Any deferred issues have a target version or follow-up issue.
+- [x] Version tracking issue #248 reflects final child issue state.
+- [x] Open v0.7 PRs are merged or explicitly deferred.
+- [x] Superseded duplicate v0.7 tracking issues are identified for cleanup.
 
 ## B. Documentation Readiness
 
@@ -35,8 +35,8 @@ Non-goals:
   - [x] `docs/requirements/v0.7-queue-recovery-system-acceptance.md`
   - [x] `docs/architecture/queue.md`
   - [x] `docs/architecture/worker-api.md`
-- [ ] README current development and latest release sections are ready for the release handoff.
-- [ ] Release history update is prepared.
+- [x] README current development and latest release sections are ready for the release handoff.
+- [x] Release history update is prepared.
 
 ## C. Verification - Queue Recovery
 
@@ -51,19 +51,19 @@ Non-goals:
 
 ## D. Release PR Readiness
 
-- [ ] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
-- [ ] Release PR updates persistent release docs.
-- [ ] Release PR is merged into `main`.
-- [ ] The merge commit SHA on `main` is recorded for tagging.
+- [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
+- [x] Release PR updates persistent release docs.
+- [x] Release PR is merged into `main`.
+- [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## E. Tagging After Merge
 
-- [ ] Create tag `v0.7.0` pointing to the release merge commit SHA on `main`.
-- [ ] Do not move or overwrite existing tags.
-- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #248 and release docs.
+- [x] Create tag `v0.7.0` pointing to the release merge commit SHA on `main`.
+- [x] Do not move or overwrite existing tags.
+- [x] If tooling cannot create the tag, record the intended tag name and target SHA in #248 and release docs.
 
 ## F. Handoff
 
-- [ ] Next version tracking issue exists from `docs/roadmap.md`.
-- [ ] Next version tracking issue is linked from #248.
-- [ ] Deferred work is linked to follow-up issues or later version tracking.
+- [x] Next version tracking issue exists from `docs/roadmap.md`.
+- [x] Next version tracking issue is linked from #248.
+- [x] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/release/v0.7-release-summary.md
+++ b/docs/release/v0.7-release-summary.md
@@ -1,0 +1,40 @@
+# v0.7.0 Release Summary - Queue Recovery System
+
+## Release Point
+
+- Version tracking issue: #248
+- Release readiness checklist: `docs/release/v0.7-release-readiness.md`
+- Tag: `v0.7.0`
+- Tag target: `b0a262ac9500a6ec0ee43f9091ad0fee0e79f0dd`
+- Release finalized at: `2026-05-23T03:21:37+09:00`
+- Tag finalized at: `2026-05-23T03:22:11+09:00`
+- Next version tracking issue: #249
+
+## Completed Scope
+
+- Added SQLite migration `0003_queue_recovery`.
+- Added Worker-owned queue recovery API.
+- Added queue item creation, listing, inspection, and command transitions.
+- Added startup reconciliation for interrupted `uploading` items.
+- Added retry count, retry limit, `quota_waiting`, and `next_attempt_at` handling.
+- Added `need_manual_review` state with structured manual adjudication evidence.
+- Documented manual review actions: retry, discard, and mark uploaded.
+- Bumped Worker/Plugin compatibility metadata to v0.7.0 / API 0.7.
+
+## Major Issues And PRs
+
+- Child issues: #237, #264, #265, #266, #267, #268, #269
+- PRs: #313
+
+## Verification
+
+- Worker tests: `python -m unittest discover -s app\worker\tests`
+- Documentation checks: `python scripts\validate_markdown_links.py`
+- Japanese docs coverage: `python scripts\validate_jp_user_docs_coverage.py`
+- Plugin build: Visual Studio 2022 / CMake Release build
+- GitHub CI: #88
+
+## Deferred Items
+
+- Template Matching MVP remains in #249 for v0.8.
+- Screenshot System remains reserved for v0.9.

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -92,6 +92,7 @@ Goals:
 - Release readiness checklist: `docs/release/v0.7-release-readiness.md`
 - Queue architecture contract: `docs/architecture/queue.md`
 - Worker API contract: `docs/architecture/worker-api.md`
+- Release record: `docs/release-history.md`; detailed summary: `docs/release/v0.7-release-summary.md`
 - Requirements (relevant sections):
   - `docs/requirements/requirements.md` -> Match Data / Queue / Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation


### PR DESCRIPTION
## Summary
- record finalized `v0.7.0` tag target and timestamps
- update README current release/development handoff to v0.8
- add v0.7 release summary and complete release readiness records

## Verification
- `python scripts\validate_markdown_links.py`
- `python scripts\validate_jp_user_docs_coverage.py`

Refs #248