### PR TITLE
Record v0.9 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Major and minor release completions are tagged as `vMajor.Minor.Patch`. See [Rel
 ## Current Development
 
 Latest released version:
-- `v0.8.0` - Template Matching MVP
+- `v0.9.0` - Screenshot System
 
 Current development target:
-- `v0.9` - Screenshot System
-- Tracking issue: [#250](https://github.com/Tao-pyth/obs-duel-recorder/issues/250)
+- `v1.0` - YouTube Upload MVP
+- Tracking issue: [#318](https://github.com/Tao-pyth/obs-duel-recorder/issues/318)
 
 Next roadmap target:
-- `v1.0` - YouTube Upload MVP
+- `v1.1` - Match Metadata
 
 ---
 
@@ -53,9 +53,9 @@ Current released foundation:
 - Worker runtime, health, logging, and migration foundations
 - OBS Plugin skeleton and Worker lifecycle management
 - OBS overlay Text Source integration
+- Screenshot capture and linkage
 
 Planned roadmap capabilities:
-- Screenshot capture and linkage (`v0.9`)
 - YouTube archive upload (`v1.0`)
 - Match memo support (`v1.1`)
 - GitHub Actions based packaging (`v1.4+`)
@@ -107,26 +107,26 @@ obs-duel-recorder/
 
 ### Latest Release
 
-- Version: `v0.8.0`
-- Scope: Template Matching MVP
+- Version: `v0.9.0`
+- Scope: Screenshot System
 - Status: released
-- Tag target: `a83fa4ca6d09e169bf8c9b175a1e4863644eb3ec`
-- Tracking issue: [#249](https://github.com/Tao-pyth/obs-duel-recorder/issues/249)
+- Tag target: `fd2fca25b632f4aea471cca7044886e689a3faf1`
+- Tracking issue: [#250](https://github.com/Tao-pyth/obs-duel-recorder/issues/250)
 - Release record: [docs/release-history.md](docs/release-history.md)
 
-### Completed in v0.8
+### Completed in v0.9
 
-- Local template configuration and loading from `user_data`
-- Deterministic Worker template matching MVP
-- Duel lifecycle states for no duel, potential duel, active duel, and ended duel
-- Detection API at `/detection/templates`, `/detection/state`, and `/detection/frame`
-- Automatic recording start/stop trigger integration through the recording lifecycle API
-- Template matching acceptance and release readiness documentation
+- Worker-owned screenshot capture and archive storage under `user_data/data/screenshots/`
+- Deterministic screenshot naming rules
+- SQLite screenshot metadata linked to matches and upload queue items
+- Screenshot preview API with missing-file diagnostics
+- Upload-state-aware screenshot cleanup that preserves failure evidence
+- Screenshot acceptance, architecture, API, DB, and release readiness documentation
 
-### Planned After v0.8
+### Planned After v0.9
 
-- `v0.9` - Screenshot System
-- Later roadmap items include screenshot capture, upload automation, packaging, and GitHub Pages documentation.
+- `v1.0` - YouTube Upload MVP
+- Later roadmap items include upload automation, metadata management, packaging, and GitHub Pages documentation.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [v0.8 release readiness checklist](release/v0.8-release-readiness.md)
 - [v0.9 release readiness checklist](release/v0.9-release-readiness.md)
 - [v0.4 release summary](release/v0.4-release-summary.md)
+- [v0.9 release summary](release/v0.9-release-summary.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
 - [v0.3 SQLite Foundation acceptance checklist](requirements/v0.3-sqlite-foundation-acceptance.md)
 - [v0.4 OBS Plugin Skeleton acceptance checklist](requirements/v0.4-obs-plugin-skeleton-acceptance.md)

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -135,3 +135,19 @@ The version tracking issue may contain the working release summary, but finalize
 - Deferred items: Screenshot System remains in #250; YouTube Upload MVP remains v1.0
 - Next version tracking issue: #250
 - Status: released
+
+### v0.9.0 - Screenshot System
+
+- Version tracking issue: #250
+- Milestone: `v0.9` (not set)
+- Release readiness checklist: `docs/release/v0.9-release-readiness.md`
+- Tag: `v0.9.0`
+- Tag target: `fd2fca25b632f4aea471cca7044886e689a3faf1`
+- Release finalized at: `2026-05-23T04:36:20+09:00`
+- Tag finalized at: `2026-05-23T04:35:10+09:00`
+- Release summary: `docs/release/v0.9-release-summary.md`
+- Major child issues: #276, #277, #278, #279, #280, #281
+- Major PRs: #317
+- Deferred items: YouTube Upload MVP remains in #318 for v1.0
+- Next version tracking issue: #318
+- Status: released

--- a/docs/release/v0.9-release-readiness.md
+++ b/docs/release/v0.9-release-readiness.md
@@ -20,11 +20,11 @@ Non-goals:
 
 ## A. Milestone Readiness
 
-- [ ] Required v0.9 child issues are closed or explicitly deferred with a clear note.
-- [ ] Any deferred issues have a target version or follow-up issue.
-- [ ] Version tracking issue #250 reflects final child issue state.
-- [ ] Open v0.9 PRs are merged or explicitly deferred.
-- [ ] Superseded duplicate v0.9 tracking issues are identified for cleanup.
+- [x] Required v0.9 child issues are closed or explicitly deferred with a clear note.
+- [x] Any deferred issues have a target version or follow-up issue.
+- [x] Version tracking issue #250 reflects final child issue state.
+- [x] Open v0.9 PRs are merged or explicitly deferred.
+- [x] Superseded duplicate v0.9 tracking issues are identified for cleanup.
 
 ## B. Documentation Readiness
 
@@ -36,8 +36,8 @@ Non-goals:
   - [x] `docs/architecture/screenshots.md`
   - [x] `docs/architecture/db.md`
   - [x] `docs/architecture/worker-api.md`
-- [ ] README current development and latest release sections are ready for the release handoff.
-- [ ] Release history update is prepared.
+- [x] README current development and latest release sections are ready for the release handoff.
+- [x] Release history update is prepared.
 
 ## C. Verification - Screenshot System
 
@@ -49,20 +49,19 @@ Non-goals:
 
 ## D. Release PR Readiness
 
-- [ ] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
-- [ ] Release PR updates persistent release docs.
-- [ ] Release PR is merged into `main`.
-- [ ] The merge commit SHA on `main` is recorded for tagging.
+- [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
+- [x] Release PR updates persistent release docs.
+- [x] Release PR is merged into `main`.
+- [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## E. Tagging After Merge
 
-- [ ] Create tag `v0.9.0` pointing to the release merge commit SHA on `main`.
-- [ ] Do not move or overwrite existing tags.
-- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #250 and release docs.
+- [x] Create tag `v0.9.0` pointing to the release merge commit SHA on `main`.
+- [x] Do not move or overwrite existing tags.
+- [x] If tooling cannot create the tag, record the intended tag name and target SHA in #250 and release docs.
 
 ## F. Handoff
 
-- [ ] Next version tracking issue exists from `docs/roadmap.md`.
-- [ ] Next version tracking issue is linked from #250.
-- [ ] Deferred work is linked to follow-up issues or later version tracking.
-
+- [x] Next version tracking issue exists from `docs/roadmap.md`.
+- [x] Next version tracking issue is linked from #250.
+- [x] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/release/v0.9-release-summary.md
+++ b/docs/release/v0.9-release-summary.md
@@ -1,0 +1,40 @@
+# v0.9.0 Release Summary - Screenshot System
+
+## Release Point
+
+- Version tracking issue: #250
+- Release readiness checklist: `docs/release/v0.9-release-readiness.md`
+- Tag: `v0.9.0`
+- Tag target: `fd2fca25b632f4aea471cca7044886e689a3faf1`
+- Release finalized at: `2026-05-23T04:36:20+09:00`
+- Tag finalized at: `2026-05-23T04:35:10+09:00`
+- Next version tracking issue: #318
+
+## Completed Scope
+
+- Added Worker-owned screenshot capture under `user_data/data/screenshots/`.
+- Added deterministic screenshot naming rules with path traversal and overwrite protection.
+- Added SQLite screenshot metadata through migration `0004_screenshots`.
+- Linked screenshots to optional match and upload queue records.
+- Added screenshot list, record, preview, capture, and cleanup Worker API endpoints.
+- Added upload-state-aware cleanup that deletes only after `uploaded` or `discarded` states.
+- Preserved screenshot evidence for upload failures, quota waits, active uploads, and manual review.
+- Bumped Worker/Plugin compatibility metadata to v0.9.0 / API 0.9.
+
+## Major Issues And PRs
+
+- Child issues: #276, #277, #278, #279, #280, #281
+- PRs: #317
+
+## Verification
+
+- Worker tests: `python -m unittest discover -s app\worker\tests`
+- Documentation checks: `python scripts\validate_markdown_links.py`
+- Japanese docs coverage: `python scripts\validate_jp_user_docs_coverage.py --root .`
+- Plugin build: Visual Studio 2022 / CMake Release build
+- GitHub CI: #317
+
+## Deferred Items
+
+- YouTube Upload MVP remains in #318 for v1.0.
+

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -124,6 +124,17 @@ Goals:
   - `docs/requirements/requirements.md` -> Match Data / Queue / Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
+### v1.0 - YouTube Upload MVP
+
+- Roadmap: `docs/roadmap.md` -> **v1.0 - YouTube Upload MVP**
+- Version tracking issue: `#318` - `[v1.0] YouTube Upload MVP release tracking`
+- Acceptance checklist: not created yet
+- Release readiness checklist: not created yet
+- Release record: not created yet
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` -> Upload Rules / Queue States / Architecture / Platform / Runtime Rules
+  - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
+
 ---
 
 ## Policy
@@ -171,3 +182,4 @@ The version tracking issue itself is not an implementation work item.
 - Refs #310
 - Refs #249
 - Refs #250
+- Refs #318


### PR DESCRIPTION
## Summary
- update README latest/current development handoff from v0.9 to v1.0
- record v0.9.0 in release history and add detailed v0.9 release summary
- mark v0.9 release readiness complete and link v1.0 tracking issue #318

## Verification
- `python scripts\validate_markdown_links.py`
- `python scripts\validate_jp_user_docs_coverage.py --root .`

Refs #250
Refs #318