### PR TITLE
Prepare v2 roadmap documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Latest released version:
 - `v1.4.0` - Update System
 
 Current development target:
-- `v2.0` - Advanced Runtime Phase
+- `v2.0` - OCR Integration
 - Tracking issue: [#324](https://github.com/Tao-pyth/obs-duel-recorder/issues/324)
 
 Next roadmap target:
-- `v2.0` - Advanced Runtime Phase
+- `v2.1` - Statistics System
 
 ---
 
@@ -61,7 +61,8 @@ Current released foundation:
 - Update entrypoint, DB backup-before-migration, update-state diagnostics, and runtime preservation
 
 Planned roadmap capabilities:
-- GitHub Actions based packaging (`v2.0+`)
+- image-recognition-assisted metadata extraction (`v2.0`)
+- GitHub Actions based packaging and SHA256 checksum assets (`v2.0+`)
 
 ---
 
@@ -128,7 +129,7 @@ obs-duel-recorder/
 
 ### Planned After v1.4
 
-- `v2.0` - Advanced Runtime Phase
+- `v2.0` - OCR Integration
 - Later roadmap items include packaging and GitHub Pages documentation.
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,10 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [v1.2 release readiness checklist](release/v1.2-release-readiness.md)
 - [v1.3 release readiness checklist](release/v1.3-release-readiness.md)
 - [v1.4 release readiness checklist](release/v1.4-release-readiness.md)
+- [v2.0 release readiness checklist](release/v2.0-release-readiness.md)
+- [v2.1 release readiness checklist](release/v2.1-release-readiness.md)
+- [v2.2 release readiness checklist](release/v2.2-release-readiness.md)
+- [v2.3 release readiness checklist](release/v2.3-release-readiness.md)
 - [v0.4 release summary](release/v0.4-release-summary.md)
 - [v0.9 release summary](release/v0.9-release-summary.md)
 - [v1.0 release summary](release/v1.0-release-summary.md)
@@ -43,6 +47,10 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [v1.2 Export System acceptance checklist](requirements/v1.2-export-system-acceptance.md)
 - [v1.3 Setup Wizard acceptance checklist](requirements/v1.3-setup-wizard-acceptance.md)
 - [v1.4 Update System acceptance checklist](requirements/v1.4-update-system-acceptance.md)
+- [v2.0 OCR Integration acceptance checklist](requirements/v2.0-ocr-integration-acceptance.md)
+- [v2.1 Statistics System acceptance checklist](requirements/v2.1-statistics-system-acceptance.md)
+- [v2.2 GitHub Pages Documentation acceptance checklist](requirements/v2.2-github-pages-documentation-acceptance.md)
+- [v2.3 Runtime Optimization acceptance checklist](requirements/v2.3-runtime-optimization-acceptance.md)
 
 ## Architecture
 
@@ -59,6 +67,11 @@ Architecture documents describe technical behavior and responsibility boundaries
 - [Match metadata](architecture/metadata.md)
 - [Export system](architecture/export.md)
 - [Setup wizard](architecture/setup-wizard.md)
+- [Image recognition](architecture/image-recognition.md)
+- [Packaging](architecture/packaging.md)
+- [Statistics](architecture/statistics.md)
+- [Runtime optimization](architecture/runtime-optimization.md)
+- [Upload provider](architecture/upload-provider.md)
 - [v0.5 OBS overlay smoke procedure](architecture/v0.5-overlay-smoke.md)
 - [v0.6 recording-state smoke procedure](architecture/v0.6-recording-state-smoke.md)
 

--- a/docs/architecture/image-recognition.md
+++ b/docs/architecture/image-recognition.md
@@ -1,0 +1,33 @@
+# Image Recognition
+
+v2.0 starts image-recognition-assisted metadata extraction. It does not require heavyweight OCR or ML runtime dependencies.
+
+## Decision
+
+- The first implementation should use an abstract Worker provider boundary and deterministic fixtures.
+- Pillow may be used for lightweight image preprocessing such as crop, resize, grayscale, or threshold preparation.
+- The initial provider may be fixture-backed so CI can verify behavior without external OCR binaries, model files, or game assets.
+- Recognition output is a candidate signal, not authoritative state.
+
+## Scope
+
+The image recognition boundary may produce candidate metadata such as:
+- result
+- rank
+- DP
+- confidence/evidence fields
+
+The recognized candidates should integrate with existing match metadata APIs so users can correct or confirm the values.
+
+## Fallback
+
+When recognition fails, confidence is low, or fixture coverage does not support the input:
+- do not mutate existing metadata automatically,
+- return actionable diagnostics,
+- fall back to manual correction and existing metadata editing.
+
+## Non-Goals
+
+- Making image recognition the primary duel trigger.
+- Adding heavyweight OCR or ML dependencies as required runtime dependencies.
+- Shipping game assets, user screenshots, or training data in the repository.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -13,6 +13,11 @@ Architecture documents describe technical behavior, responsibility boundaries, a
 - [Export System](export.md)
 - [Setup Wizard](setup-wizard.md)
 - [Update System](update-system.md)
+- [Image Recognition](image-recognition.md)
+- [Packaging](packaging.md)
+- [Statistics](statistics.md)
+- [Runtime Optimization](runtime-optimization.md)
+- [Upload Provider](upload-provider.md)
 - [v0.6 Recording-State Smoke Procedure](v0.6-recording-state-smoke.md)
 
 ## Supporting Documents

--- a/docs/architecture/packaging.md
+++ b/docs/architecture/packaging.md
@@ -1,0 +1,42 @@
+# Packaging
+
+This document defines the release packaging direction for v2.0+.
+
+## Release ZIP
+
+The preferred distribution format is a GitHub Actions generated ZIP.
+
+Expected layout:
+
+```text
+obs-duel-recorder-vX.Y.Z/
+|-- app/
+|   |-- plugin/
+|   |   `-- obs-duel-recorder.dll
+|   `-- worker/
+|       `-- <worker package files>
+|-- docs/
+|   `-- <minimal install/update/user docs>
+|-- update.bat
+|-- README.md
+|-- LICENSE
+`-- SHA256SUMS.txt
+```
+
+## Exclusions
+
+Release ZIPs must not include:
+- `user_data/`
+- logs
+- SQLite databases
+- screenshots
+- videos
+- OAuth tokens or client secrets
+- local template images or game assets
+- generated runtime exports
+
+## Release Asset Policy
+
+- GitHub Actions may build and upload draft artifacts automatically.
+- Release publication or attaching final assets should require maintainer approval unless a later policy explicitly enables full automation.
+- A SHA256 checksum must be generated for each release ZIP.

--- a/docs/architecture/runtime-optimization.md
+++ b/docs/architecture/runtime-optimization.md
@@ -1,0 +1,28 @@
+# Runtime Optimization
+
+v2.3 improves long-session runtime stability without changing ownership boundaries.
+
+## Baseline First
+
+Every optimization should start with baseline evidence:
+- memory usage
+- upload processing behavior
+- queue recovery behavior
+- DB query or migration behavior
+- long-session smoke or fixture notes
+
+## Preservation Rules
+
+Optimizations must preserve:
+- Worker API compatibility
+- Plugin launch, heartbeat, and diagnostic behavior
+- queue state transitions
+- upload failure classification
+- SQLite migration safety
+- `user_data/` persistence
+
+## Non-Goals
+
+- Removing diagnostics solely to reduce overhead.
+- Deleting or compacting user data without explicit user action.
+- Adding heavyweight runtime dependencies without documented need.

--- a/docs/architecture/statistics.md
+++ b/docs/architecture/statistics.md
@@ -1,0 +1,32 @@
+# Statistics
+
+v2.1 introduces Worker-owned statistics derived from existing SQLite runtime data.
+
+## Ownership
+
+- Statistics are computed by the Worker.
+- The OBS Plugin and documentation site should consume statistics through Worker APIs.
+- Statistics must not rewrite historical match, upload, screenshot, or recognition records merely to improve aggregates.
+
+## Data Sources
+
+Statistics may derive from:
+- match metadata
+- upload queue state
+- screenshot linkage metadata
+- image-recognition candidate metadata once confirmed or stored through match metadata
+
+## Expected Outputs
+
+The statistics boundary should support deterministic summaries such as:
+- win rate
+- deck statistics
+- opponent deck statistics
+- memo search summaries
+- upload state statistics
+
+## Safety
+
+- Empty datasets must return stable zero-count responses.
+- Filters must be documented before release.
+- Diagnostics must not expose OAuth secrets, logs, local media contents, or unnecessary absolute paths.

--- a/docs/architecture/upload-provider.md
+++ b/docs/architecture/upload-provider.md
@@ -1,0 +1,36 @@
+# Upload Provider
+
+The upload system must support deterministic tests and production YouTube uploads through a provider boundary.
+
+## Providers
+
+- `MockUploader`: deterministic local behavior for tests, CI, and smoke flows.
+- `GoogleUploader`: production YouTube upload implementation using optional official Google client libraries.
+
+The Worker API should preserve the existing upload boundary while allowing provider selection through configuration or runtime capability detection.
+
+## Optional Dependencies
+
+The Google provider may use:
+- `google-api-python-client`
+- `google-auth-oauthlib`
+- `google-auth-httplib2`
+
+These dependencies should remain optional so non-upload workflows and CI fixtures do not require Google credentials or network access.
+
+## Failure Classification
+
+Google API failures should map to stable Worker outcomes:
+
+| Category | Input Signal | Worker Outcome |
+|---|---|---|
+| quota | HTTP 403 with quota-related API reason | `quota_waiting` |
+| auth | HTTP 401/403 auth or credential reason | `need_manual_review` |
+| network | timeout, DNS, connection reset, retryable 5xx | `upload_failed` with retry evidence |
+| ambiguous | response unknown after possible upload side effect | `need_manual_review` |
+
+Diagnostics must not include OAuth tokens, client secrets, authorization codes, or bearer strings.
+
+## Preflight
+
+Setup wizard and `/upload/status` should detect missing OAuth prerequisites before a real upload attempt.

--- a/docs/release/v2.0-release-readiness.md
+++ b/docs/release/v2.0-release-readiness.md
@@ -1,0 +1,77 @@
+# v2.0 Release Readiness Checklist
+
+This checklist helps contributors prepare a **v2.0.0** release for OBS Duel Recorder.
+
+Scope:
+- Documentation and verification steps for **v2.0 - OCR Integration** readiness.
+- v2.0 uses image recognition first; heavyweight OCR/ML runtime dependencies are non-goals unless separately approved.
+- No implementation work is performed by this checklist.
+
+Quick links:
+- Version tracking issue: #324
+- Acceptance checklist: `docs/requirements/v2.0-ocr-integration-acceptance.md`
+- Image recognition architecture contract: `docs/architecture/image-recognition.md`
+
+Non-goals:
+- Completing v2.1 Statistics System.
+- Making image recognition the primary duel trigger.
+- Shipping game assets, user screenshots, or training data.
+
+---
+
+## A. Milestone Readiness
+
+- [ ] Required v2.0 child issues are closed or explicitly deferred with a clear note.
+- [ ] Any deferred issues have a target version or follow-up issue.
+- [ ] Version tracking issue #324 reflects final child issue state.
+- [ ] Open v2.0 PRs are merged or explicitly deferred.
+- [ ] Superseded duplicate v2.0 tracking issues are identified for cleanup.
+
+## B. Documentation Readiness
+
+- [ ] Canonical docs are up to date:
+  - [ ] `docs/roadmap.md`
+  - [ ] `docs/requirements/requirements.md`
+  - [ ] `docs/traceability.md`
+  - [ ] `docs/requirements/v2.0-ocr-integration-acceptance.md`
+  - [ ] `docs/architecture/image-recognition.md`
+  - [ ] `docs/architecture/packaging.md`
+  - [ ] `docs/architecture/upload-provider.md`
+  - [ ] `docs/architecture/worker-api.md`
+- [ ] README current development and latest release sections are ready for the release handoff.
+- [ ] Release history update is prepared.
+
+## C. Verification - Image Recognition
+
+- [ ] Image recognition provider boundary tests pass.
+- [ ] Fixture-backed result, rank, and DP recognition tests pass.
+- [ ] Fixture minimum success criteria are met and recorded.
+- [ ] Metadata correction/fallback behavior is tested.
+- [ ] Plugin UI/manual correction smoke notes are recorded.
+- [ ] No runtime videos, screenshots, DBs, logs, credentials, model files, game assets, or generated media are committed.
+
+## D. Packaging / Release Asset Readiness
+
+- [ ] GitHub Actions ZIP generation is available or explicitly deferred with a follow-up.
+- [ ] Release ZIP layout matches `docs/architecture/packaging.md` or any deviation is documented.
+- [ ] SHA256 checksum generation is available or explicitly deferred with a follow-up.
+- [ ] Final release asset publication requires maintainer approval.
+- [ ] Upload provider work is either completed in scoped child issues or explicitly deferred; v2.0 image recognition release must not accidentally require Google upload dependencies.
+
+## E. Release PR Readiness
+
+- [ ] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, OAuth files, local templates, model files, or game assets.
+- [ ] Release PR updates persistent release docs.
+- [ ] Release PR is merged into `main`.
+- [ ] The merge commit SHA on `main` is recorded for tagging.
+
+## F. Tagging After Merge
+
+- [ ] Create tag `v2.0.0` pointing to the release merge commit SHA on `main`.
+- [ ] Do not move or overwrite existing tags.
+- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #324 and release docs.
+
+## G. Handoff
+
+- [ ] Next version tracking issue #325 is linked from #324.
+- [ ] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/release/v2.1-release-readiness.md
+++ b/docs/release/v2.1-release-readiness.md
@@ -1,0 +1,64 @@
+# v2.1 Release Readiness Checklist
+
+This checklist helps contributors prepare a **v2.1.0** release for OBS Duel Recorder.
+
+Scope:
+- Documentation and verification steps for **v2.1 - Statistics System** readiness.
+- No implementation work is performed by this checklist.
+
+Quick links:
+- Version tracking issue: #325
+- Acceptance checklist: `docs/requirements/v2.1-statistics-system-acceptance.md`
+
+Non-goals:
+- Completing v2.2 GitHub Pages Documentation.
+- Rewriting historical match records to fabricate statistics.
+
+---
+
+## A. Milestone Readiness
+
+- [ ] Required v2.1 child issues are closed or explicitly deferred with a clear note.
+- [ ] Any deferred issues have a target version or follow-up issue.
+- [ ] Version tracking issue #325 reflects final child issue state.
+- [ ] Open v2.1 PRs are merged or explicitly deferred.
+- [ ] Superseded duplicate v2.1 tracking issues are identified for cleanup.
+
+## B. Documentation Readiness
+
+- [ ] Canonical docs are up to date:
+  - [ ] `docs/roadmap.md`
+  - [ ] `docs/requirements/requirements.md`
+  - [ ] `docs/traceability.md`
+  - [ ] `docs/requirements/v2.1-statistics-system-acceptance.md`
+  - [ ] `docs/architecture/statistics.md`
+  - [ ] `docs/architecture/worker-api.md`
+- [ ] README current development and latest release sections are ready for the release handoff.
+- [ ] Release history update is prepared.
+
+## C. Verification - Statistics
+
+- [ ] Win rate aggregation tests pass.
+- [ ] Deck and opponent statistics tests pass.
+- [ ] Memo search tests pass.
+- [ ] Upload statistics tests pass.
+- [ ] Empty and filtered dataset tests pass.
+- [ ] No runtime videos, screenshots, DBs, logs, credentials, or generated media are committed.
+
+## D. Release PR Readiness
+
+- [ ] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
+- [ ] Release PR updates persistent release docs.
+- [ ] Release PR is merged into `main`.
+- [ ] The merge commit SHA on `main` is recorded for tagging.
+
+## E. Tagging After Merge
+
+- [ ] Create tag `v2.1.0` pointing to the release merge commit SHA on `main`.
+- [ ] Do not move or overwrite existing tags.
+- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #325 and release docs.
+
+## F. Handoff
+
+- [ ] Next version tracking issue #326 is linked from #325.
+- [ ] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/release/v2.2-release-readiness.md
+++ b/docs/release/v2.2-release-readiness.md
@@ -1,0 +1,67 @@
+# v2.2 Release Readiness Checklist
+
+This checklist helps contributors prepare a **v2.2.0** release for OBS Duel Recorder.
+
+Scope:
+- Documentation and verification steps for **v2.2 - GitHub Pages Documentation** readiness.
+- No implementation work is performed by this checklist.
+
+Quick links:
+- Version tracking issue: #326
+- Acceptance checklist: `docs/requirements/v2.2-github-pages-documentation-acceptance.md`
+
+Non-goals:
+- Completing v2.3 Runtime Optimization.
+- Publishing runtime data, credentials, screenshots, videos, or game assets.
+
+---
+
+## A. Milestone Readiness
+
+- [ ] Required v2.2 child issues are closed or explicitly deferred with a clear note.
+- [ ] Any deferred issues have a target version or follow-up issue.
+- [ ] Version tracking issue #326 reflects final child issue state.
+- [ ] Open v2.2 PRs are merged or explicitly deferred.
+- [ ] Superseded duplicate v2.2 tracking issues are identified for cleanup.
+
+## B. Documentation Readiness
+
+- [ ] Canonical docs are up to date:
+  - [ ] `docs/roadmap.md`
+  - [ ] `docs/requirements/requirements.md`
+  - [ ] `docs/traceability.md`
+  - [ ] `docs/requirements/v2.2-github-pages-documentation-acceptance.md`
+  - [ ] `docs/validation.md`
+  - [ ] `docs/README.md`
+  - [ ] `docs/user/index.md`
+  - [ ] `docs/user/ja/index.md`
+  - [ ] `docs/user/ja/faq.md`
+  - [ ] `docs/user/ja/troubleshooting.md`
+- [ ] README current development and latest release sections are ready for the release handoff.
+- [ ] Release history update is prepared.
+
+## C. Verification - GitHub Pages Documentation
+
+- [ ] Markdown link validation passes.
+- [ ] Japanese user docs coverage validation passes.
+- [ ] GitHub Pages build or dry-run artifact is produced.
+- [ ] Setup, troubleshooting, FAQ, update, upload, and recognition user docs are reviewed.
+- [ ] Published docs exclude runtime data, credentials, screenshots, videos, logs, databases, local templates, and game assets.
+
+## D. Release PR Readiness
+
+- [ ] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
+- [ ] Release PR updates persistent release docs.
+- [ ] Release PR is merged into `main`.
+- [ ] The merge commit SHA on `main` is recorded for tagging.
+
+## E. Tagging After Merge
+
+- [ ] Create tag `v2.2.0` pointing to the release merge commit SHA on `main`.
+- [ ] Do not move or overwrite existing tags.
+- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #326 and release docs.
+
+## F. Handoff
+
+- [ ] Next version tracking issue #327 is linked from #326.
+- [ ] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/release/v2.3-release-readiness.md
+++ b/docs/release/v2.3-release-readiness.md
@@ -1,0 +1,66 @@
+# v2.3 Release Readiness Checklist
+
+This checklist helps contributors prepare a **v2.3.0** release for OBS Duel Recorder.
+
+Scope:
+- Documentation and verification steps for **v2.3 - Runtime Optimization** readiness.
+- No implementation work is performed by this checklist.
+
+Quick links:
+- Version tracking issue: #327
+- Acceptance checklist: `docs/requirements/v2.3-runtime-optimization-acceptance.md`
+
+Non-goals:
+- Creating new roadmap scope beyond v2.3.
+- Removing recovery diagnostics merely to improve performance.
+
+---
+
+## A. Milestone Readiness
+
+- [ ] Required v2.3 child issues are closed or explicitly deferred with a clear note.
+- [ ] Any deferred issues have a target version or follow-up issue.
+- [ ] Version tracking issue #327 reflects final child issue state.
+- [ ] Open v2.3 PRs are merged or explicitly deferred.
+- [ ] Superseded duplicate v2.3 tracking issues are identified for cleanup.
+
+## B. Documentation Readiness
+
+- [ ] Canonical docs are up to date:
+  - [ ] `docs/roadmap.md`
+  - [ ] `docs/requirements/requirements.md`
+  - [ ] `docs/traceability.md`
+  - [ ] `docs/requirements/v2.3-runtime-optimization-acceptance.md`
+  - [ ] `docs/architecture/runtime-optimization.md`
+  - [ ] `docs/architecture/plugin-worker.md`
+  - [ ] `docs/architecture/worker-api.md`
+- [ ] README current development and latest release sections are ready for the release handoff.
+- [ ] Release history update is prepared.
+
+## C. Verification - Runtime Optimization
+
+- [ ] Baseline measurement notes are recorded.
+- [ ] Memory optimization tests or measurement evidence pass.
+- [ ] Upload, queue, DB, and recovery regression tests pass.
+- [ ] Plugin launch, heartbeat, settings, overlay, and manual recording smoke or regression evidence is recorded.
+- [ ] Long-session smoke or fixture evidence is recorded.
+- [ ] Migration safety is preserved.
+- [ ] No runtime videos, screenshots, DBs, logs, credentials, or generated media are committed.
+
+## D. Release PR Readiness
+
+- [ ] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
+- [ ] Release PR updates persistent release docs.
+- [ ] Release PR is merged into `main`.
+- [ ] The merge commit SHA on `main` is recorded for tagging.
+
+## E. Tagging After Merge
+
+- [ ] Create tag `v2.3.0` pointing to the release merge commit SHA on `main`.
+- [ ] Do not move or overwrite existing tags.
+- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #327 and release docs.
+
+## F. Handoff
+
+- [ ] Next version tracking issue is linked from #327 if the next roadmap version exists.
+- [ ] Deferred work is linked to follow-up issues or later version tracking.

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -20,7 +20,7 @@ The system separates responsibilities into:
 | Component | Responsibility |
 |---|---|
 | OBS Plugin | OBS integration, overlay control, Dock UI, Worker lifecycle |
-| Python Worker | Queue processing, SQLite, OCR, template matching, screenshot archive, upload processing |
+| Python Worker | Queue processing, SQLite, image recognition, template matching, screenshot archive, upload processing |
 
 ---
 
@@ -54,6 +54,10 @@ The system separates responsibilities into:
 - Tokens, client secrets, authorization codes, and bearer strings must be redacted from diagnostics
 - Missing local videos are discarded with evidence
 - Ambiguous upload outcomes require manual review instead of blind retry
+- Upload execution must use a provider boundary so tests can use a deterministic mock uploader and production can use an optional Google uploader.
+- The Google uploader should use the official Google client libraries as optional dependencies.
+- Google API failures must be classified by HTTP status and API reason into stable outcomes such as quota, auth, network, and ambiguous failure.
+- Setup wizard and `/upload/status` must detect missing OAuth prerequisites before a real upload attempt.
 
 ---
 
@@ -64,6 +68,16 @@ The system separates responsibilities into:
 - Metadata validation failures must be actionable and must not change the existing record.
 - Upload title, description, and notes generation must be deterministic.
 - Post-upload metadata edits update future generated metadata but do not rewrite an already uploaded YouTube record automatically.
+
+---
+
+## Statistics Rules
+
+- Statistics are Worker-owned and derived from SQLite runtime data.
+- Statistics must not rewrite source records merely to improve aggregates.
+- Empty datasets must return stable zero-count responses.
+- Statistics filters must be documented and deterministic.
+- Statistics diagnostics must not expose OAuth secrets, logs, local media contents, or unnecessary absolute paths.
 
 ---
 
@@ -102,6 +116,29 @@ The system separates responsibilities into:
 
 ---
 
+## Packaging Rules
+
+- Release packaging should be produced as a GitHub Actions ZIP artifact.
+- The ZIP layout must include the Plugin DLL, Worker package, `update.bat`, and minimal user/developer docs needed for install/update.
+- `user_data/`, logs, databases, screenshots, videos, OAuth files, and generated runtime exports must never be included in release ZIPs.
+- Release assets should include a SHA256 checksum.
+- GitHub Actions may generate release assets automatically, but final release attachment/publishing should remain manually approved unless a later release defines a fully automated policy.
+
+---
+
+## Image Recognition Rules
+
+- v2.0 image analysis is image-recognition-assisted metadata extraction, not mandatory OCR text recognition.
+- Fixture-based recognition must be implemented first through an abstract Worker provider boundary.
+- Pillow is allowed for lightweight image preprocessing; heavyweight OCR or ML runtime dependencies are not required for v2.0.
+- Recognition results must be treated as candidates until verified by rules, fixtures, or user correction.
+- Fixture-based minimum success criteria must be documented before release.
+- Failed or low-confidence recognition must fall back to manual correction and existing match metadata editing.
+- Image recognition must not become the primary duel trigger mechanism; template matching and state transitions remain the primary detection path.
+- The repository must not distribute game assets, user screenshots, or proprietary training data.
+
+---
+
 ## Overlay Rules
 
 Overlay supports:
@@ -119,9 +156,9 @@ Primary:
 - template matching
 
 Secondary:
-- OCR
+- image-recognition-assisted metadata extraction
 
-OCR must not be the primary trigger mechanism.
+Image recognition must not be the primary trigger mechanism.
 
 ---
 

--- a/docs/requirements/v2.0-ocr-integration-acceptance.md
+++ b/docs/requirements/v2.0-ocr-integration-acceptance.md
@@ -1,0 +1,37 @@
+# v2.0 OCR Integration - Acceptance Checklist
+
+This document defines the acceptance criteria for **v2.0 - OCR Integration** as described in:
+- `docs/roadmap.md`
+- #324
+
+## Scope
+
+v2.0 creates image-recognition-assisted metadata extraction. The roadmap name remains OCR Integration, but the implementation direction is image recognition first:
+- result recognition
+- rank recognition
+- DP recognition
+- recognition-assisted verification
+- fallback to manual correction
+
+## Acceptance
+
+- [ ] A Worker-owned image recognition provider boundary is defined.
+- [ ] A deterministic fixture-backed provider is implemented before any real OCR or ML dependency.
+- [ ] Pillow is the only expected image preprocessing dependency for v2.0 unless a later issue explicitly expands scope.
+- [ ] Recognition fixtures cover result, rank, and DP candidate extraction.
+- [ ] Fixture-based minimum success criteria are documented and enforced by tests.
+- [ ] Recognition returns candidate values with evidence/confidence instead of blindly mutating metadata.
+- [ ] Low-confidence or failed recognition falls back to manual correction and existing match metadata editing.
+- [ ] Worker API and match metadata integration expose recognized candidates for correction/confirmation.
+- [ ] Plugin UI can surface or edit recognition-assisted metadata through the Worker/metadata boundary.
+- [ ] Image recognition does not become the primary duel trigger mechanism.
+- [ ] No game assets, user screenshots, local templates, model files, OAuth secrets, logs, or runtime media are committed.
+- [ ] Existing `/health`, `/version`, `/setup/*`, `/exports`, `/update/*`, metadata, upload, queue, recording, screenshot, overlay, and detection APIs remain compatible under the v2.0 API gate.
+
+## Evidence
+
+- Worker tests: `python -m unittest discover -s app\worker\tests`
+- Recognition fixture tests and success-rate summary
+- Architecture: `docs/architecture/image-recognition.md`
+- Metadata integration evidence
+- Plugin UI/manual correction smoke notes

--- a/docs/requirements/v2.1-statistics-system-acceptance.md
+++ b/docs/requirements/v2.1-statistics-system-acceptance.md
@@ -1,0 +1,35 @@
+# v2.1 Statistics System - Acceptance Checklist
+
+This document defines the acceptance criteria for **v2.1 - Statistics System** as described in:
+- `docs/roadmap.md`
+- #325
+
+## Scope
+
+v2.1 creates long-term duel analysis support:
+- win rate aggregation
+- deck statistics
+- opponent statistics
+- memo search
+- upload statistics
+
+## Acceptance
+
+- [ ] Statistics are Worker-owned and derived from SQLite runtime data.
+- [ ] Win rate aggregation is deterministic and covered by tests.
+- [ ] Deck statistics can aggregate by local deck name and result.
+- [ ] Opponent statistics can aggregate by opponent deck and result.
+- [ ] Memo search supports stable local lookup without mutating match records.
+- [ ] Upload statistics summarize uploaded, failed, quota waiting, manual review, and discarded states.
+- [ ] Statistics endpoints support documented filters such as date range, deck, opponent deck, and result where implemented.
+- [ ] Empty datasets return stable zero-count responses.
+- [ ] Statistics queries do not expose OAuth secrets, logs, local media contents, or absolute paths unless explicitly required for diagnostics.
+- [ ] Existing `/health`, `/version`, `/setup/*`, `/exports`, `/update/*`, metadata, upload, queue, recording, screenshot, overlay, detection, and image-recognition APIs remain compatible under the v2.1 API gate.
+
+## Evidence
+
+- Worker tests: `python -m unittest discover -s app\worker\tests`
+- Statistics fixture tests for empty, mixed, and filtered datasets
+- Architecture/API documentation updates
+- Architecture: `docs/architecture/statistics.md`
+- User or developer docs for interpreting statistics

--- a/docs/requirements/v2.2-github-pages-documentation-acceptance.md
+++ b/docs/requirements/v2.2-github-pages-documentation-acceptance.md
@@ -1,0 +1,34 @@
+# v2.2 GitHub Pages Documentation - Acceptance Checklist
+
+This document defines the acceptance criteria for **v2.2 - GitHub Pages Documentation** as described in:
+- `docs/roadmap.md`
+- #326
+
+## Scope
+
+v2.2 creates user-facing documentation publication support:
+- GitHub Pages support
+- docs publication flow
+- user setup documentation
+- troubleshooting documentation
+- FAQ system
+
+## Acceptance
+
+- [ ] GitHub Pages publication flow is documented and reproducible.
+- [ ] Documentation source paths and generated/publication paths are clearly separated.
+- [ ] User setup documentation covers install, first setup, OBS setup, YouTube setup, update, and runtime preservation.
+- [ ] Troubleshooting documentation covers common Worker, Plugin, upload, update, queue, and recognition failures.
+- [ ] FAQ entries are converted from TODO placeholders into concrete user-facing answers.
+- [ ] Published docs do not include secrets, logs, databases, screenshots, videos, OAuth files, or game assets.
+- [ ] Markdown link validation runs before publication.
+- [ ] Japanese user docs remain traceable to canonical English/user docs without contradiction.
+- [ ] Release packaging docs and GitHub Pages docs do not conflict about what is published versus what is shipped.
+- [ ] Existing release and traceability docs link the published documentation entry point.
+
+## Evidence
+
+- Markdown validation: `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
+- Japanese coverage: `python scripts\validate_jp_user_docs_coverage.py --root .`
+- Publication workflow dry run or artifact evidence
+- User docs review notes

--- a/docs/requirements/v2.3-runtime-optimization-acceptance.md
+++ b/docs/requirements/v2.3-runtime-optimization-acceptance.md
@@ -1,0 +1,37 @@
+# v2.3 Runtime Optimization - Acceptance Checklist
+
+This document defines the acceptance criteria for **v2.3 - Runtime Optimization** as described in:
+- `docs/roadmap.md`
+- #327
+
+## Scope
+
+v2.3 improves long-term runtime stability:
+- memory optimization
+- upload optimization
+- queue optimization
+- DB optimization
+- recovery optimization
+
+## Acceptance
+
+- [ ] Baseline runtime measurements are recorded before optimization changes.
+- [ ] Memory optimization work has before/after evidence and does not remove diagnostics needed for troubleshooting.
+- [ ] Upload optimization preserves retry, quota, auth, ambiguous outcome, and manual review semantics.
+- [ ] Queue optimization preserves restart recovery and state transition rules.
+- [ ] DB optimization preserves migration safety, schema version tracking, and runtime data persistence.
+- [ ] Recovery optimization preserves interrupted recording/upload recovery behavior.
+- [ ] Long-session smoke or fixture tests cover sustained Worker operation.
+- [ ] Performance changes do not delete or reset `user_data`.
+- [ ] Optimizations do not introduce required heavyweight dependencies without documented need.
+- [ ] Existing `/health`, `/version`, `/setup/*`, `/exports`, `/update/*`, metadata, upload, queue, recording, screenshot, overlay, detection, image-recognition, statistics, and documentation publication APIs remain compatible under the v2.3 API gate.
+- [ ] Plugin launch, heartbeat, settings, overlay, manual recording, and diagnostic behavior remain compatible.
+
+## Evidence
+
+- Worker tests: `python -m unittest discover -s app\worker\tests`
+- Before/after measurement notes
+- Long-session smoke or fixture evidence
+- Architecture: `docs/architecture/runtime-optimization.md`
+- Plugin compatibility notes from `docs/architecture/plugin-worker.md`
+- Migration/recovery regression tests

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -366,19 +366,23 @@ Advanced automation and analysis phase.
 
 ### Goals
 
-Add OCR-assisted metadata analysis.
+Add image-recognition-assisted metadata analysis.
+
+Implementation note:
+- v2.0 starts with image recognition fixtures and an abstract Worker provider boundary.
+- Heavyweight OCR or ML runtime dependencies are not required for v2.0.
 
 ### Planned
 
-- result OCR
-- rank OCR
-- DP OCR
-- OCR-assisted verification
-- OCR fallback support
+- result recognition
+- rank recognition
+- DP recognition
+- recognition-assisted verification
+- manual correction fallback support
 
 ### Deliverables
 
-- OCR-assisted metadata extraction
+- image-recognition-assisted metadata extraction
 
 ---
 

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -192,6 +192,67 @@ Goals:
 
 ---
 
+## v2.x
+
+### v2.0 - OCR Integration
+
+- Roadmap: `docs/roadmap.md` -> **v2.0 - OCR Integration**
+- Version tracking issue: `#324` - `[v2.0] OCR Integration release tracking`
+- Acceptance checklist: `docs/requirements/v2.0-ocr-integration-acceptance.md`
+- Release readiness checklist: `docs/release/v2.0-release-readiness.md`
+- Image recognition architecture contract: `docs/architecture/image-recognition.md`
+- Packaging architecture contract: `docs/architecture/packaging.md`
+- Upload provider architecture contract: `docs/architecture/upload-provider.md`
+- Worker API contract: `docs/architecture/worker-api.md`
+- Release record: not created yet
+- Scope note: packaging and upload-provider documents record v2.x preparation contracts; v2.0 implementation remains image-recognition-first unless child issues explicitly expand scope.
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` -> Image Recognition Rules / Upload Rules / Packaging Rules / Detection Rules / Match Data / Runtime Rules
+  - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
+
+### v2.1 - Statistics System
+
+- Roadmap: `docs/roadmap.md` -> **v2.1 - Statistics System**
+- Version tracking issue: `#325` - `[v2.1] Statistics System release tracking`
+- Acceptance checklist: `docs/requirements/v2.1-statistics-system-acceptance.md`
+- Release readiness checklist: `docs/release/v2.1-release-readiness.md`
+- Statistics architecture contract: `docs/architecture/statistics.md`
+- Worker API contract: `docs/architecture/worker-api.md`
+- Release record: not created yet
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` -> Statistics Rules / Match Data / Upload Rules / Runtime Rules / Architecture / Platform
+  - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
+
+### v2.2 - GitHub Pages Documentation
+
+- Roadmap: `docs/roadmap.md` -> **v2.2 - GitHub Pages Documentation**
+- Version tracking issue: `#326` - `[v2.2] GitHub Pages Documentation release tracking`
+- Acceptance checklist: `docs/requirements/v2.2-github-pages-documentation-acceptance.md`
+- Release readiness checklist: `docs/release/v2.2-release-readiness.md`
+- Documentation validation policy: `docs/validation.md`
+- Packaging architecture contract: `docs/architecture/packaging.md`
+- Release record: not created yet
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` -> Packaging Rules / Runtime Rules / Architecture / Platform
+  - `docs/README.md` -> Documentation Rules / Validation
+  - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
+
+### v2.3 - Runtime Optimization
+
+- Roadmap: `docs/roadmap.md` -> **v2.3 - Runtime Optimization**
+- Version tracking issue: `#327` - `[v2.3] Runtime Optimization release tracking`
+- Acceptance checklist: `docs/requirements/v2.3-runtime-optimization-acceptance.md`
+- Release readiness checklist: `docs/release/v2.3-release-readiness.md`
+- Runtime optimization architecture contract: `docs/architecture/runtime-optimization.md`
+- Plugin architecture contract: `docs/architecture/plugin-worker.md`
+- Worker API contract: `docs/architecture/worker-api.md`
+- Release record: not created yet
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` -> Update Rules / Runtime Rules / Upload Rules / Queue States / Architecture / Platform
+  - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
+
+---
+
 ## Policy
 
 ### Source roles
@@ -242,3 +303,7 @@ The version tracking issue itself is not an implementation work item.
 - Refs #321
 - Refs #322
 - Refs #323
+- Refs #324
+- Refs #325
+- Refs #326
+- Refs #327


### PR DESCRIPTION
## Summary
- Add v2.0-v2.3 acceptance and release readiness documents at the same release-management granularity as v1.x.
- Add v2 architecture contracts for image recognition, packaging, upload provider, statistics, and runtime optimization.
- Update roadmap, README, requirements, docs index, architecture index, and traceability for #324-#327.
- Record current decisions: image recognition/fixture provider first, Pillow-level preprocessing only for v2.0, manual correction fallback, GitHub Actions ZIP + checksum packaging, and optional GoogleUploader provider.

## Verification
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `git diff --check`
- Parallel subagent documentation consistency reviews completed; findings addressed.

Refs #324
Refs #325
Refs #326
Refs #327