### PR TITLE
Record v1.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Major and minor release completions are tagged as `vMajor.Minor.Patch`. See [Rel
 ## Current Development
 
 Latest released version:
-- `v1.3.0` - Setup Wizard
+- `v1.4.0` - Update System
 
 Current development target:
-- `v1.4` - Update System
-- Tracking issue: [#323](https://github.com/Tao-pyth/obs-duel-recorder/issues/323)
+- `v2.0` - Advanced Runtime Phase
+- Tracking issue: [#324](https://github.com/Tao-pyth/obs-duel-recorder/issues/324)
 
 Next roadmap target:
 - `v2.0` - Advanced Runtime Phase
@@ -58,10 +58,10 @@ Current released foundation:
 - Match metadata, memo, search, and upload metadata generation
 - Export archive generation with SQLite, metadata, screenshots, and video linkages
 - Setup wizard state and validation for runtime path, OBS integration, OAuth, and templates
+- Update entrypoint, DB backup-before-migration, update-state diagnostics, and runtime preservation
 
 Planned roadmap capabilities:
-- Update system (`v1.4`)
-- GitHub Actions based packaging (`v1.4+`)
+- GitHub Actions based packaging (`v2.0+`)
 
 ---
 
@@ -110,25 +110,25 @@ obs-duel-recorder/
 
 ### Latest Release
 
-- Version: `v1.3.0`
-- Scope: Setup Wizard
+- Version: `v1.4.0`
+- Scope: Update System
 - Status: released
-- Tag target: `c0579c1f9f3c892059d4bf27dc43e90754453730`
-- Tracking issue: [#322](https://github.com/Tao-pyth/obs-duel-recorder/issues/322)
+- Tag target: `333d3ce757b3724f223cec1f9a8b33046df7007b`
+- Tracking issue: [#323](https://github.com/Tao-pyth/obs-duel-recorder/issues/323)
 - Release record: [docs/release-history.md](docs/release-history.md)
 
-### Completed in v1.3
+### Completed in v1.4
 
-- Worker-owned setup wizard API
-- First-run, partial, complete, cancel, and reset state handling
-- Runtime path, OBS integration, OAuth, and template validation
-- Secret-safe setup diagnostics
-- Runtime-data-preserving reset/rerun behavior
-- v1.3 acceptance and release readiness documentation
+- Canonical Windows `update.bat` entrypoint
+- Worker-owned update status, validation, and apply API
+- DB backup-before-migration under `user_data/data/db/backups/`
+- Partial/failed update-state diagnostics and installed-version records
+- Runtime preservation for config, DB, videos, screenshots, exports, and logs
+- v1.4 acceptance and release readiness documentation
 
-### Planned After v1.3
+### Planned After v1.4
 
-- `v1.4` - Update System
+- `v2.0` - Advanced Runtime Phase
 - Later roadmap items include packaging and GitHub Pages documentation.
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [v1.1 release summary](release/v1.1-release-summary.md)
 - [v1.2 release summary](release/v1.2-release-summary.md)
 - [v1.3 release summary](release/v1.3-release-summary.md)
+- [v1.4 release summary](release/v1.4-release-summary.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
 - [v0.3 SQLite Foundation acceptance checklist](requirements/v0.3-sqlite-foundation-acceptance.md)
 - [v0.4 OBS Plugin Skeleton acceptance checklist](requirements/v0.4-obs-plugin-skeleton-acceptance.md)

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -215,3 +215,19 @@ The version tracking issue may contain the working release summary, but finalize
 - Deferred items: Update System remains in #323 for v1.4
 - Next version tracking issue: #323
 - Status: released
+
+### v1.4.0 - Update System
+
+- Version tracking issue: #323
+- Milestone: `v1.4` (not set)
+- Release readiness checklist: `docs/release/v1.4-release-readiness.md`
+- Tag: `v1.4.0`
+- Tag target: `333d3ce757b3724f223cec1f9a8b33046df7007b`
+- Release finalized at: `2026-05-23T12:48:01+09:00`
+- Tag finalized at: `2026-05-23T12:47:19+09:00`
+- Release summary: `docs/release/v1.4-release-summary.md`
+- Major child issues: #344, #345, #346, #347
+- Major PRs: #372
+- Deferred items: Advanced Runtime Phase remains in #324 for v2.0
+- Next version tracking issue: #324
+- Status: released

--- a/docs/release/v1.4-release-readiness.md
+++ b/docs/release/v1.4-release-readiness.md
@@ -19,11 +19,11 @@ Non-goals:
 
 ## A. Milestone Readiness
 
-- [ ] Required v1.4 child issues are closed or explicitly deferred with a clear note.
-- [ ] Any deferred issues have a target version or follow-up issue.
-- [ ] Version tracking issue #323 reflects final child issue state.
-- [ ] Open v1.4 PRs are merged or explicitly deferred.
-- [ ] Superseded duplicate v1.4 tracking issues are identified for cleanup.
+- [x] Required v1.4 child issues are closed or explicitly deferred with a clear note.
+- [x] Any deferred issues have a target version or follow-up issue.
+- [x] Version tracking issue #323 reflects final child issue state.
+- [x] Open v1.4 PRs are merged or explicitly deferred.
+- [x] Superseded duplicate v1.4 tracking issues are identified for cleanup.
 
 ## B. Documentation Readiness
 
@@ -34,8 +34,8 @@ Non-goals:
   - [x] `docs/requirements/v1.4-update-system-acceptance.md`
   - [x] `docs/architecture/update-system.md`
   - [x] `docs/architecture/worker-api.md`
-- [ ] README current development and latest release sections are ready for the release handoff.
-- [ ] Release history update is prepared.
+- [x] README current development and latest release sections are ready for the release handoff.
+- [x] Release history update is prepared.
 
 ## C. Verification - Update System
 
@@ -48,18 +48,18 @@ Non-goals:
 
 ## D. Release PR Readiness
 
-- [ ] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
-- [ ] Release PR updates persistent release docs.
-- [ ] Release PR is merged into `main`.
-- [ ] The merge commit SHA on `main` is recorded for tagging.
+- [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
+- [x] Release PR updates persistent release docs.
+- [x] Release PR is merged into `main`.
+- [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## E. Tagging After Merge
 
-- [ ] Create tag `v1.4.0` pointing to the release merge commit SHA on `main`.
-- [ ] Do not move or overwrite existing tags.
-- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #323 and release docs.
+- [x] Create tag `v1.4.0` pointing to the release merge commit SHA on `main`.
+- [x] Do not move or overwrite existing tags.
+- [x] If tooling cannot create the tag, record the intended tag name and target SHA in #323 and release docs.
 
 ## F. Handoff
 
-- [ ] Next version tracking issue #324 is linked from #323.
-- [ ] Deferred work is linked to follow-up issues or later version tracking.
+- [x] Next version tracking issue #324 is linked from #323.
+- [x] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/release/v1.4-release-summary.md
+++ b/docs/release/v1.4-release-summary.md
@@ -1,0 +1,38 @@
+# v1.4.0 Release Summary - Update System
+
+Status: **released**
+
+- Version tracking issue: #323
+- Release readiness checklist: `docs/release/v1.4-release-readiness.md`
+- Tag: `v1.4.0`
+- Tag target: `333d3ce757b3724f223cec1f9a8b33046df7007b`
+- Release finalized at: `2026-05-23T12:48:01+09:00`
+- Tag finalized at: `2026-05-23T12:47:19+09:00`
+- Next version tracking issue: #324
+
+## Completed Scope
+
+- Added canonical Windows `update.bat` entrypoint.
+- Added Worker update status, validation, and apply endpoints.
+- Added version/API compatibility preflight with unsupported downgrade diagnostics.
+- Added DB backup-before-migration flow under `user_data/data/db/backups/`.
+- Added partial/failed update-state diagnostics under `user_data/data/update-state.json`.
+- Added installed-version records under `user_data/data/installed-version.json`.
+- Documented rollback boundary, backup restore guidance, and runtime preservation.
+- Bumped Worker/Plugin compatibility metadata to v1.4.0 / API 1.4.
+
+## Validation
+
+- Worker tests: `python -m unittest discover -s app\worker\tests`
+- Worker version: `python -m odr_worker --version`
+- Markdown links: `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
+- Japanese docs coverage: `python scripts\validate_jp_user_docs_coverage.py --root .`
+- Update validation: `.\update.bat validate --from-version 1.3.0`
+- Update status: `.\update.bat status`
+- Diff whitespace check: `git diff --check`
+- Plugin Release build: `cmake --build build/plugin-v13-setup --config Release` using the local OBS/Qt smoke SDK cache
+- CI for #372: Docs validation and Worker unit tests passed
+
+## Deferred Items
+
+- Advanced Runtime Phase remains in #324 for v2.0.

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -185,7 +185,7 @@ Goals:
 - Release readiness checklist: `docs/release/v1.4-release-readiness.md`
 - Update system architecture contract: `docs/architecture/update-system.md`
 - Worker API contract: `docs/architecture/worker-api.md`
-- Release record: not created yet
+- Release record: `docs/release-history.md`; detailed summary: `docs/release/v1.4-release-summary.md`
 - Requirements (relevant sections):
   - `docs/requirements/requirements.md` -> Update Rules / Runtime Rules / Architecture / Platform
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation


### PR DESCRIPTION
## Summary
- Record v1.4.0 as the latest released version in README and release history.
- Add the v1.4 release summary and mark the v1.4 readiness checklist complete.
- Update traceability for the v1.4 release record and v2.0 handoff.

## Verification
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `git diff --check`

Refs #323
Refs #324