### PR TITLE
Add v2.1 statistics APIs

### DIFF
--- a/app/worker/odr_worker/api.py
+++ b/app/worker/odr_worker/api.py
@@ -27,6 +27,7 @@ from .recording import (
 from .runtime_dirs import RuntimeDirs
 from .screenshots import ScreenshotError, ScreenshotStore
 from .setup_wizard import SetupWizardError, SetupWizardStore
+from .statistics import StatisticsError, StatisticsStore, filters_from_query
 from .update_system import UpdateError, UpdateManager
 from .upload import UploadCommandError, UploadStore, build_upload_settings
 from .version import __version__
@@ -44,6 +45,39 @@ def _error_response(*, status_code: int, code: str, message: str, details: objec
         status_code=status_code,
         content=_error_payload(code=code, message=message, details=details),
     )
+
+
+def _statistics_group_response(
+    app: FastAPI,
+    group: str,
+    *,
+    from_date: str | None,
+    to_date: str | None,
+    deck: str | None,
+    opponent_deck: str | None,
+    result: str | None,
+    limit: int,
+):
+    if app.state.statistics_store is None:
+        return _error_response(status_code=503, code="statistics_unavailable", message="Statistics are unavailable")
+    try:
+        filters = filters_from_query(
+            from_date=from_date,
+            to_date=to_date,
+            deck=deck,
+            opponent_deck=opponent_deck,
+            result=result,
+        )
+        if group == "decks":
+            return app.state.statistics_store.decks(filters, limit=limit)
+        return app.state.statistics_store.opponents(filters, limit=limit)
+    except StatisticsError as exc:
+        return _error_response(
+            status_code=400,
+            code=exc.code,
+            message="Statistics request is invalid",
+            details=exc.details,
+        )
 
 
 def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, db_info: DbInfo | None = None) -> FastAPI:
@@ -87,6 +121,7 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
     app.state.upload_store = None
     app.state.metadata_store = None
     app.state.recognition_store = None
+    app.state.statistics_store = None
     app.state.export_store = None
     app.state.setup_store = SetupWizardStore(runtime_dirs=runtime_dirs)
     app.state.update_manager = UpdateManager(runtime_dirs=runtime_dirs)
@@ -104,6 +139,7 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
         )
         app.state.metadata_store = MatchMetadataStore(db_info.db_path)
         app.state.recognition_store = RecognitionCandidateStore(db_info.db_path)
+        app.state.statistics_store = StatisticsStore(db_info.db_path)
         app.state.upload_store = UploadStore(
             queue_store=app.state.queue_store,
             videos_dir=runtime_dirs.videos_dir,
@@ -626,6 +662,101 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
                 status_code=400,
                 code="recognition_command_invalid",
                 message="Recognition command must be JSON object",
+            )
+
+    @app.get("/statistics/summary")
+    def get_statistics_summary(
+        from_date: str | None = None,
+        to_date: str | None = None,
+        deck: str | None = None,
+        opponent_deck: str | None = None,
+        result: str | None = None,
+    ):
+        if app.state.statistics_store is None:
+            return _error_response(status_code=503, code="statistics_unavailable", message="Statistics are unavailable")
+        filters = filters_from_query(
+            from_date=from_date,
+            to_date=to_date,
+            deck=deck,
+            opponent_deck=opponent_deck,
+            result=result,
+        )
+        return app.state.statistics_store.summary(filters)
+
+    @app.get("/statistics/decks")
+    def get_statistics_decks(
+        from_date: str | None = None,
+        to_date: str | None = None,
+        deck: str | None = None,
+        opponent_deck: str | None = None,
+        result: str | None = None,
+        limit: int = 50,
+    ):
+        return _statistics_group_response(
+            app,
+            "decks",
+            from_date=from_date,
+            to_date=to_date,
+            deck=deck,
+            opponent_deck=opponent_deck,
+            result=result,
+            limit=limit,
+        )
+
+    @app.get("/statistics/opponents")
+    def get_statistics_opponents(
+        from_date: str | None = None,
+        to_date: str | None = None,
+        deck: str | None = None,
+        opponent_deck: str | None = None,
+        result: str | None = None,
+        limit: int = 50,
+    ):
+        return _statistics_group_response(
+            app,
+            "opponents",
+            from_date=from_date,
+            to_date=to_date,
+            deck=deck,
+            opponent_deck=opponent_deck,
+            result=result,
+            limit=limit,
+        )
+
+    @app.get("/statistics/uploads")
+    def get_statistics_uploads(from_date: str | None = None, to_date: str | None = None):
+        if app.state.statistics_store is None:
+            return _error_response(status_code=503, code="statistics_unavailable", message="Statistics are unavailable")
+        filters = filters_from_query(from_date=from_date, to_date=to_date)
+        return app.state.statistics_store.uploads(filters)
+
+    @app.get("/statistics/memos")
+    def get_statistics_memos(
+        query: str,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        deck: str | None = None,
+        opponent_deck: str | None = None,
+        result: str | None = None,
+        limit: int = 50,
+    ):
+        if app.state.statistics_store is None:
+            return _error_response(status_code=503, code="statistics_unavailable", message="Statistics are unavailable")
+        try:
+            filters = filters_from_query(
+                from_date=from_date,
+                to_date=to_date,
+                deck=deck,
+                opponent_deck=opponent_deck,
+                result=result,
+            )
+            return app.state.statistics_store.memos(filters, query=query, limit=limit)
+        except StatisticsError as exc:
+            return _error_response(
+                status_code=400,
+                code=exc.code,
+                message="Statistics request is invalid",
+                details=exc.details,
             )
 
     @app.get("/screenshots")

--- a/app/worker/odr_worker/db.py
+++ b/app/worker/odr_worker/db.py
@@ -27,6 +27,7 @@ _MIGRATIONS: tuple[str, ...] = (
     "0004_screenshots",
     "0005_match_metadata",
     "0006_image_recognition_metadata",
+    "0007_statistics_indexes",
 )
 
 

--- a/app/worker/odr_worker/migrations/0007_statistics_indexes.sql
+++ b/app/worker/odr_worker/migrations/0007_statistics_indexes.sql
@@ -1,0 +1,6 @@
+-- v2.1 migration 0007_statistics_indexes
+-- Purpose: add read-side indexes for statistics queries.
+
+CREATE INDEX IF NOT EXISTS idx_matches_deck_name ON matches(deck_name);
+CREATE INDEX IF NOT EXISTS idx_matches_result_started_at ON matches(result, started_at);
+CREATE INDEX IF NOT EXISTS idx_upload_queue_match_id_state ON upload_queue(match_id, state);

--- a/app/worker/odr_worker/statistics.py
+++ b/app/worker/odr_worker/statistics.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .queue import QUEUE_STATES
+
+
+KNOWN_RESULTS = ("win", "loss", "draw")
+MAX_LIMIT = 200
+DEFAULT_LIMIT = 50
+
+
+class StatisticsError(ValueError):
+    def __init__(self, code: str, details: dict[str, object]):
+        super().__init__(code)
+        self.code = code
+        self.details = details
+
+
+@dataclass(frozen=True)
+class StatisticsFilters:
+    from_date: str = ""
+    to_date: str = ""
+    deck: str = ""
+    opponent_deck: str = ""
+    result: str = ""
+
+    def as_payload(self) -> dict[str, str]:
+        return {
+            "from_date": self.from_date,
+            "to_date": self.to_date,
+            "deck": self.deck,
+            "opponent_deck": self.opponent_deck,
+            "result": self.result,
+        }
+
+
+class StatisticsStore:
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON;")
+        return conn
+
+    def summary(self, filters: StatisticsFilters) -> dict[str, object]:
+        rows = self._match_rows(filters)
+        counts = _result_counts(rows)
+        known_count = sum(counts[result] for result in KNOWN_RESULTS)
+        win_rate = 0.0 if known_count == 0 else counts["win"] / known_count
+        return {
+            "filters": filters.as_payload(),
+            "total_matches": len(rows),
+            "known_result_count": known_count,
+            "unknown_result_count": counts["unknown"],
+            "result_counts": counts,
+            "win_rate": round(win_rate, 4),
+        }
+
+    def decks(self, filters: StatisticsFilters, *, limit: int = DEFAULT_LIMIT) -> dict[str, object]:
+        return {
+            "filters": filters.as_payload(),
+            "items": _group_match_rows(self._match_rows(filters), "deck_name", limit=_limit(limit)),
+        }
+
+    def opponents(self, filters: StatisticsFilters, *, limit: int = DEFAULT_LIMIT) -> dict[str, object]:
+        return {
+            "filters": filters.as_payload(),
+            "items": _group_match_rows(self._match_rows(filters), "opponent_deck", limit=_limit(limit)),
+        }
+
+    def uploads(self, filters: StatisticsFilters) -> dict[str, object]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if filters.from_date:
+            clauses.append("created_at >= ?")
+            params.append(filters.from_date)
+        if filters.to_date:
+            clauses.append("created_at <= ?")
+            params.append(filters.to_date)
+        where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                f"SELECT state, COUNT(*) AS count FROM upload_queue{where} GROUP BY state ORDER BY state;",
+                params,
+            ).fetchall()
+        finally:
+            conn.close()
+        counts = {state: 0 for state in sorted(QUEUE_STATES)}
+        for row in rows:
+            state = str(row["state"])
+            counts[state] = int(row["count"])
+        return {
+            "filters": {"from_date": filters.from_date, "to_date": filters.to_date},
+            "total_items": sum(counts.values()),
+            "state_counts": counts,
+        }
+
+    def memos(self, filters: StatisticsFilters, *, query: str, limit: int = DEFAULT_LIMIT) -> dict[str, object]:
+        query = query.strip()
+        if not query:
+            raise StatisticsError("statistics_query_invalid", {"query": "non_empty_required"})
+        items: list[dict[str, object]] = []
+        query_key = query.casefold()
+        for row in self._match_rows(filters):
+            memo = str(row["memo"])
+            if query_key not in memo.casefold():
+                continue
+            items.append(
+                {
+                    "match_id": int(row["id"]),
+                    "created_at": str(row["created_at"]),
+                    "started_at": str(row["started_at"]),
+                    "deck_name": _display_value(row["deck_name"]),
+                    "opponent_deck": _display_value(row["opponent_deck"]),
+                    "result": _normalize_result(row["result"]),
+                    "memo_excerpt": _excerpt(memo, query),
+                }
+            )
+            if len(items) >= _limit(limit):
+                break
+        return {"filters": filters.as_payload(), "query": query, "items": items}
+
+    def _match_rows(self, filters: StatisticsFilters) -> list[sqlite3.Row]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if filters.from_date:
+            clauses.append("COALESCE(NULLIF(started_at, ''), created_at) >= ?")
+            params.append(filters.from_date)
+        if filters.to_date:
+            clauses.append("COALESCE(NULLIF(started_at, ''), created_at) <= ?")
+            params.append(filters.to_date)
+        if filters.deck:
+            clauses.append("LOWER(TRIM(deck_name)) = ?")
+            params.append(_key(filters.deck))
+        if filters.opponent_deck:
+            clauses.append("LOWER(TRIM(opponent_deck)) = ?")
+            params.append(_key(filters.opponent_deck))
+        if filters.result:
+            clauses.append("LOWER(TRIM(result)) = ?")
+            params.append(_normalize_result(filters.result))
+        where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+        conn = self._connect()
+        try:
+            return conn.execute(f"SELECT * FROM matches{where} ORDER BY id;", params).fetchall()
+        finally:
+            conn.close()
+
+
+def filters_from_query(
+    *,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    deck: str | None = None,
+    opponent_deck: str | None = None,
+    result: str | None = None,
+) -> StatisticsFilters:
+    return StatisticsFilters(
+        from_date=(from_date or "").strip(),
+        to_date=(to_date or "").strip(),
+        deck=(deck or "").strip(),
+        opponent_deck=(opponent_deck or "").strip(),
+        result=(result or "").strip(),
+    )
+
+
+def _result_counts(rows: list[sqlite3.Row]) -> dict[str, int]:
+    counts = {"win": 0, "loss": 0, "draw": 0, "unknown": 0}
+    for row in rows:
+        counts[_normalize_result(row["result"])] += 1
+    return counts
+
+
+def _group_match_rows(rows: list[sqlite3.Row], field: str, *, limit: int) -> list[dict[str, object]]:
+    grouped: dict[str, dict[str, Any]] = {}
+    labels: dict[str, str] = {}
+    for row in rows:
+        raw = str(row[field])
+        key = _key(raw) or "unknown"
+        labels.setdefault(key, _display_value(raw))
+        item = grouped.setdefault(
+            key,
+            {
+                "name": labels[key],
+                "total_matches": 0,
+                "result_counts": {"win": 0, "loss": 0, "draw": 0, "unknown": 0},
+                "win_rate": 0.0,
+            },
+        )
+        item["total_matches"] += 1
+        item["result_counts"][_normalize_result(row["result"])] += 1
+
+    items = list(grouped.values())
+    for item in items:
+        result_counts = item["result_counts"]
+        known_count = sum(result_counts[result] for result in KNOWN_RESULTS)
+        item["known_result_count"] = known_count
+        item["win_rate"] = 0.0 if known_count == 0 else round(result_counts["win"] / known_count, 4)
+    items.sort(key=lambda item: (-int(item["total_matches"]), str(item["name"]).casefold()))
+    return items[:limit]
+
+
+def _normalize_result(value: object) -> str:
+    normalized = str(value or "").strip().casefold()
+    return normalized if normalized in KNOWN_RESULTS else "unknown"
+
+
+def _display_value(value: object) -> str:
+    normalized = " ".join(str(value or "").strip().split())
+    return normalized or "unknown"
+
+
+def _key(value: object) -> str:
+    return " ".join(str(value or "").strip().casefold().split())
+
+
+def _limit(value: int) -> int:
+    if value < 1:
+        raise StatisticsError("statistics_limit_invalid", {"limit": "must_be_positive"})
+    return min(value, MAX_LIMIT)
+
+
+def _excerpt(memo: str, query: str) -> str:
+    index = memo.casefold().find(query.casefold())
+    if index < 0:
+        return memo[:120]
+    start = max(0, index - 40)
+    end = min(len(memo), index + len(query) + 40)
+    prefix = "..." if start > 0 else ""
+    suffix = "..." if end < len(memo) else ""
+    return prefix + memo[start:end] + suffix

--- a/app/worker/tests/test_db.py
+++ b/app/worker/tests/test_db.py
@@ -34,6 +34,7 @@ class SqliteFoundationTests(unittest.TestCase):
                     "0004_screenshots",
                     "0005_match_metadata",
                     "0006_image_recognition_metadata",
+                    "0007_statistics_indexes",
                 ),
             )
 

--- a/app/worker/tests/test_statistics.py
+++ b/app/worker/tests/test_statistics.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+WORKER_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(WORKER_ROOT))
+
+
+class StatisticsApiTests(unittest.TestCase):
+    def _client(self):
+        from fastapi.testclient import TestClient
+
+        from odr_worker.api import create_app
+        from odr_worker.config import LoadedWorkerConfig, WorkerConfig
+        from odr_worker.db import init_db
+        from odr_worker.runtime_dirs import ensure_runtime_dirs
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        runtime_dirs = ensure_runtime_dirs(user_data_dir=Path(tmp.name))
+        db_info = init_db(runtime_dirs=runtime_dirs)
+        loaded_config = LoadedWorkerConfig(
+            config=WorkerConfig(),
+            config_path=runtime_dirs.config_dir / "worker.toml",
+            config_loaded=False,
+        )
+        client = TestClient(create_app(runtime_dirs=runtime_dirs, loaded_config=loaded_config, db_info=db_info))
+        self.addCleanup(client.close)
+        return client, runtime_dirs
+
+    def test_empty_statistics_are_stable_zero_counts(self) -> None:
+        client, _ = self._client()
+
+        summary = client.get("/statistics/summary")
+        decks = client.get("/statistics/decks")
+        opponents = client.get("/statistics/opponents")
+        uploads = client.get("/statistics/uploads")
+
+        self.assertEqual(summary.status_code, 200)
+        self.assertEqual(summary.json()["total_matches"], 0)
+        self.assertEqual(summary.json()["win_rate"], 0.0)
+        self.assertEqual(decks.json()["items"], [])
+        self.assertEqual(opponents.json()["items"], [])
+        self.assertEqual(sum(uploads.json()["state_counts"].values()), 0)
+
+    def test_summary_deck_opponent_and_filters_are_deterministic(self) -> None:
+        client, _ = self._client()
+        self._create_match(client, deck_name="Labrynth", opponent_deck="Branded", result="win", memo="Long game")
+        self._create_match(client, deck_name="Labrynth", opponent_deck="Branded", result="loss")
+        self._create_match(client, deck_name="Swordsoul", opponent_deck="Purrely", result="draw")
+        self._create_match(client, deck_name="", opponent_deck="", result="")
+
+        summary = client.get("/statistics/summary")
+        self.assertEqual(summary.status_code, 200)
+        self.assertEqual(summary.json()["result_counts"], {"win": 1, "loss": 1, "draw": 1, "unknown": 1})
+        self.assertEqual(summary.json()["known_result_count"], 3)
+        self.assertEqual(summary.json()["win_rate"], 0.3333)
+
+        decks = client.get("/statistics/decks")
+        self.assertEqual(decks.status_code, 200)
+        self.assertEqual(decks.json()["items"][0]["name"], "Labrynth")
+        self.assertEqual(decks.json()["items"][0]["total_matches"], 2)
+
+        opponents = client.get("/statistics/opponents", params={"result": "win"})
+        self.assertEqual(opponents.status_code, 200)
+        self.assertEqual(opponents.json()["items"][0]["name"], "Branded")
+        self.assertEqual(opponents.json()["items"][0]["result_counts"]["win"], 1)
+
+    def test_memo_search_is_case_insensitive_and_does_not_mutate(self) -> None:
+        client, _ = self._client()
+        match_id = self._create_match(
+            client,
+            deck_name="Vanquish Soul",
+            opponent_deck="Tearlaments",
+            result="win",
+            memo="Played around Nibiru in game two.",
+        )["id"]
+
+        found = client.get("/statistics/memos", params={"query": "nibiru"})
+
+        self.assertEqual(found.status_code, 200)
+        self.assertEqual(found.json()["items"][0]["match_id"], match_id)
+        self.assertIn("Nibiru", found.json()["items"][0]["memo_excerpt"])
+        self.assertEqual(client.get(f"/matches/{match_id}").json()["memo"], "Played around Nibiru in game two.")
+
+    def test_upload_statistics_count_states_without_paths(self) -> None:
+        client, runtime_dirs = self._client()
+        match = self._create_match(client, result="win")
+        client.post("/queue/items", json={"match_id": match["id"], "video_path": "duel.mp4"}).json()
+        uploaded = client.post("/queue/items", json={"match_id": match["id"], "video_path": "duel2.mp4"}).json()
+        failed = client.post(
+            "/queue/items",
+            json={"match_id": match["id"], "video_path": "duel3.mp4", "max_retries": 0},
+        ).json()
+
+        (runtime_dirs.videos_dir / "duel2.mp4").write_bytes(b"video")
+        client.post(f"/queue/items/{uploaded['id']}/command", json={"action": "start_upload"})
+        client.post(f"/queue/items/{uploaded['id']}/command", json={"action": "mark_uploaded", "youtube_video_id": "abc"})
+        client.post(f"/queue/items/{failed['id']}/command", json={"action": "start_upload"})
+        client.post(f"/queue/items/{failed['id']}/command", json={"action": "mark_upload_failed", "error_code": "network"})
+
+        uploads = client.get("/statistics/uploads")
+
+        self.assertEqual(uploads.status_code, 200)
+        self.assertEqual(uploads.json()["state_counts"]["ready_upload"], 1)
+        self.assertEqual(uploads.json()["state_counts"]["uploaded"], 1)
+        self.assertEqual(uploads.json()["state_counts"]["need_manual_review"], 1)
+        self.assertNotIn("duel", str(uploads.json()))
+
+    def test_invalid_statistics_requests_are_diagnosable(self) -> None:
+        client, _ = self._client()
+
+        bad_limit = client.get("/statistics/decks", params={"limit": 0})
+        bad_query = client.get("/statistics/memos", params={"query": " "})
+
+        self.assertEqual(bad_limit.status_code, 400)
+        self.assertEqual(bad_limit.json()["code"], "statistics_limit_invalid")
+        self.assertEqual(bad_query.status_code, 400)
+        self.assertEqual(bad_query.json()["code"], "statistics_query_invalid")
+
+    def _create_match(self, client, **payload):
+        response = client.post("/matches", json=payload)
+        self.assertEqual(response.status_code, 200)
+        return response.json()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/architecture/statistics.md
+++ b/docs/architecture/statistics.md
@@ -25,6 +25,32 @@ The statistics boundary should support deterministic summaries such as:
 - memo search summaries
 - upload state statistics
 
+## Worker API
+
+v2.1 exposes statistics through read-only Worker endpoints:
+
+- `GET /statistics/summary`
+- `GET /statistics/decks`
+- `GET /statistics/opponents`
+- `GET /statistics/uploads`
+- `GET /statistics/memos?query=...`
+
+Supported match filters:
+
+- `from_date`
+- `to_date`
+- `deck`
+- `opponent_deck`
+- `result`
+
+`/statistics/uploads` supports `from_date` and `to_date` over upload queue creation time.
+
+Result values are normalized to `win`, `loss`, `draw`, or `unknown`. Win rate is computed as `win / (win + loss + draw)` and returns `0.0` when no known results exist.
+
+Deck and opponent names are grouped by trimmed case-insensitive keys. Empty names are grouped as `unknown`.
+
+Memo search is case-insensitive partial matching over the memo field only. It returns excerpts and never mutates match records.
+
 ## Safety
 
 - Empty datasets must return stable zero-count responses.

--- a/docs/architecture/worker-api.md
+++ b/docs/architecture/worker-api.md
@@ -567,3 +567,67 @@ Error behavior:
 The v2.0 image recognition API is defined by:
 - `docs/architecture/image-recognition.md`
 - `docs/requirements/v2.0-ocr-integration-acceptance.md`
+
+---
+
+## v2.1 Statistics Endpoints
+
+v2.1 adds read-only Worker-owned statistics derived from SQLite runtime data.
+
+### `GET /statistics/summary`
+
+Purpose:
+- Return total match count, known/unknown result counts, result counts, and win rate.
+
+Query:
+- `from_date`: optional lower bound using `started_at` when present, otherwise `created_at`.
+- `to_date`: optional upper bound using `started_at` when present, otherwise `created_at`.
+- `deck`: optional exact normalized local deck filter.
+- `opponent_deck`: optional exact normalized opponent deck filter.
+- `result`: optional result filter.
+
+### `GET /statistics/decks`
+
+Purpose:
+- Aggregate match counts, result counts, known result counts, and win rate by local deck name.
+
+Query:
+- Same filters as `/statistics/summary`.
+- `limit`: optional positive integer, capped by the Worker.
+
+### `GET /statistics/opponents`
+
+Purpose:
+- Aggregate match counts, result counts, known result counts, and win rate by opponent deck name.
+
+Query:
+- Same filters as `/statistics/summary`.
+- `limit`: optional positive integer, capped by the Worker.
+
+### `GET /statistics/uploads`
+
+Purpose:
+- Return upload queue counts by state without exposing video paths, OAuth paths, or local media contents.
+
+Query:
+- `from_date`: optional lower bound over upload queue `created_at`.
+- `to_date`: optional upper bound over upload queue `created_at`.
+
+### `GET /statistics/memos`
+
+Purpose:
+- Search match memos with case-insensitive partial matching.
+- Return match metadata and memo excerpts without mutating match records.
+
+Query:
+- `query`: required non-empty search text.
+- Same filters as `/statistics/summary`.
+- `limit`: optional positive integer, capped by the Worker.
+
+Error behavior:
+- Invalid limits return HTTP 400 with `code=statistics_limit_invalid`.
+- Empty memo queries return HTTP 400 with `code=statistics_query_invalid`.
+
+The v2.1 statistics API is defined by:
+- `docs/architecture/statistics.md`
+- `docs/requirements/v2.1-statistics-system-acceptance.md`

--- a/docs/user/ja/usage.md
+++ b/docs/user/ja/usage.md
@@ -35,6 +35,20 @@ Dock UI から次の操作ができる想定です。
 - [キュー / 履歴](queue.md)
 - [トラブルシューティング](troubleshooting.md)
 
+## Statistics
+
+v2.1 では Worker の読み取り専用統計 API を追加します。
+
+- `/statistics/summary`
+- `/statistics/decks`
+- `/statistics/opponents`
+- `/statistics/uploads`
+- `/statistics/memos?query=...`
+
+統計はローカル SQLite の match metadata と upload queue state から計算されます。match record は書き換えず、OAuth secrets や local media path は返しません。
+
+Result は `win` / `loss` / `draw` / `unknown` に分類します。Win rate は known results のみを分母にします。Memo search は local case-insensitive partial search です。
+
 ## TODO
 
 - TODO: 具体的な画面/操作フロー（将来のUI確定後）


### PR DESCRIPTION
## Summary
- add Worker-owned read-only statistics endpoints for summary, deck, opponent, upload, and memo search data
- compute statistics from existing SQLite `matches` and `upload_queue` data without derived tables
- add statistics query indexes, docs, and user-facing usage notes
- cover empty, mixed, filtered, memo, upload, and invalid request cases

## Issue Coverage
- Addresses #352
- Addresses #353
- Addresses #354
- Provides validation evidence for #355
- Progresses #325

## Verification
- `python -m unittest app.worker.tests.test_statistics app.worker.tests.test_db app.worker.tests.test_metadata app.worker.tests.test_upload`
- `python -m unittest discover -s app\worker\tests`
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `git diff --check`