### PR TITLE
Record v0.8 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Major and minor release completions are tagged as `vMajor.Minor.Patch`. See [Rel
 ## Current Development
 
 Latest released version:
-- `v0.7.0` - Queue Recovery System
+- `v0.8.0` - Template Matching MVP
 
 Current development target:
-- `v0.8` - Template Matching MVP
-- Tracking issue: [#249](https://github.com/Tao-pyth/obs-duel-recorder/issues/249)
+- `v0.9` - Screenshot System
+- Tracking issue: [#250](https://github.com/Tao-pyth/obs-duel-recorder/issues/250)
 
 Next roadmap target:
-- `v0.9` - Screenshot System
+- `v1.0` - YouTube Upload MVP
 
 ---
 
@@ -55,7 +55,6 @@ Current released foundation:
 - OBS overlay Text Source integration
 
 Planned roadmap capabilities:
-- Automatic duel recording (`v0.8`)
 - Screenshot capture and linkage (`v0.9`)
 - YouTube archive upload (`v1.0`)
 - Match memo support (`v1.1`)
@@ -108,26 +107,26 @@ obs-duel-recorder/
 
 ### Latest Release
 
-- Version: `v0.7.0`
-- Scope: Queue Recovery System
+- Version: `v0.8.0`
+- Scope: Template Matching MVP
 - Status: released
-- Tag target: `b0a262ac9500a6ec0ee43f9091ad0fee0e79f0dd`
-- Tracking issue: [#248](https://github.com/Tao-pyth/obs-duel-recorder/issues/248)
+- Tag target: `a83fa4ca6d09e169bf8c9b175a1e4863644eb3ec`
+- Tracking issue: [#249](https://github.com/Tao-pyth/obs-duel-recorder/issues/249)
 - Release record: [docs/release-history.md](docs/release-history.md)
 
-### Completed in v0.7
+### Completed in v0.8
 
-- Recovery-safe upload queue schema migration
-- Worker queue API at `/queue/items` and `/queue/items/{id}/command`
-- Startup reconciliation for interrupted `uploading` items
-- Retry, retry-limit, and `quota_waiting` state handling
-- `need_manual_review` runtime state and manual adjudication evidence
-- Queue recovery acceptance and release readiness documentation
+- Local template configuration and loading from `user_data`
+- Deterministic Worker template matching MVP
+- Duel lifecycle states for no duel, potential duel, active duel, and ended duel
+- Detection API at `/detection/templates`, `/detection/state`, and `/detection/frame`
+- Automatic recording start/stop trigger integration through the recording lifecycle API
+- Template matching acceptance and release readiness documentation
 
-### Planned After v0.7
+### Planned After v0.8
 
-- `v0.8` - Template Matching MVP
-- Later roadmap items include template matching, screenshot capture, upload automation, packaging, and GitHub Pages documentation.
+- `v0.9` - Screenshot System
+- Later roadmap items include screenshot capture, upload automation, packaging, and GitHub Pages documentation.
 
 ---
 

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -119,3 +119,19 @@ The version tracking issue may contain the working release summary, but finalize
 - Deferred items: Template Matching MVP remains in #249; Screenshot System remains v0.9
 - Next version tracking issue: #249
 - Status: released
+
+### v0.8.0 - Template Matching MVP
+
+- Version tracking issue: #249
+- Milestone: `v0.8` (not set)
+- Release readiness checklist: `docs/release/v0.8-release-readiness.md`
+- Tag: `v0.8.0`
+- Tag target: `a83fa4ca6d09e169bf8c9b175a1e4863644eb3ec`
+- Release finalized at: `2026-05-23T03:46:21+09:00`
+- Tag finalized at: `2026-05-23T03:46:55+09:00`
+- Release summary: `docs/release/v0.8-release-summary.md`
+- Major child issues: #270, #271, #272, #273, #274, #275
+- Major PRs: #315
+- Deferred items: Screenshot System remains in #250; YouTube Upload MVP remains v1.0
+- Next version tracking issue: #250
+- Status: released

--- a/docs/release/v0.8-release-readiness.md
+++ b/docs/release/v0.8-release-readiness.md
@@ -20,11 +20,11 @@ Non-goals:
 
 ## A. Milestone Readiness
 
-- [ ] Required v0.8 child issues are closed or explicitly deferred with a clear note.
-- [ ] Any deferred issues have a target version or follow-up issue.
-- [ ] Version tracking issue #249 reflects final child issue state.
-- [ ] Open v0.8 PRs are merged or explicitly deferred.
-- [ ] Superseded duplicate v0.8 tracking issues are identified for cleanup.
+- [x] Required v0.8 child issues are closed or explicitly deferred with a clear note.
+- [x] Any deferred issues have a target version or follow-up issue.
+- [x] Version tracking issue #249 reflects final child issue state.
+- [x] Open v0.8 PRs are merged or explicitly deferred.
+- [x] Superseded duplicate v0.8 tracking issues are identified for cleanup.
 
 ## B. Documentation Readiness
 
@@ -35,8 +35,8 @@ Non-goals:
   - [x] `docs/requirements/v0.8-template-matching-mvp-acceptance.md`
   - [x] `docs/architecture/detection.md`
   - [x] `docs/architecture/worker-api.md`
-- [ ] README current development and latest release sections are ready for the release handoff.
-- [ ] Release history update is prepared.
+- [x] README current development and latest release sections are ready for the release handoff.
+- [x] Release history update is prepared.
 
 ## C. Verification - Template Matching MVP
 
@@ -49,19 +49,19 @@ Non-goals:
 
 ## D. Release PR Readiness
 
-- [ ] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
-- [ ] Release PR updates persistent release docs.
-- [ ] Release PR is merged into `main`.
-- [ ] The merge commit SHA on `main` is recorded for tagging.
+- [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
+- [x] Release PR updates persistent release docs.
+- [x] Release PR is merged into `main`.
+- [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## E. Tagging After Merge
 
-- [ ] Create tag `v0.8.0` pointing to the release merge commit SHA on `main`.
-- [ ] Do not move or overwrite existing tags.
-- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #249 and release docs.
+- [x] Create tag `v0.8.0` pointing to the release merge commit SHA on `main`.
+- [x] Do not move or overwrite existing tags.
+- [x] If tooling cannot create the tag, record the intended tag name and target SHA in #249 and release docs.
 
 ## F. Handoff
 
-- [ ] Next version tracking issue exists from `docs/roadmap.md`.
-- [ ] Next version tracking issue is linked from #249.
-- [ ] Deferred work is linked to follow-up issues or later version tracking.
+- [x] Next version tracking issue exists from `docs/roadmap.md`.
+- [x] Next version tracking issue is linked from #249.
+- [x] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/release/v0.8-release-summary.md
+++ b/docs/release/v0.8-release-summary.md
@@ -1,0 +1,39 @@
+# v0.8.0 Release Summary - Template Matching MVP
+
+## Release Point
+
+- Version tracking issue: #249
+- Release readiness checklist: `docs/release/v0.8-release-readiness.md`
+- Tag: `v0.8.0`
+- Tag target: `a83fa4ca6d09e169bf8c9b175a1e4863644eb3ec`
+- Release finalized at: `2026-05-23T03:46:21+09:00`
+- Tag finalized at: `2026-05-23T03:46:55+09:00`
+- Next version tracking issue: #250
+
+## Completed Scope
+
+- Added local template configuration loading from `user_data/config/templates.toml`.
+- Added local template loading from `user_data/templates/` without committing template assets.
+- Added deterministic template matching MVP over submitted frame bytes.
+- Added duel lifecycle states: `no_duel`, `potential_duel`, `active_duel`, and `ended_duel`.
+- Added detection endpoints: `/detection/templates`, `/detection/state`, and `/detection/frame`.
+- Integrated confirmed duel start/end detection with the v0.6 recording lifecycle boundary.
+- Bumped Worker/Plugin compatibility metadata to v0.8.0 / API 0.8.
+
+## Major Issues And PRs
+
+- Child issues: #270, #271, #272, #273, #274, #275
+- PRs: #315
+
+## Verification
+
+- Worker tests: `python -m unittest discover -s app\worker\tests`
+- Documentation checks: `python scripts\validate_markdown_links.py`
+- Japanese docs coverage: `python scripts\validate_jp_user_docs_coverage.py`
+- Plugin build: Visual Studio 2022 / CMake Release build
+- GitHub CI: #92
+
+## Deferred Items
+
+- Screenshot System remains in #250 for v0.9.
+- YouTube Upload MVP remains reserved for v1.0.

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -105,6 +105,7 @@ Goals:
 - Release readiness checklist: `docs/release/v0.8-release-readiness.md`
 - Detection architecture contract: `docs/architecture/detection.md`
 - Worker API contract: `docs/architecture/worker-api.md`
+- Release record: `docs/release-history.md`; detailed summary: `docs/release/v0.8-release-summary.md`
 - Requirements (relevant sections):
   - `docs/requirements/requirements.md` -> Detection Rules / Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation


### PR DESCRIPTION
## Summary
- record finalized `v0.8.0` tag target and timestamps
- update README current release/development handoff to v0.9
- add v0.8 release summary and complete release readiness records

## Verification
- `python scripts\validate_markdown_links.py`
- `python scripts\validate_jp_user_docs_coverage.py`

Refs #249