### PR TITLE
Record v2.1 tag target

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ obs-duel-recorder/
 - Version: `v2.1.0`
 - Scope: Statistics System
 - Status: released
-- Tag target: to be finalized after release commit merge
+- Tag target: `c7ba88b3e4524ac472ebab9f336afbfcdcf3330e`
 - Tracking issue: [#325](https://github.com/Tao-pyth/obs-duel-recorder/issues/325)
 - Release record: [docs/release-history.md](docs/release-history.md)
 

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -254,12 +254,12 @@ The version tracking issue may contain the working release summary, but finalize
 - Milestone: `v2.1` (not set)
 - Release readiness checklist: `docs/release/v2.1-release-readiness.md`
 - Tag: `v2.1.0`
-- Tag target: to be finalized after release commit merge
+- Tag target: `c7ba88b3e4524ac472ebab9f336afbfcdcf3330e`
 - Release finalized at: `2026-05-23T14:42:54+09:00`
-- Tag finalized at: pending
+- Tag finalized at: `2026-05-23T14:51:00+09:00`
 - Release summary: `docs/release/v2.1-release-summary.md`
 - Major child issues: #352, #353, #354, #355
 - Major PRs: #378
 - Deferred items: GitHub Pages Documentation remains in #326 for v2.2; Runtime Optimization remains in #327 for v2.3; packaging ZIP workflow remains v2.x follow-up under `docs/architecture/packaging.md`
 - Next version tracking issue: #326
-- Status: release finalization in progress
+- Status: released

--- a/docs/release/v2.1-release-readiness.md
+++ b/docs/release/v2.1-release-readiness.md
@@ -49,14 +49,14 @@ Non-goals:
 
 - [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
 - [x] Release PR updates persistent release docs.
-- [ ] Release PR is merged into `main`.
-- [ ] The merge commit SHA on `main` is recorded for tagging.
+- [x] Release PR is merged into `main`.
+- [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## E. Tagging After Merge
 
-- [ ] Create tag `v2.1.0` pointing to the release merge commit SHA on `main`.
+- [x] Create tag `v2.1.0` pointing to the release merge commit SHA on `main`.
 - [x] Do not move or overwrite existing tags.
-- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #325 and release docs.
+- [x] Tag target SHA is recorded in #325 and release docs.
 
 ## F. Handoff
 

--- a/docs/release/v2.1-release-summary.md
+++ b/docs/release/v2.1-release-summary.md
@@ -1,13 +1,13 @@
 # v2.1.0 Release Summary - Statistics System
 
-Status: **release finalization in progress**
+Status: **released**
 
 - Version tracking issue: #325
 - Release readiness checklist: `docs/release/v2.1-release-readiness.md`
 - Tag: `v2.1.0`
-- Tag target: to be finalized after release commit merge
+- Tag target: `c7ba88b3e4524ac472ebab9f336afbfcdcf3330e`
 - Release finalized at: `2026-05-23T14:42:54+09:00`
-- Tag finalized at: pending
+- Tag finalized at: `2026-05-23T14:51:00+09:00`
 - Next version tracking issue: #326
 
 ## Completed Scope


### PR DESCRIPTION
## Summary
- record the pushed `v2.1.0` tag target SHA in README and release docs
- mark v2.1 release summary/history as released
- complete the v2.1 readiness tag-record checkboxes

## Verification
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `git diff --check`

Tag:
- `v2.1.0` -> `c7ba88b3e4524ac472ebab9f336afbfcdcf3330e`