### PR TITLE
Record v1.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Major and minor release completions are tagged as `vMajor.Minor.Patch`. See [Rel
 ## Current Development
 
 Latest released version:
-- `v1.1.0` - Match Metadata
+- `v1.2.0` - Export System
 
 Current development target:
-- `v1.2` - Export System
-- Tracking issue: [#321](https://github.com/Tao-pyth/obs-duel-recorder/issues/321)
+- `v1.3` - Setup Wizard
+- Tracking issue: [#322](https://github.com/Tao-pyth/obs-duel-recorder/issues/322)
 
 Next roadmap target:
-- `v1.3` - Setup Wizard
+- `v1.4` - Update System
 
 ---
 
@@ -56,9 +56,9 @@ Current released foundation:
 - Screenshot capture and linkage
 - YouTube upload MVP boundary
 - Match metadata, memo, search, and upload metadata generation
+- Export archive generation with SQLite, metadata, screenshots, and video linkages
 
 Planned roadmap capabilities:
-- Export system (`v1.2`)
 - Setup wizard (`v1.3`)
 - Update system (`v1.4`)
 - GitHub Actions based packaging (`v1.4+`)
@@ -110,26 +110,26 @@ obs-duel-recorder/
 
 ### Latest Release
 
-- Version: `v1.1.0`
-- Scope: Match Metadata
+- Version: `v1.2.0`
+- Scope: Export System
 - Status: released
-- Tag target: `afbb6fa73db60afb50a20e1de4e0dccb8b25b65b`
-- Tracking issue: [#320](https://github.com/Tao-pyth/obs-duel-recorder/issues/320)
+- Tag target: `1f307e8dba227bed8de3cbd10a089210959f07e5`
+- Tracking issue: [#321](https://github.com/Tao-pyth/obs-duel-recorder/issues/321)
 - Release record: [docs/release-history.md](docs/release-history.md)
 
-### Completed in v1.1
+### Completed in v1.2
 
-- Worker-owned match metadata API
-- Opponent deck, deck name, result, timestamp, title template, and Match Memo persistence
-- Metadata search across opponent deck, memo, deck name, and result
-- Deterministic upload title, description, and notes generation
-- Upload process metadata handoff for linked queue items
-- v1.1 acceptance and release readiness documentation
+- Worker-owned export API
+- ZIP archive generation under `user_data/data/exports/`
+- SQLite snapshot, metadata JSON, screenshot file, and video linkage export
+- Manifest output with included artifacts, missing files, schema version, and exclusion rules
+- Secret, config, log, and temporary-file exclusion by default
+- v1.2 acceptance and release readiness documentation
 
-### Planned After v1.1
+### Planned After v1.2
 
-- `v1.2` - Export System
-- Later roadmap items include setup wizard, update system, packaging, and GitHub Pages documentation.
+- `v1.3` - Setup Wizard
+- Later roadmap items include update system, packaging, and GitHub Pages documentation.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [v0.9 release summary](release/v0.9-release-summary.md)
 - [v1.0 release summary](release/v1.0-release-summary.md)
 - [v1.1 release summary](release/v1.1-release-summary.md)
+- [v1.2 release summary](release/v1.2-release-summary.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
 - [v0.3 SQLite Foundation acceptance checklist](requirements/v0.3-sqlite-foundation-acceptance.md)
 - [v0.4 OBS Plugin Skeleton acceptance checklist](requirements/v0.4-obs-plugin-skeleton-acceptance.md)

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -183,3 +183,19 @@ The version tracking issue may contain the working release summary, but finalize
 - Deferred items: Export System remains in #321 for v1.2
 - Next version tracking issue: #321
 - Status: released
+
+### v1.2.0 - Export System
+
+- Version tracking issue: #321
+- Milestone: `v1.2` (not set)
+- Release readiness checklist: `docs/release/v1.2-release-readiness.md`
+- Tag: `v1.2.0`
+- Tag target: `1f307e8dba227bed8de3cbd10a089210959f07e5`
+- Release finalized at: `2026-05-23T12:10:23+09:00`
+- Tag finalized at: `2026-05-23T12:09:43+09:00`
+- Release summary: `docs/release/v1.2-release-summary.md`
+- Major child issues: #336, #337, #338, #339
+- Major PRs: #368
+- Deferred items: Setup Wizard remains in #322 for v1.3
+- Next version tracking issue: #322
+- Status: released

--- a/docs/release/v1.2-release-readiness.md
+++ b/docs/release/v1.2-release-readiness.md
@@ -19,11 +19,11 @@ Non-goals:
 
 ## A. Milestone Readiness
 
-- [ ] Required v1.2 child issues are closed or explicitly deferred with a clear note.
-- [ ] Any deferred issues have a target version or follow-up issue.
-- [ ] Version tracking issue #321 reflects final child issue state.
-- [ ] Open v1.2 PRs are merged or explicitly deferred.
-- [ ] Superseded duplicate v1.2 tracking issues are identified for cleanup.
+- [x] Required v1.2 child issues are closed or explicitly deferred with a clear note.
+- [x] Any deferred issues have a target version or follow-up issue.
+- [x] Version tracking issue #321 reflects final child issue state.
+- [x] Open v1.2 PRs are merged or explicitly deferred.
+- [x] Superseded duplicate v1.2 tracking issues are identified for cleanup.
 
 ## B. Documentation Readiness
 
@@ -34,8 +34,8 @@ Non-goals:
   - [x] `docs/requirements/v1.2-export-system-acceptance.md`
   - [x] `docs/architecture/export.md`
   - [x] `docs/architecture/worker-api.md`
-- [ ] README current development and latest release sections are ready for the release handoff.
-- [ ] Release history update is prepared.
+- [x] README current development and latest release sections are ready for the release handoff.
+- [x] Release history update is prepared.
 
 ## C. Verification - Export System
 
@@ -48,18 +48,18 @@ Non-goals:
 
 ## D. Release PR Readiness
 
-- [ ] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
-- [ ] Release PR updates persistent release docs.
-- [ ] Release PR is merged into `main`.
-- [ ] The merge commit SHA on `main` is recorded for tagging.
+- [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
+- [x] Release PR updates persistent release docs.
+- [x] Release PR is merged into `main`.
+- [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## E. Tagging After Merge
 
-- [ ] Create tag `v1.2.0` pointing to the release merge commit SHA on `main`.
-- [ ] Do not move or overwrite existing tags.
-- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #321 and release docs.
+- [x] Create tag `v1.2.0` pointing to the release merge commit SHA on `main`.
+- [x] Do not move or overwrite existing tags.
+- [x] If tooling cannot create the tag, record the intended tag name and target SHA in #321 and release docs.
 
 ## F. Handoff
 
-- [ ] Next version tracking issue #322 is linked from #321.
-- [ ] Deferred work is linked to follow-up issues or later version tracking.
+- [x] Next version tracking issue #322 is linked from #321.
+- [x] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/release/v1.2-release-summary.md
+++ b/docs/release/v1.2-release-summary.md
@@ -1,0 +1,41 @@
+# v1.2.0 Release Summary - Export System
+
+## Release Point
+
+- Version tracking issue: #321
+- Release readiness checklist: `docs/release/v1.2-release-readiness.md`
+- Tag: `v1.2.0`
+- Tag target: `1f307e8dba227bed8de3cbd10a089210959f07e5`
+- Release finalized at: `2026-05-23T12:10:23+09:00`
+- Tag finalized at: `2026-05-23T12:09:43+09:00`
+- Next version tracking issue: #322
+
+## Completed Scope
+
+- Added Worker-owned export endpoints at `GET /exports` and `POST /exports`.
+- Added ZIP archive generation under `user_data/data/exports/`.
+- Added SQLite snapshot export as `database/odr.sqlite3`.
+- Added metadata JSON exports for matches, upload queue, screenshots, and video linkages.
+- Added screenshot file export for existing referenced screenshot files.
+- Added manifest output with included artifacts, missing files, counts, schema version, app version, API version, and exclusion rules.
+- Added explicit `include_videos` opt-in for video file inclusion while preserving linkage-only default behavior.
+- Excluded config, OAuth tokens, client secrets, logs, temporary files, and generated work files by default.
+- Bumped Worker/Plugin compatibility metadata to v1.2.0 / API 1.2.
+
+## Major Issues And PRs
+
+- Child issues: #336, #337, #338, #339
+- PRs: #368
+
+## Verification
+
+- Worker tests: `python -m unittest discover -s app\worker\tests`
+- Worker version: `python -m odr_worker --version`
+- Documentation checks: `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
+- Japanese docs coverage: `python scripts\validate_jp_user_docs_coverage.py --root .`
+- Plugin build: Visual Studio 2022 / CMake Release build
+- GitHub CI: #368
+
+## Deferred Items
+
+- Setup Wizard remains in #322 for v1.3.

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -159,9 +159,20 @@ Goals:
 - Release readiness checklist: `docs/release/v1.2-release-readiness.md`
 - Export architecture contract: `docs/architecture/export.md`
 - Worker API contract: `docs/architecture/worker-api.md`
-- Release record: not created yet
+- Release record: `docs/release-history.md`; detailed summary: `docs/release/v1.2-release-summary.md`
 - Requirements (relevant sections):
   - `docs/requirements/requirements.md` -> Export Rules / Match Data / Queue / Screenshot Rules / Architecture / Platform / Runtime Rules
+  - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
+
+### v1.3 - Setup Wizard
+
+- Roadmap: `docs/roadmap.md` -> **v1.3 - Setup Wizard**
+- Version tracking issue: `#322` - `[v1.3] Setup Wizard release tracking`
+- Acceptance checklist: not created yet
+- Release readiness checklist: not created yet
+- Release record: not created yet
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` -> Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
 ---
@@ -214,3 +225,4 @@ The version tracking issue itself is not an implementation work item.
 - Refs #318
 - Refs #320
 - Refs #321
+- Refs #322


### PR DESCRIPTION
## Summary
- record v1.2.0 in README and release history
- add the v1.2 release summary and complete the v1.2 readiness checklist
- update traceability for the v1.2 release record and v1.3 handoff

## Verification
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `git diff --check`

Refs #321
Refs #322