### PR TITLE
Add v2.0 image recognition candidate flow

### DIFF
--- a/app/worker/odr_worker/api.py
+++ b/app/worker/odr_worker/api.py
@@ -11,6 +11,7 @@ from .db import DbInfo
 from .detection import DetectionRuntime, TemplateConfigError, load_template_config, load_templates
 from .exports import ExportError, ExportStore
 from .health import API_VERSION, PID, STARTED_AT, WorkerDb, WorkerPaths, build_health_payload
+from .image_recognition import ImageRecognitionError, RecognitionCandidateStore, analyze_fixture_payload
 from .identity import INSTANCE_ID
 from .metadata import MatchMetadataStore, MetadataError
 from .overlay import OverlayPayloadError, OverlayState, apply_overlay_update
@@ -85,6 +86,7 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
     app.state.screenshot_store = None
     app.state.upload_store = None
     app.state.metadata_store = None
+    app.state.recognition_store = None
     app.state.export_store = None
     app.state.setup_store = SetupWizardStore(runtime_dirs=runtime_dirs)
     app.state.update_manager = UpdateManager(runtime_dirs=runtime_dirs)
@@ -101,6 +103,7 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
             screenshots_dir=runtime_dirs.screenshots_dir,
         )
         app.state.metadata_store = MatchMetadataStore(db_info.db_path)
+        app.state.recognition_store = RecognitionCandidateStore(db_info.db_path)
         app.state.upload_store = UploadStore(
             queue_store=app.state.queue_store,
             videos_dir=runtime_dirs.videos_dir,
@@ -528,6 +531,101 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
                 code=exc.code,
                 message="Match upload metadata is invalid",
                 details=exc.details,
+            )
+
+    @app.post("/recognition/analyze")
+    async def post_recognition_analyze(request: Request):
+        try:
+            payload = await request.json()
+            if not isinstance(payload, dict):
+                raise ValueError
+            match_id = payload.get("match_id")
+            if match_id is not None and not isinstance(match_id, int):
+                return _error_response(
+                    status_code=400,
+                    code="recognition_payload_invalid",
+                    message="Recognition payload is invalid",
+                    details={"match_id": "must_be_integer_or_null"},
+                )
+            if match_id is not None and app.state.metadata_store is not None:
+                app.state.metadata_store.get_match(match_id)
+            result = analyze_fixture_payload(payload)
+            response = result.as_payload(match_id=match_id)
+            if app.state.recognition_store is not None:
+                records = app.state.recognition_store.save_result(match_id=match_id, result=result)
+                response["candidate_records"] = [record.as_payload() for record in records]
+            return response
+        except ImageRecognitionError as exc:
+            return _error_response(
+                status_code=400,
+                code=exc.code,
+                message="Recognition request is invalid",
+                details=exc.details,
+            )
+        except MetadataError as exc:
+            return _error_response(
+                status_code=404 if exc.code == "match_not_found" else 400,
+                code=exc.code,
+                message="Match metadata request is invalid",
+                details=exc.details,
+            )
+        except ValueError:
+            return _error_response(
+                status_code=400,
+                code="recognition_payload_invalid",
+                message="Recognition payload must be JSON object",
+            )
+
+    @app.get("/recognition/candidates")
+    def get_recognition_candidates(match_id: int | None = None, status: str | None = None):
+        if app.state.recognition_store is None:
+            return _error_response(
+                status_code=503,
+                code="recognition_unavailable",
+                message="Recognition storage is unavailable",
+            )
+        try:
+            records = app.state.recognition_store.list_candidates(match_id=match_id, status=status)
+            return {"items": [record.as_payload() for record in records]}
+        except ImageRecognitionError as exc:
+            return _error_response(
+                status_code=400,
+                code=exc.code,
+                message="Recognition request is invalid",
+                details=exc.details,
+            )
+
+    @app.post("/recognition/candidates/{candidate_id}/command")
+    async def post_recognition_candidate_command(candidate_id: int, request: Request):
+        if app.state.recognition_store is None:
+            return _error_response(
+                status_code=503,
+                code="recognition_unavailable",
+                message="Recognition storage is unavailable",
+            )
+        try:
+            payload = await request.json()
+            if not isinstance(payload, dict):
+                raise ValueError
+            record = app.state.recognition_store.apply_command(
+                candidate_id,
+                payload,
+                metadata_store=app.state.metadata_store,
+            )
+            return record.as_payload()
+        except ImageRecognitionError as exc:
+            status_code = 404 if exc.code in {"recognition_candidate_not_found", "match_not_found"} else 400
+            return _error_response(
+                status_code=status_code,
+                code=exc.code,
+                message="Recognition command is invalid",
+                details=exc.details,
+            )
+        except ValueError:
+            return _error_response(
+                status_code=400,
+                code="recognition_command_invalid",
+                message="Recognition command must be JSON object",
             )
 
     @app.get("/screenshots")

--- a/app/worker/odr_worker/db.py
+++ b/app/worker/odr_worker/db.py
@@ -26,6 +26,7 @@ _MIGRATIONS: tuple[str, ...] = (
     "0003_queue_recovery",
     "0004_screenshots",
     "0005_match_metadata",
+    "0006_image_recognition_metadata",
 )
 
 

--- a/app/worker/odr_worker/image_recognition.py
+++ b/app/worker/odr_worker/image_recognition.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+import datetime as _dt
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .metadata import MatchMetadataStore, MetadataError
+
+
+SUPPORTED_FIELDS = ("result", "rank", "dp")
+MIN_ACCEPT_CONFIDENCE = 0.80
+MAX_EVIDENCE_LENGTH = 160
+CANDIDATE_STATUSES = {"candidate", "confirmed", "corrected", "rejected"}
+
+
+class ImageRecognitionError(ValueError):
+    def __init__(self, code: str, details: dict[str, object]):
+        super().__init__(code)
+        self.code = code
+        self.details = details
+
+
+@dataclass(frozen=True)
+class RecognitionCandidate:
+    field: str
+    value: str
+    confidence: float
+    evidence: str
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "field": self.field,
+            "value": self.value,
+            "confidence": self.confidence,
+            "evidence": self.evidence,
+        }
+
+
+@dataclass(frozen=True)
+class RecognitionCandidateRecord:
+    id: int
+    match_id: int | None
+    provider: str
+    field: str
+    value: str
+    confidence: float
+    evidence: str
+    status: str
+    corrected_value: str
+    created_at: str
+    updated_at: str
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "match_id": self.match_id,
+            "provider": self.provider,
+            "field": self.field,
+            "value": self.value,
+            "confidence": self.confidence,
+            "evidence": self.evidence,
+            "status": self.status,
+            "corrected_value": self.corrected_value,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass(frozen=True)
+class RecognitionResult:
+    provider: str
+    status: str
+    candidates: tuple[RecognitionCandidate, ...]
+    diagnostics: tuple[dict[str, object], ...]
+
+    def metadata_patch(self) -> dict[str, str]:
+        return {
+            candidate.field: candidate.value
+            for candidate in self.candidates
+            if candidate.confidence >= MIN_ACCEPT_CONFIDENCE
+        }
+
+    def as_payload(self, *, match_id: int | None = None) -> dict[str, object]:
+        metadata_patch = self.metadata_patch()
+        payload: dict[str, object] = {
+            "provider": self.provider,
+            "status": self.status,
+            "match_id": match_id,
+            "minimum_confidence": MIN_ACCEPT_CONFIDENCE,
+            "candidates": [candidate.as_payload() for candidate in self.candidates],
+            "metadata_patch": metadata_patch,
+            "diagnostics": list(self.diagnostics),
+            "mutated": False,
+        }
+        if match_id is not None:
+            payload["manual_correction"] = {
+                "method": "PUT",
+                "endpoint": f"/matches/{match_id}/metadata",
+                "body": metadata_patch,
+            }
+        return payload
+
+
+class RecognitionCandidateStore:
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON;")
+        return conn
+
+    def save_result(self, *, match_id: int | None, result: RecognitionResult) -> list[RecognitionCandidateRecord]:
+        conn = self._connect()
+        try:
+            records: list[RecognitionCandidateRecord] = []
+            now = _utc_now_iso()
+            for candidate in result.candidates:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO recognition_candidates(
+                      match_id, provider, field, value, confidence, evidence,
+                      status, corrected_value, created_at, updated_at
+                    ) VALUES(?, ?, ?, ?, ?, ?, 'candidate', '', ?, ?);
+                    """,
+                    (
+                        match_id,
+                        result.provider,
+                        candidate.field,
+                        candidate.value,
+                        candidate.confidence,
+                        candidate.evidence,
+                        now,
+                        now,
+                    ),
+                )
+                records.append(self._get(conn, int(cursor.lastrowid)))
+            conn.commit()
+            return records
+        finally:
+            conn.close()
+
+    def list_candidates(self, *, match_id: int | None = None, status: str | None = None) -> list[RecognitionCandidateRecord]:
+        if status is not None and status not in CANDIDATE_STATUSES:
+            raise ImageRecognitionError("recognition_status_invalid", {"status": status})
+        clauses: list[str] = []
+        params: list[object] = []
+        if match_id is not None:
+            clauses.append("match_id = ?")
+            params.append(match_id)
+        if status is not None:
+            clauses.append("status = ?")
+            params.append(status)
+        where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+        conn = self._connect()
+        try:
+            rows = conn.execute(f"SELECT * FROM recognition_candidates{where} ORDER BY id;", params).fetchall()
+            return [_record_from_row(row) for row in rows]
+        finally:
+            conn.close()
+
+    def apply_command(
+        self,
+        candidate_id: int,
+        payload: dict[str, Any],
+        *,
+        metadata_store: MatchMetadataStore | None,
+    ) -> RecognitionCandidateRecord:
+        action = payload.get("action")
+        if action not in {"confirm", "correct", "reject"}:
+            raise ImageRecognitionError("recognition_command_invalid", {"action": "confirm_correct_or_reject_required"})
+
+        conn = self._connect()
+        try:
+            record = self._get(conn, candidate_id)
+            if record.status != "candidate":
+                raise ImageRecognitionError(
+                    "recognition_candidate_already_resolved",
+                    {"id": candidate_id, "status": record.status},
+                )
+
+            corrected_value = ""
+            metadata_value = record.value
+            status = "confirmed"
+            if action == "reject":
+                status = "rejected"
+                metadata_value = ""
+            elif action == "correct":
+                value = payload.get("value")
+                if not isinstance(value, str) or not value.strip():
+                    raise ImageRecognitionError("recognition_command_invalid", {"value": "non_empty_string_required"})
+                corrected_value = _normalize_candidate_value(record.field, value)
+                metadata_value = corrected_value
+                status = "corrected"
+
+            if action in {"confirm", "correct"}:
+                if record.match_id is None:
+                    raise ImageRecognitionError("recognition_match_required", {"id": candidate_id})
+                if metadata_store is None:
+                    raise ImageRecognitionError("recognition_metadata_unavailable", {"id": candidate_id})
+                metadata_store.update_match(record.match_id, {record.field: metadata_value})
+
+            conn.execute(
+                """
+                UPDATE recognition_candidates
+                SET status = ?, corrected_value = ?, updated_at = ?
+                WHERE id = ?;
+                """,
+                (status, corrected_value, _utc_now_iso(), candidate_id),
+            )
+            conn.commit()
+            return self._get(conn, candidate_id)
+        except MetadataError as exc:
+            raise ImageRecognitionError(exc.code, exc.details) from exc
+        finally:
+            conn.close()
+
+    def _get(self, conn: sqlite3.Connection, candidate_id: int) -> RecognitionCandidateRecord:
+        row = conn.execute("SELECT * FROM recognition_candidates WHERE id = ?;", (candidate_id,)).fetchone()
+        if row is None:
+            raise ImageRecognitionError("recognition_candidate_not_found", {"id": candidate_id})
+        return _record_from_row(row)
+
+
+class FixtureImageRecognitionProvider:
+    name = "fixture"
+
+    def analyze(self, payload: dict[str, Any]) -> RecognitionResult:
+        if not isinstance(payload, dict):
+            raise ImageRecognitionError("recognition_payload_invalid", {"payload": "must_be_object"})
+
+        source_text = _source_text(payload)
+        candidates = tuple(_candidate(field, source_text) for field in SUPPORTED_FIELDS if _field_value(field, source_text))
+        diagnostics: list[dict[str, object]] = []
+        if not candidates:
+            diagnostics.append({"code": "no_candidates", "message": "No fixture recognition fields were found"})
+        low_confidence = [candidate.field for candidate in candidates if candidate.confidence < MIN_ACCEPT_CONFIDENCE]
+        if low_confidence:
+            diagnostics.append({"code": "low_confidence", "fields": low_confidence})
+
+        status = "candidates_available" if candidates and not low_confidence else "manual_review_required"
+        return RecognitionResult(
+            provider=self.name,
+            status=status,
+            candidates=candidates,
+            diagnostics=tuple(diagnostics),
+        )
+
+
+def analyze_fixture_payload(payload: dict[str, Any]) -> RecognitionResult:
+    provider = payload.get("provider", "fixture")
+    if provider != "fixture":
+        raise ImageRecognitionError("recognition_provider_unsupported", {"provider": provider})
+    return FixtureImageRecognitionProvider().analyze(payload)
+
+
+def _source_text(payload: dict[str, Any]) -> str:
+    value = payload.get("content_text")
+    if isinstance(value, str):
+        return value
+    fixture = payload.get("fixture")
+    if isinstance(fixture, dict):
+        lines: list[str] = []
+        for field in SUPPORTED_FIELDS:
+            field_value = fixture.get(field)
+            if field_value is not None:
+                lines.append(f"{field}: {field_value}")
+        confidence = fixture.get("confidence")
+        if confidence is not None:
+            lines.append(f"confidence: {confidence}")
+        return "\n".join(lines)
+    raise ImageRecognitionError(
+        "recognition_payload_invalid",
+        {"content": "content_text_or_fixture_required"},
+    )
+
+
+def _field_value(field: str, source_text: str) -> str:
+    pattern = re.compile(rf"^\s*{re.escape(field)}\s*[:=]\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+    match = pattern.search(source_text)
+    if match is None:
+        return ""
+    value = match.group(1).strip()
+    if field == "result":
+        return _normalize_result(value)
+    if field == "dp":
+        return _normalize_dp(value)
+    return _normalize_text(value)
+
+
+def _candidate(field: str, source_text: str) -> RecognitionCandidate:
+    value = _field_value(field, source_text)
+    return RecognitionCandidate(
+        field=field,
+        value=value,
+        confidence=_confidence(source_text),
+        evidence=_evidence(field, source_text),
+    )
+
+
+def _normalize_result(value: str) -> str:
+    normalized = _normalize_text(value).lower()
+    aliases = {
+        "w": "win",
+        "won": "win",
+        "victory": "win",
+        "l": "loss",
+        "lost": "loss",
+        "defeat": "loss",
+        "d": "draw",
+        "tie": "draw",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def _normalize_dp(value: str) -> str:
+    return re.sub(r"[^0-9]", "", value)
+
+
+def _normalize_text(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip())
+
+
+def _confidence(source_text: str) -> float:
+    match = re.search(r"^\s*confidence\s*[:=]\s*([0-9]+(?:\.[0-9]+)?)\s*$", source_text, re.IGNORECASE | re.MULTILINE)
+    if match is None:
+        return 0.95
+    try:
+        value = float(match.group(1))
+    except ValueError:
+        return 0.0
+    if value > 1.0:
+        value = value / 100.0
+    return max(0.0, min(1.0, value))
+
+
+def _evidence(field: str, source_text: str) -> str:
+    pattern = re.compile(rf"^\s*{re.escape(field)}\s*[:=]\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+    match = pattern.search(source_text)
+    if match is None:
+        return ""
+    evidence = _normalize_text(match.group(0))
+    if len(evidence) <= MAX_EVIDENCE_LENGTH:
+        return evidence
+    return evidence[: MAX_EVIDENCE_LENGTH - 3] + "..."
+
+
+def _normalize_candidate_value(field: str, value: str) -> str:
+    if field == "result":
+        return _normalize_result(value)
+    if field == "dp":
+        return _normalize_dp(value)
+    return _normalize_text(value)
+
+
+def _record_from_row(row: sqlite3.Row) -> RecognitionCandidateRecord:
+    return RecognitionCandidateRecord(
+        id=int(row["id"]),
+        match_id=row["match_id"],
+        provider=str(row["provider"]),
+        field=str(row["field"]),
+        value=str(row["value"]),
+        confidence=float(row["confidence"]),
+        evidence=str(row["evidence"]),
+        status=str(row["status"]),
+        corrected_value=str(row["corrected_value"]),
+        created_at=str(row["created_at"]),
+        updated_at=str(row["updated_at"]),
+    )
+
+
+def _utc_now_iso() -> str:
+    return _dt.datetime.now(tz=_dt.timezone.utc).isoformat().replace("+00:00", "Z")

--- a/app/worker/odr_worker/metadata.py
+++ b/app/worker/odr_worker/metadata.py
@@ -14,6 +14,8 @@ FIELD_LIMITS = {
     "deck_name": 120,
     "opponent_deck": 120,
     "result": 40,
+    "rank": 80,
+    "dp": 40,
     "memo": 4000,
     "started_at": 64,
     "ended_at": 64,
@@ -36,6 +38,8 @@ class MatchMetadataRecord:
     deck_name: str
     opponent_deck: str
     result: str
+    rank: str
+    dp: str
     memo: str
     started_at: str
     ended_at: str
@@ -49,6 +53,8 @@ class MatchMetadataRecord:
             "deck_name": self.deck_name,
             "opponent_deck": self.opponent_deck,
             "result": self.result,
+            "rank": self.rank,
+            "dp": self.dp,
             "memo": self.memo,
             "started_at": self.started_at,
             "ended_at": self.ended_at,
@@ -132,6 +138,8 @@ class MatchMetadataStore:
             "deck_name": record.deck_name or "Unknown Deck",
             "opponent_deck": record.opponent_deck or "Unknown Opponent",
             "result": record.result or "unknown",
+            "rank": record.rank or "unknown",
+            "dp": record.dp or "unknown",
             "started_at": record.started_at or record.created_at,
             "ended_at": record.ended_at or "unknown",
             "created_at": record.created_at,
@@ -189,6 +197,8 @@ def _record_from_row(row: sqlite3.Row) -> MatchMetadataRecord:
         deck_name=str(row["deck_name"]),
         opponent_deck=str(row["opponent_deck"]),
         result=str(row["result"]),
+        rank=str(row["rank"]),
+        dp=str(row["dp"]),
         memo=str(row["memo"]),
         started_at=str(row["started_at"]),
         ended_at=str(row["ended_at"]),
@@ -204,6 +214,8 @@ def _description(record: MatchMetadataRecord, values: dict[str, str]) -> str:
         f"Deck: {values['deck_name']}",
         f"Opponent: {values['opponent_deck']}",
         f"Result: {values['result']}",
+        f"Rank: {values['rank']}",
+        f"DP: {values['dp']}",
         f"Started: {values['started_at']}",
         f"Ended: {values['ended_at']}",
     ]

--- a/app/worker/odr_worker/migrations/0006_image_recognition_metadata.sql
+++ b/app/worker/odr_worker/migrations/0006_image_recognition_metadata.sql
@@ -1,0 +1,26 @@
+-- v2.0 migration 0006_image_recognition_metadata
+-- Purpose: add editable recognition-assisted metadata fields.
+
+ALTER TABLE matches ADD COLUMN rank TEXT NOT NULL DEFAULT '';
+ALTER TABLE matches ADD COLUMN dp TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_matches_rank ON matches(rank);
+CREATE INDEX IF NOT EXISTS idx_matches_dp ON matches(dp);
+
+CREATE TABLE IF NOT EXISTS recognition_candidates (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  match_id INTEGER,
+  provider TEXT NOT NULL,
+  field TEXT NOT NULL,
+  value TEXT NOT NULL,
+  confidence REAL NOT NULL,
+  evidence TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'candidate',
+  corrected_value TEXT NOT NULL DEFAULT '',
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  FOREIGN KEY(match_id) REFERENCES matches(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_recognition_candidates_match_id ON recognition_candidates(match_id);
+CREATE INDEX IF NOT EXISTS idx_recognition_candidates_status ON recognition_candidates(status);

--- a/app/worker/tests/test_db.py
+++ b/app/worker/tests/test_db.py
@@ -27,7 +27,14 @@ class SqliteFoundationTests(unittest.TestCase):
             self.assertGreaterEqual(db_info.schema_version, 5)
             self.assertEqual(
                 db_info.applied_migrations,
-                ("0001_init", "0002_tables", "0003_queue_recovery", "0004_screenshots", "0005_match_metadata"),
+                (
+                    "0001_init",
+                    "0002_tables",
+                    "0003_queue_recovery",
+                    "0004_screenshots",
+                    "0005_match_metadata",
+                    "0006_image_recognition_metadata",
+                ),
             )
 
             conn = sqlite3.connect(db_info.db_path)
@@ -39,6 +46,7 @@ class SqliteFoundationTests(unittest.TestCase):
                 self.assertIn("matches", tables)
                 self.assertIn("upload_queue", tables)
                 self.assertIn("screenshots", tables)
+                self.assertIn("recognition_candidates", tables)
 
                 conn.execute("INSERT INTO matches DEFAULT VALUES;")
                 match_id = conn.execute("SELECT id FROM matches ORDER BY id DESC LIMIT 1;").fetchone()[0]
@@ -57,12 +65,14 @@ class SqliteFoundationTests(unittest.TestCase):
                 self.assertEqual(row[2], "{}")
 
                 metadata = conn.execute(
-                    "SELECT opponent_deck, memo, title_template FROM matches WHERE id = ?;",
+                    "SELECT opponent_deck, memo, title_template, rank, dp FROM matches WHERE id = ?;",
                     (match_id,),
                 ).fetchone()
                 self.assertEqual(metadata[0], "")
                 self.assertEqual(metadata[1], "")
                 self.assertEqual(metadata[2], "")
+                self.assertEqual(metadata[3], "")
+                self.assertEqual(metadata[4], "")
             finally:
                 conn.close()
 

--- a/app/worker/tests/test_image_recognition.py
+++ b/app/worker/tests/test_image_recognition.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+WORKER_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(WORKER_ROOT))
+
+
+class ImageRecognitionApiTests(unittest.TestCase):
+    def _client(self):
+        from fastapi.testclient import TestClient
+
+        from odr_worker.api import create_app
+        from odr_worker.config import LoadedWorkerConfig, WorkerConfig
+        from odr_worker.db import init_db
+        from odr_worker.runtime_dirs import ensure_runtime_dirs
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        runtime_dirs = ensure_runtime_dirs(user_data_dir=Path(tmp.name))
+        db_info = init_db(runtime_dirs=runtime_dirs)
+        loaded_config = LoadedWorkerConfig(
+            config=WorkerConfig(),
+            config_path=runtime_dirs.config_dir / "worker.toml",
+            config_loaded=False,
+        )
+        client = TestClient(create_app(runtime_dirs=runtime_dirs, loaded_config=loaded_config, db_info=db_info))
+        self.addCleanup(client.close)
+        return client
+
+    def test_fixture_provider_returns_candidates_without_mutating_metadata(self) -> None:
+        client = self._client()
+        match_id = client.post("/matches", json={"result": "unknown"}).json()["id"]
+
+        analyzed = client.post(
+            "/recognition/analyze",
+            json={
+                "provider": "fixture",
+                "match_id": match_id,
+                "content_text": "result: Victory\nrank: Diamond I\ndp: 12,345\nconfidence: 0.92",
+            },
+        )
+
+        self.assertEqual(analyzed.status_code, 200)
+        body = analyzed.json()
+        self.assertEqual(body["status"], "candidates_available")
+        self.assertFalse(body["mutated"])
+        self.assertEqual(body["metadata_patch"], {"result": "win", "rank": "Diamond I", "dp": "12345"})
+        self.assertEqual(body["manual_correction"]["endpoint"], f"/matches/{match_id}/metadata")
+        self.assertEqual([item["field"] for item in body["candidate_records"]], ["result", "rank", "dp"])
+
+        unchanged = client.get(f"/matches/{match_id}")
+        self.assertEqual(unchanged.json()["result"], "unknown")
+        self.assertEqual(unchanged.json()["rank"], "")
+        self.assertEqual(unchanged.json()["dp"], "")
+
+    def test_manual_correction_can_persist_recognized_metadata(self) -> None:
+        client = self._client()
+        match_id = client.post("/matches", json={}).json()["id"]
+        patch = client.post(
+            "/recognition/analyze",
+            json={"match_id": match_id, "fixture": {"result": "loss", "rank": "Gold V", "dp": "8500"}},
+        ).json()["metadata_patch"]
+
+        corrected = client.put(f"/matches/{match_id}/metadata", json=patch)
+
+        self.assertEqual(corrected.status_code, 200)
+        self.assertEqual(corrected.json()["result"], "loss")
+        self.assertEqual(corrected.json()["rank"], "Gold V")
+        self.assertEqual(corrected.json()["dp"], "8500")
+
+    def test_candidate_confirm_correct_and_reject_are_auditable(self) -> None:
+        client = self._client()
+        match_id = client.post("/matches", json={}).json()["id"]
+        records = client.post(
+            "/recognition/analyze",
+            json={"match_id": match_id, "content_text": "result: win\nrank: Bronze III\ndp: 1000"},
+        ).json()["candidate_records"]
+
+        confirmed = client.post(f"/recognition/candidates/{records[0]['id']}/command", json={"action": "confirm"})
+        corrected = client.post(
+            f"/recognition/candidates/{records[1]['id']}/command",
+            json={"action": "correct", "value": "Silver I"},
+        )
+        rejected = client.post(f"/recognition/candidates/{records[2]['id']}/command", json={"action": "reject"})
+
+        self.assertEqual(confirmed.status_code, 200)
+        self.assertEqual(confirmed.json()["status"], "confirmed")
+        self.assertEqual(corrected.status_code, 200)
+        self.assertEqual(corrected.json()["status"], "corrected")
+        self.assertEqual(corrected.json()["corrected_value"], "Silver I")
+        self.assertEqual(rejected.status_code, 200)
+        self.assertEqual(rejected.json()["status"], "rejected")
+
+        match = client.get(f"/matches/{match_id}").json()
+        self.assertEqual(match["result"], "win")
+        self.assertEqual(match["rank"], "Silver I")
+        self.assertEqual(match["dp"], "")
+
+        listed = client.get("/recognition/candidates", params={"match_id": match_id})
+        self.assertEqual([item["status"] for item in listed.json()["items"]], ["confirmed", "corrected", "rejected"])
+
+    def test_low_confidence_requires_manual_review_and_no_patch(self) -> None:
+        client = self._client()
+
+        analyzed = client.post(
+            "/recognition/analyze",
+            json={"content_text": "result: win\nrank: Platinum\ndp: 4000\nconfidence: 0.50"},
+        )
+
+        self.assertEqual(analyzed.status_code, 200)
+        self.assertEqual(analyzed.json()["status"], "manual_review_required")
+        self.assertEqual(analyzed.json()["metadata_patch"], {})
+        self.assertEqual(analyzed.json()["diagnostics"][0]["code"], "low_confidence")
+        self.assertEqual(len(analyzed.json()["candidate_records"]), 3)
+
+    def test_invalid_provider_and_missing_match_are_diagnosable(self) -> None:
+        client = self._client()
+
+        unsupported = client.post("/recognition/analyze", json={"provider": "real_ocr", "content_text": "result: win"})
+        self.assertEqual(unsupported.status_code, 400)
+        self.assertEqual(unsupported.json()["code"], "recognition_provider_unsupported")
+
+        missing = client.post("/recognition/analyze", json={"match_id": 999, "content_text": "result: win"})
+        self.assertEqual(missing.status_code, 404)
+        self.assertEqual(missing.json()["code"], "match_not_found")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/worker/tests/test_metadata.py
+++ b/app/worker/tests/test_metadata.py
@@ -42,6 +42,8 @@ class MatchMetadataApiTests(unittest.TestCase):
                 "deck_name": "Labrynth",
                 "opponent_deck": "Branded",
                 "result": "win",
+                "rank": "Diamond I",
+                "dp": "12000",
                 "memo": "Game 2 went long.",
                 "started_at": "2026-05-23T05:00:00Z",
             },
@@ -50,6 +52,8 @@ class MatchMetadataApiTests(unittest.TestCase):
         self.assertEqual(created.status_code, 200)
         match_id = created.json()["id"]
         self.assertEqual(created.json()["opponent_deck"], "Branded")
+        self.assertEqual(created.json()["rank"], "Diamond I")
+        self.assertEqual(created.json()["dp"], "12000")
 
         edited = client.put(
             f"/matches/{match_id}/metadata",
@@ -96,6 +100,8 @@ class MatchMetadataApiTests(unittest.TestCase):
         self.assertEqual(metadata.status_code, 200)
         self.assertEqual(metadata.json()["title"], "Swordsoul vs Purrely [loss]")
         self.assertIn("Notes:", metadata.json()["description"])
+        self.assertIn("Rank: unknown", metadata.json()["description"])
+        self.assertIn("DP: unknown", metadata.json()["description"])
         self.assertIn("Misplayed turn three.", metadata.json()["description"])
         self.assertIn("opponent_deck", metadata.json()["variables"])
 

--- a/docs/architecture/image-recognition.md
+++ b/docs/architecture/image-recognition.md
@@ -19,6 +19,10 @@ The image recognition boundary may produce candidate metadata such as:
 
 The recognized candidates should integrate with existing match metadata APIs so users can correct or confirm the values.
 
+v2.0 exposes this through `POST /recognition/analyze`. The endpoint accepts fixture text or a fixture object and returns candidate `result`, `rank`, and `dp` values with confidence and evidence. It does not mutate metadata automatically. When a `match_id` is supplied, the response includes the `PUT /matches/{match_id}/metadata` correction endpoint and a `metadata_patch` body that the Plugin UI or user tooling can review before saving.
+
+Recognition candidates are persisted when SQLite is available. `GET /recognition/candidates` lists the audit records, and `POST /recognition/candidates/{candidate_id}/command` resolves them as confirmed, corrected, or rejected. Confirming or correcting a candidate is an explicit manual action and updates match metadata through the existing metadata boundary.
+
 ## Fallback
 
 When recognition fails, confidence is low, or fixture coverage does not support the input:

--- a/docs/architecture/worker-api.md
+++ b/docs/architecture/worker-api.md
@@ -503,3 +503,67 @@ Error behavior:
 The v1.4 update API is defined by:
 - `docs/architecture/update-system.md`
 - `docs/requirements/v1.4-update-system-acceptance.md`
+
+---
+
+## v2.0 Image Recognition Endpoints
+
+v2.0 adds recognition-assisted metadata extraction while preserving prior API compatibility.
+
+### `POST /recognition/analyze`
+
+Purpose:
+- Evaluate deterministic fixture input through the Worker-owned recognition provider boundary.
+- Return result, rank, and DP candidates with evidence and confidence.
+- Avoid mutating match metadata automatically.
+- Provide the manual correction endpoint and patch body when a `match_id` is supplied.
+
+Request fields:
+- `provider`: optional; `fixture` is the only v2.0 provider.
+- `match_id`: optional integer; validates that the target match exists.
+- `content_text`: UTF-8 fixture text containing lines such as `result: win`, `rank: Diamond I`, and `dp: 12000`, or
+- `fixture`: object containing optional `result`, `rank`, `dp`, and `confidence` values.
+
+Response fields:
+- `provider`: `fixture`.
+- `status`: `candidates_available` or `manual_review_required`.
+- `minimum_confidence`: required confidence for `metadata_patch`.
+- `candidates`: list of `{field, value, confidence, evidence}`.
+- `metadata_patch`: values safe to apply through `PUT /matches/{match_id}/metadata`.
+- `manual_correction`: correction method, endpoint, and body when `match_id` is provided.
+- `mutated`: always `false` for v2.0 analysis.
+- `candidate_records`: persisted audit records when SQLite is available.
+
+Error behavior:
+- Unsupported providers return HTTP 400 with `code=recognition_provider_unsupported`.
+- Invalid recognition payloads return HTTP 400 with `code=recognition_payload_invalid`.
+- Missing target matches return HTTP 404 with `code=match_not_found`.
+
+### `GET /recognition/candidates`
+
+Purpose:
+- List persisted recognition candidates for audit and manual review.
+
+Query:
+- `match_id`: optional integer filter.
+- `status`: optional filter: `candidate`, `confirmed`, `corrected`, or `rejected`.
+
+### `POST /recognition/candidates/{candidate_id}/command`
+
+Purpose:
+- Resolve a candidate through explicit manual action.
+- Preserve an audit trail while allowing confirmed or corrected values to update match metadata.
+
+Actions:
+- `confirm`: apply the candidate value to the linked match metadata.
+- `correct`: apply the provided `value` to the linked match metadata and store the corrected value.
+- `reject`: mark the candidate rejected without changing match metadata.
+
+Error behavior:
+- Invalid commands return HTTP 400 with `code=recognition_command_invalid`.
+- Missing candidates return HTTP 404 with `code=recognition_candidate_not_found`.
+- Already resolved candidates return HTTP 400 with `code=recognition_candidate_already_resolved`.
+
+The v2.0 image recognition API is defined by:
+- `docs/architecture/image-recognition.md`
+- `docs/requirements/v2.0-ocr-integration-acceptance.md`


### PR DESCRIPTION
## Summary
- add a v2.0 Worker image recognition provider boundary with deterministic fixture-backed analysis
- add rank/DP metadata fields and persisted recognition candidate audit records
- expose `/recognition/analyze`, `/recognition/candidates`, and candidate confirm/correct/reject commands
- document the v2.0 Worker API and image recognition fallback/audit flow

## Issue Coverage
- Addresses #348
- Addresses #349
- Addresses #350
- Provides validation evidence for #351
- Progresses #324

## Verification
- `python -m unittest app.worker.tests.test_image_recognition app.worker.tests.test_metadata app.worker.tests.test_db app.worker.tests.test_screenshots app.worker.tests.test_upload app.worker.tests.test_detection`
- `python -m unittest discover -s app\worker\tests`
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `git diff --check`