### PR TITLE
Record v1.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Major and minor release completions are tagged as `vMajor.Minor.Patch`. See [Rel
 ## Current Development
 
 Latest released version:
-- `v1.0.0` - YouTube Upload MVP
+- `v1.1.0` - Match Metadata
 
 Current development target:
-- `v1.1` - Match Metadata
-- Tracking issue: [#320](https://github.com/Tao-pyth/obs-duel-recorder/issues/320)
+- `v1.2` - Export System
+- Tracking issue: [#321](https://github.com/Tao-pyth/obs-duel-recorder/issues/321)
 
 Next roadmap target:
-- `v1.2` - Export System
+- `v1.3` - Setup Wizard
 
 ---
 
@@ -55,10 +55,12 @@ Current released foundation:
 - OBS overlay Text Source integration
 - Screenshot capture and linkage
 - YouTube upload MVP boundary
+- Match metadata, memo, search, and upload metadata generation
 
 Planned roadmap capabilities:
-- Match memo support (`v1.1`)
 - Export system (`v1.2`)
+- Setup wizard (`v1.3`)
+- Update system (`v1.4`)
 - GitHub Actions based packaging (`v1.4+`)
 
 ---
@@ -108,26 +110,26 @@ obs-duel-recorder/
 
 ### Latest Release
 
-- Version: `v1.0.0`
-- Scope: YouTube Upload MVP
+- Version: `v1.1.0`
+- Scope: Match Metadata
 - Status: released
-- Tag target: `30dfd9b0d1670a4cbbe3bc0f4bf328bcc7bc67d1`
-- Tracking issue: [#318](https://github.com/Tao-pyth/obs-duel-recorder/issues/318)
+- Tag target: `afbb6fa73db60afb50a20e1de4e0dccb8b25b65b`
+- Tracking issue: [#320](https://github.com/Tao-pyth/obs-duel-recorder/issues/320)
 - Release record: [docs/release-history.md](docs/release-history.md)
 
-### Completed in v1.0
+### Completed in v1.1
 
-- Worker-owned upload status API
-- Deterministic mocked upload processing for CI and smoke checks
-- Upload success, retryable failure, quota wait, missing file, auth/manual-review, and ambiguous outcome handling
-- YouTube video id and URL persistence
-- OAuth scope, privacy, and secret-redaction contract
-- v1.0 acceptance and release readiness documentation
+- Worker-owned match metadata API
+- Opponent deck, deck name, result, timestamp, title template, and Match Memo persistence
+- Metadata search across opponent deck, memo, deck name, and result
+- Deterministic upload title, description, and notes generation
+- Upload process metadata handoff for linked queue items
+- v1.1 acceptance and release readiness documentation
 
-### Planned After v1.0
+### Planned After v1.1
 
-- `v1.1` - Match Metadata
-- Later roadmap items include metadata management, export, packaging, and GitHub Pages documentation.
+- `v1.2` - Export System
+- Later roadmap items include setup wizard, update system, packaging, and GitHub Pages documentation.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [v0.4 release summary](release/v0.4-release-summary.md)
 - [v0.9 release summary](release/v0.9-release-summary.md)
 - [v1.0 release summary](release/v1.0-release-summary.md)
+- [v1.1 release summary](release/v1.1-release-summary.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
 - [v0.3 SQLite Foundation acceptance checklist](requirements/v0.3-sqlite-foundation-acceptance.md)
 - [v0.4 OBS Plugin Skeleton acceptance checklist](requirements/v0.4-obs-plugin-skeleton-acceptance.md)

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -167,3 +167,19 @@ The version tracking issue may contain the working release summary, but finalize
 - Deferred items: Match Metadata remains in #320 for v1.1
 - Next version tracking issue: #320
 - Status: released
+
+### v1.1.0 - Match Metadata
+
+- Version tracking issue: #320
+- Milestone: `v1.1` (not set)
+- Release readiness checklist: `docs/release/v1.1-release-readiness.md`
+- Tag: `v1.1.0`
+- Tag target: `afbb6fa73db60afb50a20e1de4e0dccb8b25b65b`
+- Release finalized at: `2026-05-23T11:35:46+09:00`
+- Tag finalized at: `2026-05-23T11:34:46+09:00`
+- Release summary: `docs/release/v1.1-release-summary.md`
+- Major child issues: #332, #333, #334, #335
+- Major PRs: #366
+- Deferred items: Export System remains in #321 for v1.2
+- Next version tracking issue: #321
+- Status: released

--- a/docs/release/v1.1-release-readiness.md
+++ b/docs/release/v1.1-release-readiness.md
@@ -19,11 +19,11 @@ Non-goals:
 
 ## A. Milestone Readiness
 
-- [ ] Required v1.1 child issues are closed or explicitly deferred with a clear note.
-- [ ] Any deferred issues have a target version or follow-up issue.
-- [ ] Version tracking issue #320 reflects final child issue state.
-- [ ] Open v1.1 PRs are merged or explicitly deferred.
-- [ ] Superseded duplicate v1.1 tracking issues are identified for cleanup.
+- [x] Required v1.1 child issues are closed or explicitly deferred with a clear note.
+- [x] Any deferred issues have a target version or follow-up issue.
+- [x] Version tracking issue #320 reflects final child issue state.
+- [x] Open v1.1 PRs are merged or explicitly deferred.
+- [x] Superseded duplicate v1.1 tracking issues are identified for cleanup.
 
 ## B. Documentation Readiness
 
@@ -35,8 +35,8 @@ Non-goals:
   - [x] `docs/architecture/metadata.md`
   - [x] `docs/architecture/db.md`
   - [x] `docs/architecture/worker-api.md`
-- [ ] README current development and latest release sections are ready for the release handoff.
-- [ ] Release history update is prepared.
+- [x] README current development and latest release sections are ready for the release handoff.
+- [x] Release history update is prepared.
 
 ## C. Verification - Match Metadata
 
@@ -49,19 +49,18 @@ Non-goals:
 
 ## D. Release PR Readiness
 
-- [ ] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
-- [ ] Release PR updates persistent release docs.
-- [ ] Release PR is merged into `main`.
-- [ ] The merge commit SHA on `main` is recorded for tagging.
+- [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
+- [x] Release PR updates persistent release docs.
+- [x] Release PR is merged into `main`.
+- [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## E. Tagging After Merge
 
-- [ ] Create tag `v1.1.0` pointing to the release merge commit SHA on `main`.
-- [ ] Do not move or overwrite existing tags.
-- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #320 and release docs.
+- [x] Create tag `v1.1.0` pointing to the release merge commit SHA on `main`.
+- [x] Do not move or overwrite existing tags.
+- [x] If tooling cannot create the tag, record the intended tag name and target SHA in #320 and release docs.
 
 ## F. Handoff
 
-- [ ] Next version tracking issue #321 is linked from #320.
-- [ ] Deferred work is linked to follow-up issues or later version tracking.
-
+- [x] Next version tracking issue #321 is linked from #320.
+- [x] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/release/v1.1-release-summary.md
+++ b/docs/release/v1.1-release-summary.md
@@ -1,0 +1,39 @@
+# v1.1.0 Release Summary - Match Metadata
+
+## Release Point
+
+- Version tracking issue: #320
+- Release readiness checklist: `docs/release/v1.1-release-readiness.md`
+- Tag: `v1.1.0`
+- Tag target: `afbb6fa73db60afb50a20e1de4e0dccb8b25b65b`
+- Release finalized at: `2026-05-23T11:35:46+09:00`
+- Tag finalized at: `2026-05-23T11:34:46+09:00`
+- Next version tracking issue: #321
+
+## Completed Scope
+
+- Added Worker-owned match metadata persistence on the existing `matches` table.
+- Added metadata fields for deck name, opponent deck, result, memo, start time, end time, and title template.
+- Added match metadata create, read, update, list, and search endpoints.
+- Added deterministic upload title, description, and notes generation.
+- Added upload metadata handoff from `POST /upload/process-next` when a queue item is linked to a match.
+- Preserved existing v1.0 upload records through the v1.1 migration.
+- Bumped Worker/Plugin compatibility metadata to v1.1.0 / API 1.1.
+
+## Major Issues And PRs
+
+- Child issues: #332, #333, #334, #335
+- PRs: #366
+
+## Verification
+
+- Worker tests: `python -m unittest discover -s app\worker\tests`
+- Worker version: `python -m odr_worker --version`
+- Documentation checks: `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
+- Japanese docs coverage: `python scripts\validate_jp_user_docs_coverage.py --root .`
+- Plugin build: Visual Studio 2022 / CMake Release build
+- GitHub CI: #366
+
+## Deferred Items
+
+- Export System remains in #321 for v1.2.

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -146,9 +146,20 @@ Goals:
 - Metadata architecture contract: `docs/architecture/metadata.md`
 - Database contract: `docs/architecture/db.md`
 - Worker API contract: `docs/architecture/worker-api.md`
-- Release record: not created yet
+- Release record: `docs/release-history.md`; detailed summary: `docs/release/v1.1-release-summary.md`
 - Requirements (relevant sections):
   - `docs/requirements/requirements.md` -> Match Data / Upload Rules / Architecture / Platform / Runtime Rules
+  - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
+
+### v1.2 - Export System
+
+- Roadmap: `docs/roadmap.md` -> **v1.2 - Export System**
+- Version tracking issue: `#321` - `[v1.2] Export System release tracking`
+- Acceptance checklist: not created yet
+- Release readiness checklist: not created yet
+- Release record: not created yet
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` -> Match Data / Queue / Screenshot Rules / Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
 ---
@@ -200,3 +211,4 @@ The version tracking issue itself is not an implementation work item.
 - Refs #250
 - Refs #318
 - Refs #320
+- Refs #321


### PR DESCRIPTION
## Summary
- record v1.1.0 in README and release history
- add the v1.1 release summary and complete the v1.1 readiness checklist
- update traceability for the v1.1 release record and v1.2 handoff

## Verification
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `git diff --check`

Refs #320
Refs #321