### PR TITLE
Record v1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Major and minor release completions are tagged as `vMajor.Minor.Patch`. See [Rel
 ## Current Development
 
 Latest released version:
-- `v0.9.0` - Screenshot System
+- `v1.0.0` - YouTube Upload MVP
 
 Current development target:
-- `v1.0` - YouTube Upload MVP
-- Tracking issue: [#318](https://github.com/Tao-pyth/obs-duel-recorder/issues/318)
+- `v1.1` - Match Metadata
+- Tracking issue: [#320](https://github.com/Tao-pyth/obs-duel-recorder/issues/320)
 
 Next roadmap target:
-- `v1.1` - Match Metadata
+- `v1.2` - Export System
 
 ---
 
@@ -54,10 +54,11 @@ Current released foundation:
 - OBS Plugin skeleton and Worker lifecycle management
 - OBS overlay Text Source integration
 - Screenshot capture and linkage
+- YouTube upload MVP boundary
 
 Planned roadmap capabilities:
-- YouTube archive upload (`v1.0`)
 - Match memo support (`v1.1`)
+- Export system (`v1.2`)
 - GitHub Actions based packaging (`v1.4+`)
 
 ---
@@ -107,26 +108,26 @@ obs-duel-recorder/
 
 ### Latest Release
 
-- Version: `v0.9.0`
-- Scope: Screenshot System
+- Version: `v1.0.0`
+- Scope: YouTube Upload MVP
 - Status: released
-- Tag target: `fd2fca25b632f4aea471cca7044886e689a3faf1`
-- Tracking issue: [#250](https://github.com/Tao-pyth/obs-duel-recorder/issues/250)
+- Tag target: `30dfd9b0d1670a4cbbe3bc0f4bf328bcc7bc67d1`
+- Tracking issue: [#318](https://github.com/Tao-pyth/obs-duel-recorder/issues/318)
 - Release record: [docs/release-history.md](docs/release-history.md)
 
-### Completed in v0.9
+### Completed in v1.0
 
-- Worker-owned screenshot capture and archive storage under `user_data/data/screenshots/`
-- Deterministic screenshot naming rules
-- SQLite screenshot metadata linked to matches and upload queue items
-- Screenshot preview API with missing-file diagnostics
-- Upload-state-aware screenshot cleanup that preserves failure evidence
-- Screenshot acceptance, architecture, API, DB, and release readiness documentation
+- Worker-owned upload status API
+- Deterministic mocked upload processing for CI and smoke checks
+- Upload success, retryable failure, quota wait, missing file, auth/manual-review, and ambiguous outcome handling
+- YouTube video id and URL persistence
+- OAuth scope, privacy, and secret-redaction contract
+- v1.0 acceptance and release readiness documentation
 
-### Planned After v0.9
+### Planned After v1.0
 
-- `v1.0` - YouTube Upload MVP
-- Later roadmap items include upload automation, metadata management, packaging, and GitHub Pages documentation.
+- `v1.1` - Match Metadata
+- Later roadmap items include metadata management, export, packaging, and GitHub Pages documentation.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [v1.0 release readiness checklist](release/v1.0-release-readiness.md)
 - [v0.4 release summary](release/v0.4-release-summary.md)
 - [v0.9 release summary](release/v0.9-release-summary.md)
+- [v1.0 release summary](release/v1.0-release-summary.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
 - [v0.3 SQLite Foundation acceptance checklist](requirements/v0.3-sqlite-foundation-acceptance.md)
 - [v0.4 OBS Plugin Skeleton acceptance checklist](requirements/v0.4-obs-plugin-skeleton-acceptance.md)

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -151,3 +151,19 @@ The version tracking issue may contain the working release summary, but finalize
 - Deferred items: YouTube Upload MVP remains in #318 for v1.0
 - Next version tracking issue: #318
 - Status: released
+
+### v1.0.0 - YouTube Upload MVP
+
+- Version tracking issue: #318
+- Milestone: `v1.0` (not set)
+- Release readiness checklist: `docs/release/v1.0-release-readiness.md`
+- Tag: `v1.0.0`
+- Tag target: `30dfd9b0d1670a4cbbe3bc0f4bf328bcc7bc67d1`
+- Release finalized at: `2026-05-23T06:16:38+09:00`
+- Tag finalized at: `2026-05-23T06:16:08+09:00`
+- Release summary: `docs/release/v1.0-release-summary.md`
+- Major child issues: #328, #329, #330, #331
+- Major PRs: #364
+- Deferred items: Match Metadata remains in #320 for v1.1
+- Next version tracking issue: #320
+- Status: released

--- a/docs/release/v1.0-release-readiness.md
+++ b/docs/release/v1.0-release-readiness.md
@@ -20,11 +20,11 @@ Non-goals:
 
 ## A. Milestone Readiness
 
-- [ ] Required v1.0 child issues are closed or explicitly deferred with a clear note.
-- [ ] Any deferred issues have a target version or follow-up issue.
-- [ ] Version tracking issue #318 reflects final child issue state.
-- [ ] Open v1.0 PRs are merged or explicitly deferred.
-- [ ] Superseded duplicate v1.0 tracking issues are identified for cleanup.
+- [x] Required v1.0 child issues are closed or explicitly deferred with a clear note.
+- [x] Any deferred issues have a target version or follow-up issue.
+- [x] Version tracking issue #318 reflects final child issue state.
+- [x] Open v1.0 PRs are merged or explicitly deferred.
+- [x] Superseded duplicate v1.0 tracking issues are identified for cleanup.
 
 ## B. Documentation Readiness
 
@@ -35,8 +35,8 @@ Non-goals:
   - [x] `docs/requirements/v1.0-youtube-upload-mvp-acceptance.md`
   - [x] `docs/architecture/upload.md`
   - [x] `docs/architecture/worker-api.md`
-- [ ] README current development and latest release sections are ready for the release handoff.
-- [ ] Release history update is prepared.
+- [x] README current development and latest release sections are ready for the release handoff.
+- [x] Release history update is prepared.
 
 ## C. Verification - YouTube Upload MVP
 
@@ -50,19 +50,18 @@ Non-goals:
 
 ## D. Release PR Readiness
 
-- [ ] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
-- [ ] Release PR updates persistent release docs.
-- [ ] Release PR is merged into `main`.
-- [ ] The merge commit SHA on `main` is recorded for tagging.
+- [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
+- [x] Release PR updates persistent release docs.
+- [x] Release PR is merged into `main`.
+- [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## E. Tagging After Merge
 
-- [ ] Create tag `v1.0.0` pointing to the release merge commit SHA on `main`.
-- [ ] Do not move or overwrite existing tags.
-- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #318 and release docs.
+- [x] Create tag `v1.0.0` pointing to the release merge commit SHA on `main`.
+- [x] Do not move or overwrite existing tags.
+- [x] If tooling cannot create the tag, record the intended tag name and target SHA in #318 and release docs.
 
 ## F. Handoff
 
-- [ ] Next version tracking issue #320 is linked from #318.
-- [ ] Deferred work is linked to follow-up issues or later version tracking.
-
+- [x] Next version tracking issue #320 is linked from #318.
+- [x] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/release/v1.0-release-summary.md
+++ b/docs/release/v1.0-release-summary.md
@@ -1,0 +1,41 @@
+# v1.0.0 Release Summary - YouTube Upload MVP
+
+## Release Point
+
+- Version tracking issue: #318
+- Release readiness checklist: `docs/release/v1.0-release-readiness.md`
+- Tag: `v1.0.0`
+- Tag target: `30dfd9b0d1670a4cbbe3bc0f4bf328bcc7bc67d1`
+- Release finalized at: `2026-05-23T06:16:38+09:00`
+- Tag finalized at: `2026-05-23T06:16:08+09:00`
+- Next version tracking issue: #320
+
+## Completed Scope
+
+- Added Worker-owned upload status endpoint at `/upload/status`.
+- Added deterministic upload processing endpoint at `/upload/process-next`.
+- Added mocked YouTube upload outcomes for success, network failure, quota exceeded, missing local file, auth/manual-review, and ambiguous outcome handling.
+- Persisted `youtube_video_id` and derived/persisted `youtube_url` on upload success.
+- Preserved failure and manual-review evidence while redacting tokens, client secrets, authorization codes, and bearer strings.
+- Documented the upload-only OAuth scope `https://www.googleapis.com/auth/youtube.upload`.
+- Documented default `private` upload privacy and explicit `unlisted` allowance.
+- Bumped Worker/Plugin compatibility metadata to v1.0.0 / API 1.0.
+
+## Major Issues And PRs
+
+- Child issues: #328, #329, #330, #331
+- PRs: #364
+
+## Verification
+
+- Worker tests: `python -m unittest discover -s app\worker\tests`
+- Worker version: `python -m odr_worker --version`
+- Documentation checks: `python scripts\validate_markdown_links.py`
+- Japanese docs coverage: `python scripts\validate_jp_user_docs_coverage.py --root .`
+- Plugin build: Visual Studio 2022 / CMake Release build
+- GitHub CI: #364
+
+## Deferred Items
+
+- Match Metadata remains in #320 for v1.1.
+

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -132,9 +132,20 @@ Goals:
 - Release readiness checklist: `docs/release/v1.0-release-readiness.md`
 - Upload architecture contract: `docs/architecture/upload.md`
 - Worker API contract: `docs/architecture/worker-api.md`
-- Release record: not created yet
+- Release record: `docs/release-history.md`; detailed summary: `docs/release/v1.0-release-summary.md`
 - Requirements (relevant sections):
   - `docs/requirements/requirements.md` -> Upload Rules / Queue States / Architecture / Platform / Runtime Rules
+  - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
+
+### v1.1 - Match Metadata
+
+- Roadmap: `docs/roadmap.md` -> **v1.1 - Match Metadata**
+- Version tracking issue: `#320` - `[v1.1] Match Metadata release tracking`
+- Acceptance checklist: not created yet
+- Release readiness checklist: not created yet
+- Release record: not created yet
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` -> Match Data / Upload Rules / Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
 ---
@@ -185,3 +196,4 @@ The version tracking issue itself is not an implementation work item.
 - Refs #249
 - Refs #250
 - Refs #318
+- Refs #320


### PR DESCRIPTION
## Summary
- update README latest/current development handoff from v1.0 to v1.1
- record v1.0.0 in release history and add detailed v1.0 release summary
- mark v1.0 release readiness complete and link v1.1 tracking issue #320

## Verification
- `python scripts\validate_markdown_links.py`
- `python scripts\validate_jp_user_docs_coverage.py --root .`

Refs #318
Refs #320