### PR TITLE
Record v2.0 tag target

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ obs-duel-recorder/
 - Version: `v2.0.0`
 - Scope: OCR Integration
 - Status: released
-- Tag target: to be finalized after release commit merge
+- Tag target: `ad16666fcc4d12a0c8adc0d4a71f123e2b346a0a`
 - Tracking issue: [#324](https://github.com/Tao-pyth/obs-duel-recorder/issues/324)
 - Release record: [docs/release-history.md](docs/release-history.md)
 

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -238,12 +238,12 @@ The version tracking issue may contain the working release summary, but finalize
 - Milestone: `v2.0` (not set)
 - Release readiness checklist: `docs/release/v2.0-release-readiness.md`
 - Tag: `v2.0.0`
-- Tag target: to be finalized after release commit merge
+- Tag target: `ad16666fcc4d12a0c8adc0d4a71f123e2b346a0a`
 - Release finalized at: `2026-05-23T14:19:47+09:00`
-- Tag finalized at: pending
+- Tag finalized at: `2026-05-23T14:27:00+09:00`
 - Release summary: `docs/release/v2.0-release-summary.md`
 - Major child issues: #348, #349, #350, #351
 - Major PRs: #375
 - Deferred items: Statistics System remains in #325 for v2.1; GitHub Pages Documentation remains in #326 for v2.2; Runtime Optimization remains in #327 for v2.3; packaging ZIP workflow remains v2.x follow-up under `docs/architecture/packaging.md`
 - Next version tracking issue: #325
-- Status: release finalization in progress
+- Status: released

--- a/docs/release/v2.0-release-readiness.md
+++ b/docs/release/v2.0-release-readiness.md
@@ -62,14 +62,14 @@ Non-goals:
 
 - [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, OAuth files, local templates, model files, or game assets.
 - [x] Release PR updates persistent release docs.
-- [ ] Release PR is merged into `main`.
-- [ ] The merge commit SHA on `main` is recorded for tagging.
+- [x] Release PR is merged into `main`.
+- [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## F. Tagging After Merge
 
-- [ ] Create tag `v2.0.0` pointing to the release merge commit SHA on `main`.
+- [x] Create tag `v2.0.0` pointing to the release merge commit SHA on `main`.
 - [x] Do not move or overwrite existing tags.
-- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #324 and release docs.
+- [x] Tag target SHA is recorded in #324 and release docs.
 
 ## G. Handoff
 

--- a/docs/release/v2.0-release-summary.md
+++ b/docs/release/v2.0-release-summary.md
@@ -1,13 +1,13 @@
 # v2.0.0 Release Summary - OCR Integration
 
-Status: **release finalization in progress**
+Status: **released**
 
 - Version tracking issue: #324
 - Release readiness checklist: `docs/release/v2.0-release-readiness.md`
 - Tag: `v2.0.0`
-- Tag target: to be finalized after release commit merge
+- Tag target: `ad16666fcc4d12a0c8adc0d4a71f123e2b346a0a`
 - Release finalized at: `2026-05-23T14:19:47+09:00`
-- Tag finalized at: pending
+- Tag finalized at: `2026-05-23T14:27:00+09:00`
 - Next version tracking issue: #325
 
 ## Completed Scope


### PR DESCRIPTION
## Summary
- record the pushed `v2.0.0` tag target SHA in README and release docs
- mark v2.0 release summary/history as released
- complete the v2.0 readiness tag-record checkboxes

## Verification
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `git diff --check`

Tag:
- `v2.0.0` -> `ad16666fcc4d12a0c8adc0d4a71f123e2b346a0a`