### PR TITLE
Record v1.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Major and minor release completions are tagged as `vMajor.Minor.Patch`. See [Rel
 ## Current Development
 
 Latest released version:
-- `v1.2.0` - Export System
+- `v1.3.0` - Setup Wizard
 
 Current development target:
-- `v1.3` - Setup Wizard
-- Tracking issue: [#322](https://github.com/Tao-pyth/obs-duel-recorder/issues/322)
+- `v1.4` - Update System
+- Tracking issue: [#323](https://github.com/Tao-pyth/obs-duel-recorder/issues/323)
 
 Next roadmap target:
-- `v1.4` - Update System
+- `v2.0` - Advanced Runtime Phase
 
 ---
 
@@ -57,9 +57,9 @@ Current released foundation:
 - YouTube upload MVP boundary
 - Match metadata, memo, search, and upload metadata generation
 - Export archive generation with SQLite, metadata, screenshots, and video linkages
+- Setup wizard state and validation for runtime path, OBS integration, OAuth, and templates
 
 Planned roadmap capabilities:
-- Setup wizard (`v1.3`)
 - Update system (`v1.4`)
 - GitHub Actions based packaging (`v1.4+`)
 
@@ -110,26 +110,26 @@ obs-duel-recorder/
 
 ### Latest Release
 
-- Version: `v1.2.0`
-- Scope: Export System
+- Version: `v1.3.0`
+- Scope: Setup Wizard
 - Status: released
-- Tag target: `1f307e8dba227bed8de3cbd10a089210959f07e5`
-- Tracking issue: [#321](https://github.com/Tao-pyth/obs-duel-recorder/issues/321)
+- Tag target: `c0579c1f9f3c892059d4bf27dc43e90754453730`
+- Tracking issue: [#322](https://github.com/Tao-pyth/obs-duel-recorder/issues/322)
 - Release record: [docs/release-history.md](docs/release-history.md)
 
-### Completed in v1.2
+### Completed in v1.3
 
-- Worker-owned export API
-- ZIP archive generation under `user_data/data/exports/`
-- SQLite snapshot, metadata JSON, screenshot file, and video linkage export
-- Manifest output with included artifacts, missing files, schema version, and exclusion rules
-- Secret, config, log, and temporary-file exclusion by default
-- v1.2 acceptance and release readiness documentation
+- Worker-owned setup wizard API
+- First-run, partial, complete, cancel, and reset state handling
+- Runtime path, OBS integration, OAuth, and template validation
+- Secret-safe setup diagnostics
+- Runtime-data-preserving reset/rerun behavior
+- v1.3 acceptance and release readiness documentation
 
-### Planned After v1.2
+### Planned After v1.3
 
-- `v1.3` - Setup Wizard
-- Later roadmap items include update system, packaging, and GitHub Pages documentation.
+- `v1.4` - Update System
+- Later roadmap items include packaging and GitHub Pages documentation.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [v1.0 release summary](release/v1.0-release-summary.md)
 - [v1.1 release summary](release/v1.1-release-summary.md)
 - [v1.2 release summary](release/v1.2-release-summary.md)
+- [v1.3 release summary](release/v1.3-release-summary.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
 - [v0.3 SQLite Foundation acceptance checklist](requirements/v0.3-sqlite-foundation-acceptance.md)
 - [v0.4 OBS Plugin Skeleton acceptance checklist](requirements/v0.4-obs-plugin-skeleton-acceptance.md)

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -199,3 +199,19 @@ The version tracking issue may contain the working release summary, but finalize
 - Deferred items: Setup Wizard remains in #322 for v1.3
 - Next version tracking issue: #322
 - Status: released
+
+### v1.3.0 - Setup Wizard
+
+- Version tracking issue: #322
+- Milestone: `v1.3` (not set)
+- Release readiness checklist: `docs/release/v1.3-release-readiness.md`
+- Tag: `v1.3.0`
+- Tag target: `c0579c1f9f3c892059d4bf27dc43e90754453730`
+- Release finalized at: `2026-05-23T12:26:36+09:00`
+- Tag finalized at: `2026-05-23T12:26:04+09:00`
+- Release summary: `docs/release/v1.3-release-summary.md`
+- Major child issues: #340, #341, #342, #343
+- Major PRs: #370
+- Deferred items: Update System remains in #323 for v1.4
+- Next version tracking issue: #323
+- Status: released

--- a/docs/release/v1.3-release-readiness.md
+++ b/docs/release/v1.3-release-readiness.md
@@ -19,11 +19,11 @@ Non-goals:
 
 ## A. Milestone Readiness
 
-- [ ] Required v1.3 child issues are closed or explicitly deferred with a clear note.
-- [ ] Any deferred issues have a target version or follow-up issue.
-- [ ] Version tracking issue #322 reflects final child issue state.
-- [ ] Open v1.3 PRs are merged or explicitly deferred.
-- [ ] Superseded duplicate v1.3 tracking issues are identified for cleanup.
+- [x] Required v1.3 child issues are closed or explicitly deferred with a clear note.
+- [x] Any deferred issues have a target version or follow-up issue.
+- [x] Version tracking issue #322 reflects final child issue state.
+- [x] Open v1.3 PRs are merged or explicitly deferred.
+- [x] Superseded duplicate v1.3 tracking issues are identified for cleanup.
 
 ## B. Documentation Readiness
 
@@ -34,8 +34,8 @@ Non-goals:
   - [x] `docs/requirements/v1.3-setup-wizard-acceptance.md`
   - [x] `docs/architecture/setup-wizard.md`
   - [x] `docs/architecture/worker-api.md`
-- [ ] README current development and latest release sections are ready for the release handoff.
-- [ ] Release history update is prepared.
+- [x] README current development and latest release sections are ready for the release handoff.
+- [x] Release history update is prepared.
 
 ## C. Verification - Setup Wizard
 
@@ -48,18 +48,18 @@ Non-goals:
 
 ## D. Release PR Readiness
 
-- [ ] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
-- [ ] Release PR updates persistent release docs.
-- [ ] Release PR is merged into `main`.
-- [ ] The merge commit SHA on `main` is recorded for tagging.
+- [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
+- [x] Release PR updates persistent release docs.
+- [x] Release PR is merged into `main`.
+- [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## E. Tagging After Merge
 
-- [ ] Create tag `v1.3.0` pointing to the release merge commit SHA on `main`.
-- [ ] Do not move or overwrite existing tags.
-- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #322 and release docs.
+- [x] Create tag `v1.3.0` pointing to the release merge commit SHA on `main`.
+- [x] Do not move or overwrite existing tags.
+- [x] If tooling cannot create the tag, record the intended tag name and target SHA in #322 and release docs.
 
 ## F. Handoff
 
-- [ ] Next version tracking issue #323 is linked from #322.
-- [ ] Deferred work is linked to follow-up issues or later version tracking.
+- [x] Next version tracking issue #323 is linked from #322.
+- [x] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/release/v1.3-release-summary.md
+++ b/docs/release/v1.3-release-summary.md
@@ -1,0 +1,40 @@
+# v1.3.0 Release Summary - Setup Wizard
+
+## Release Point
+
+- Version tracking issue: #322
+- Release readiness checklist: `docs/release/v1.3-release-readiness.md`
+- Tag: `v1.3.0`
+- Tag target: `c0579c1f9f3c892059d4bf27dc43e90754453730`
+- Release finalized at: `2026-05-23T12:26:36+09:00`
+- Tag finalized at: `2026-05-23T12:26:04+09:00`
+- Next version tracking issue: #323
+
+## Completed Scope
+
+- Added Worker-owned setup wizard endpoints under `/setup/*`.
+- Persisted setup state under `user_data/data/setup-wizard.json`.
+- Added first-run, partial, complete, cancel, reset, and rerun behavior.
+- Added runtime path validation that checks required directories and writability.
+- Added OBS integration compatibility status through Worker API/version evidence.
+- Added OAuth credential presence validation without exposing secret contents.
+- Added local template setup validation through the existing detection config loader.
+- Bumped Worker/Plugin compatibility metadata to v1.3.0 / API 1.3.
+
+## Major Issues And PRs
+
+- Child issues: #340, #341, #342, #343
+- PRs: #370
+
+## Verification
+
+- Worker tests: `python -m unittest discover -s app\worker\tests`
+- Worker version: `python -m odr_worker --version`
+- Documentation checks: `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
+- Japanese docs coverage: `python scripts\validate_jp_user_docs_coverage.py --root .`
+- Plugin build: Visual Studio 2022 / CMake Release build
+- GitHub CI: #370
+
+## Deferred Items
+
+- Update System remains in #323 for v1.4.

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -172,9 +172,20 @@ Goals:
 - Release readiness checklist: `docs/release/v1.3-release-readiness.md`
 - Setup wizard architecture contract: `docs/architecture/setup-wizard.md`
 - Worker API contract: `docs/architecture/worker-api.md`
-- Release record: not created yet
+- Release record: `docs/release-history.md`; detailed summary: `docs/release/v1.3-release-summary.md`
 - Requirements (relevant sections):
   - `docs/requirements/requirements.md` -> Setup Rules / Architecture / Platform / Runtime Rules
+  - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
+
+### v1.4 - Update System
+
+- Roadmap: `docs/roadmap.md` -> **v1.4 - Update System**
+- Version tracking issue: `#323` - `[v1.4] Update System release tracking`
+- Acceptance checklist: not created yet
+- Release readiness checklist: not created yet
+- Release record: not created yet
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` -> Runtime Rules / Architecture / Platform
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
 ---
@@ -228,3 +239,4 @@ The version tracking issue itself is not an implementation work item.
 - Refs #320
 - Refs #321
 - Refs #322
+- Refs #323


### PR DESCRIPTION
## Summary
- Record v1.3.0 as the latest released version in README and release history.
- Add the v1.3 release summary and mark the v1.3 readiness checklist complete.
- Update traceability for the v1.3 release record and v1.4 handoff.

## Verification
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `git diff --check`

Refs #322
Refs #323