### PR TITLE
Add v2.2 documentation publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
         shell: powershell
         run: python scripts/validate_jp_user_docs_coverage.py --root .
 
+      - name: Build documentation site artifact
+        run: python scripts/build_docs_site.py --root . --output build/docs-site
+
       - name: Validate v0.4 plugin smoke collector
         shell: powershell
         run: |

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -25,3 +25,6 @@ jobs:
       - name: Validate Japanese user docs coverage
         shell: powershell
         run: python scripts/validate_jp_user_docs_coverage.py --root .
+
+      - name: Build documentation site artifact
+        run: python scripts/build_docs_site.py --root . --output build/docs-site

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,61 @@
+name: GitHub Pages documentation
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "README.md"
+      - "docs/**"
+      - "scripts/build_docs_site.py"
+      - ".github/workflows/pages.yml"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build documentation site
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Validate Markdown links
+        shell: powershell
+        run: powershell -ExecutionPolicy Bypass -File docs/tools/validate_markdown_links.ps1
+
+      - name: Validate Japanese user docs coverage
+        shell: powershell
+        run: python scripts/validate_jp_user_docs_coverage.py --root .
+
+      - name: Build Pages artifact
+        run: python scripts/build_docs_site.py --root . --output build/docs-site
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/docs-site
+
+  deploy:
+    name: Deploy documentation site
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [Traceability](traceability.md)
 - [Release and tag policy](release.md)
 - [Release history](release-history.md)
+- [GitHub Pages publication](pages.md)
 - [Version tracking issue template](release/version-tracking-issue-template.md)
 - [v0.2 release readiness checklist](release/v0.2-release-readiness.md)
 - [v0.3 release readiness checklist](release/v0.3-release-readiness.md)
@@ -99,11 +100,13 @@ Quick validation commands (run from the repository root):
 ```powershell
 powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs/tools/validate_markdown_links.ps1
 python scripts/validate_jp_user_docs_coverage.py --root .
+python scripts/build_docs_site.py --root . --output build/docs-site
 ```
 
 Notes:
 - Markdown links: checks `README*.md` and `docs/**/*.md`.
 - JP user docs coverage: checks English ↔ Japanese topic coverage.
+- Pages artifact: builds generated documentation under `build/docs-site/`.
 
 ## Documentation Rules
 

--- a/docs/architecture/packaging.md
+++ b/docs/architecture/packaging.md
@@ -40,3 +40,9 @@ Release ZIPs must not include:
 - GitHub Actions may build and upload draft artifacts automatically.
 - Release publication or attaching final assets should require maintainer approval unless a later policy explicitly enables full automation.
 - A SHA256 checksum must be generated for each release ZIP.
+
+## Relationship To GitHub Pages
+
+GitHub Pages is documentation publication only and is defined by `docs/pages.md`.
+
+The Pages artifact must not include plugin DLLs, Worker packages, release ZIP files, checksums, runtime data, credentials, screenshots, videos, logs, DBs, local template images, or game assets.

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -1,0 +1,62 @@
+# GitHub Pages Publication
+
+This document defines the v2.2 documentation publication contract.
+
+## Source And Generated Paths
+
+- Source documentation lives under `docs/`.
+- User-facing documentation source lives under `docs/user/`.
+- Generated GitHub Pages artifacts are written to `build/docs-site/`.
+- The generated artifact is not a release ZIP and must not be used as an application package.
+
+## Publication Flow
+
+1. Run Markdown link validation.
+2. Run Japanese user docs coverage validation.
+3. Build the static documentation artifact:
+
+   ```powershell
+   python scripts/build_docs_site.py --root . --output build/docs-site
+   ```
+
+4. Upload `build/docs-site/` as the GitHub Pages artifact.
+5. Deploy through GitHub Pages after the validation and artifact steps pass.
+
+The GitHub Actions workflow is `.github/workflows/pages.yml`.
+
+## Published Entry Point
+
+The generated artifact entry point is:
+
+```text
+build/docs-site/index.html
+```
+
+Markdown sources are also copied into the artifact for traceability, but published navigation should use the generated `.html` files.
+
+The expected public URL is:
+
+```text
+https://tao-pyth.github.io/obs-duel-recorder/
+```
+
+If repository Pages settings use a different owner or project URL, record the actual URL in the release notes.
+
+## Publication Exclusions
+
+The Pages artifact must not include:
+
+- `user_data/`
+- logs
+- SQLite databases
+- screenshots
+- videos
+- OAuth tokens or client secrets
+- local template images or game assets
+- generated runtime exports
+
+## Relationship To Release ZIPs
+
+GitHub Pages publishes documentation only.
+
+Release ZIP contents remain governed by `docs/architecture/packaging.md`. Release ZIPs may include a minimal documentation subset, but Pages must not include plugin DLLs, Worker runtime packages, update bundles, runtime data, secrets, or generated media.

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -20,3 +20,9 @@ These pages remain the current source of truth until `docs/user/en/**` is introd
 - English documents are the canonical source of truth for user docs and design docs.
 - Japanese documents under `docs/user/ja/` are translated/expanded from the English source and must not contradict it.
 - Japanese pages may split a single English page into multiple guides (e.g. setup), but the **major sections** should remain traceable.
+
+## Published documentation
+
+GitHub Pages publication is defined by [`docs/pages.md`](../pages.md).
+
+The Pages artifact is generated from repository documentation into `build/docs-site/`. It is documentation-only and does not include release ZIP assets, runtime data, credentials, screenshots, videos, logs, DBs, local template images, or game assets.

--- a/docs/user/ja/faq.md
+++ b/docs/user/ja/faq.md
@@ -1,45 +1,63 @@
 # FAQ
 
-← [日本語ユーザードキュメント](index.md)
+-> [日本語ユーザードキュメント](index.md)
 
-このページは、よくある質問を集約します（必要に応じて追記します）。
-
-ステータス注記: このページには、未リリースの手順や UI 名称が含まれる可能性があります。利用可否は [ロードマップ](../../roadmap.md) で確認してください。
+このページは、OBS Duel Recorder の利用時によくある質問をまとめます。
 
 ## 基本
 
-### Q. このプロジェクトは公式ですか？
+### Q. このプロジェクトは公式ツールですか？
 
-A. いいえ。非公式のファンメイドツールです。
+A. いいえ。OBS Duel Recorder は非公式のファンメイドツールです。KONAMI とは無関係です。
 
-## 資産（ゲーム素材）について
+### Q. ゲーム画像やカード画像は同梱されていますか？
 
-- 本ソフトウェアは Yu-Gi-Oh! Master Duel の画像/音声などの素材を配布しません。
-- TODO: ユーザーがローカルで用意する必要があるもの（将来の仕様確定後）
+A. いいえ。Yu-Gi-Oh! Master Duel の画像、音声、動画、テンプレート画像、学習データは配布しません。検出用テンプレートやサンプルは利用者がローカルで用意します。
 
-### Q. ゲームのアセットは同梱されていますか？
+### Q. どの環境を想定していますか？
 
-A. いいえ。本プロジェクトは Yu-Gi-Oh! Master Duel のアセットを配布しません。
+A. Windows x64 と OBS Studio x64 を前提にしています。Worker はローカルホストで動作し、OBS Plugin は Worker API を通じて状態確認や操作を行います。
 
-## OBS について
+## セットアップ
 
-- TODO: 対応 OBS バージョン
-- TODO: セットアップ手順の入口
+### Q. 最初に何を確認すればよいですか？
 
-## YouTube について
+A. [インストール](install.md)、[初回セットアップ](first-setup.md)、[OBS セットアップ](obs-setup.md)、[YouTube セットアップ](youtube-setup.md) の順に確認してください。Worker の状態は `/setup/status` と `/setup/validate` で確認できます。
 
-- TODO: ログイン/OAuth
-- TODO: アップロード設定
+### Q. `user_data/` は何のためにありますか？
 
-## アップデートについて
+A. 設定、SQLite DB、動画、スクリーンショット、エクスポート、ログを保存するローカル実行データ領域です。更新時にも保持される前提なので、削除や上書きは慎重に行ってください。
 
-- TODO: `user_data/` のバックアップが必要な理由
-- TODO: 更新手順の入口
+### Q. 更新前にバックアップは必要ですか？
 
-## キュー / 履歴について
+A. v1.4 以降は update API が DB backup-before-migration を行います。ただし重要な録画や設定がある場合は、更新前に `user_data/` 全体を別の場所へコピーしておくと復旧しやすくなります。
 
-- TODO: キューに残る/失敗する場合のよくある原因
+## YouTube
 
-## TODO
+### Q. YouTube にアップロードできない場合は何を確認しますか？
 
-- TODO: 実装が進んだら質問項目を具体化する
+A. `/upload/status` で OAuth client secret と token の有無、queue state、manual action を確認してください。認証不足は `need_manual_review`、quota は `quota_waiting`、通信失敗は `upload_failed` として扱われます。
+
+### Q. Google 認証情報はリポジトリに入れますか？
+
+A. 入れません。OAuth token、client secret、authorization code、bearer token は `user_data/config/secrets/` などのローカル領域で扱い、GitHub Pages、release ZIP、issue、PR には含めません。
+
+## キュー
+
+### Q. キューに項目が残るのはなぜですか？
+
+A. アップロード待ち、通信失敗、quota 待ち、認証不足、手動確認待ちなどの状態があるためです。`/queue/items` と `/upload/status` で状態を確認し、必要に応じて retry、discard、mark_uploaded を使います。
+
+### Q. 失敗が続く場合はどうしますか？
+
+A. 連続 retry の前に `last_error_code`、`manual_review_reason`、YouTube quota、OAuth token、動画ファイルの存在を確認してください。曖昧な失敗は二重アップロード防止のため手動確認に降格します。
+
+## 認識と統計
+
+### Q. v2.0 の OCR Integration は実OCRですか？
+
+A. v2.0 は画像認識先行です。Worker は deterministic fixture provider から result、rank、DP の候補を返し、確定・修正・却下を監査レコードとして保存します。重いOCR/ML依存は必須ではありません。
+
+### Q. 統計はどこから計算されますか？
+
+A. v2.1 の統計は SQLite の match metadata と upload queue state から読み取り専用で計算します。履歴レコードを統計のために書き換えることはありません。

--- a/docs/user/ja/queue.md
+++ b/docs/user/ja/queue.md
@@ -1,31 +1,31 @@
 # キュー / 履歴
 
-← [日本語ユーザードキュメント](index.md)
+-> [日本語ユーザードキュメント](index.md)
 
-このページは、録画後のアップロード待ち項目（キュー）と履歴の考え方をまとめます。
+アップロードキューは Worker が所有します。OBS Plugin は SQLite を直接編集せず、Worker API を通じて状態を確認します。
 
-ステータス注記: このページには、未リリースの手順や UI 名称が含まれる可能性があります。利用可否は [ロードマップ](../../roadmap.md) で確認してください。
+## 主な状態
 
-## キューとは
+- `ready_upload`: アップロード待ちです。
+- `uploading`: アップロード処理中です。
+- `uploaded`: YouTube video id または URL が記録済みです。
+- `upload_failed`: 通信失敗などで retry 可能です。
+- `quota_waiting`: YouTube quota 待ちです。
+- `need_manual_review`: 認証不足、曖昧な失敗、retry 上限などで手動確認が必要です。
+- `discarded`: 処理対象から外れています。
 
-- 録画が完了した動画が、アップロード対象として並ぶ想定です。
-- アップロード結果に応じて状態が変わります。
+## 状態確認
 
-## 代表的な状態（例）
+```powershell
+Invoke-WebRequest http://127.0.0.1:8787/queue/items | Select-Object -ExpandProperty Content
+Invoke-WebRequest http://127.0.0.1:8787/upload/status | Select-Object -ExpandProperty Content
+```
 
-- `ready_upload`: アップロード待ち
-- `uploading`: アップロード中
-- `uploaded`: アップロード完了
-- `upload_failed`: 失敗（リトライ可能）
-- `quota_waiting`: クォータ待ち
-- `need_manual_review`: 手動確認が必要
+## retry 前に確認すること
 
-## リトライ
+- ローカル動画ファイルが存在するか。
+- OAuth token と client secret が配置されているか。
+- YouTube quota 待ちではないか。
+- `last_error_code` と `manual_review_reason` に二重アップロードの可能性がないか。
 
-- TODO: リトライ前に確認するポイント
-- TODO: 連続リトライを避ける指針（必要なら）
-
-## 関連ページ
-
-- [使い方](usage.md)
-- [トラブルシューティング](troubleshooting.md)
+曖昧な失敗では、二重アップロード防止を優先して `need_manual_review` に降格します。

--- a/docs/user/ja/troubleshooting.md
+++ b/docs/user/ja/troubleshooting.md
@@ -1,42 +1,73 @@
 # トラブルシューティング
 
-← [日本語ユーザードキュメント](index.md)
+-> [日本語ユーザードキュメント](index.md)
 
-このページは、よくある症状と切り分けの入口をまとめます。
+このページは、よくある問題の切り分け入口です。秘密情報、OAuth token、client secret、動画、スクリーンショット、DB を issue や PR に貼らないでください。
 
-ステータス注記: このページには、未リリースの手順や UI 名称が含まれる可能性があります。利用可否は [ロードマップ](../../roadmap.md) で確認してください。
+## Worker が起動しない
 
-## 起動しない / 動作しない
+1. OBS Duel Recorder Dock の状態を確認します。
+2. `user_data_dir` が正しいか確認します。
+3. Worker の `/health` を確認します。
 
-- OBS を再起動します。
-- Worker を再起動します。
-- ログ（`user_data/logs/`）を確認します。
-- TODO: 設定ファイルの場所/確認手順（仕様確定後）
+```powershell
+Invoke-WebRequest http://127.0.0.1:8787/health | Select-Object -ExpandProperty Content
+```
 
-## OBS の問題
+`config_error` の場合は設定パスを見直します。`api_incompatible` の場合は Plugin と Worker のバージョンが一致しているか確認します。
 
-- Dock UI が表示されない
-  - まずはプラグイン導入手順を見直してください: [OBS セットアップ](obs-setup.md)
-- TODO: 録画が開始/停止しない（実装確定後に切り分け手順を追記）
+## Plugin Dock が表示されない
 
-## YouTube の問題
+1. OBS Studio x64 を使用しているか確認します。
+2. Plugin DLL が OBS の plugin path に配置されているか確認します。
+3. OBS のログで `OBS Duel Recorder plugin startup` を探します。
+4. 依存 DLL や Qt/OBS SDK の配置漏れがないか確認します。
 
-- YouTube にログインできない / アップロードできない
-  - OAuth 設定を見直してください: [YouTube セットアップ](youtube-setup.md)
-- TODO: エラー別の対処（クォータ等）
+## 録画が開始または停止しない
 
-## キューの問題
+1. `/recording/state` を確認します。
+2. Dock の手動 Start/Stop が失敗する場合は、Worker state と OBS recording state がずれていないか確認します。
+3. 自動録画の場合は `/detection/state` と `/detection/templates` を確認します。
 
-- キューが進まない
-  - 状態を確認してください: [キュー / 履歴](queue.md)
-- TODO: 失敗が続くときの確認ポイント（実装確定後）
+認識候補 API は録画トリガではありません。録画開始/停止の判定は detection/template matching 側を確認してください。
 
-## ログの場所
+## YouTube アップロードに失敗する
 
-- ログは通常 `user_data/logs/` に保存されます。
-- TODO: 代表的なログファイル名/確認方法
+1. `/upload/status` を確認します。
+2. `client_secret_configured` と `token_configured` が `true` か確認します。
+3. `/queue/items` で対象 item の state、retry_count、last_error_code、manual_review_reason を確認します。
 
-## TODO
+主な状態:
 
-- TODO: エラー別の対処フローを追加する
-- TODO: FAQ への誘導を整理する
+- `upload_failed`: 通信失敗など。原因確認後に retry できます。
+- `quota_waiting`: YouTube quota 待ちです。次回試行時刻を確認します。
+- `need_manual_review`: 認証不足、曖昧な失敗、retry 上限などです。二重アップロードを避けるため手動確認してください。
+- `discarded`: ローカル動画欠損などで処理対象から外れています。
+
+## キューが進まない
+
+1. `/queue/items` で state を確認します。
+2. `ready_upload` がない場合、処理対象はありません。
+3. `uploading` が残っている場合、Worker 再起動時に安全側へ復旧されます。
+4. 失敗が続く場合は動画ファイル、OAuth、quota、network を確認します。
+
+## 更新に失敗する
+
+1. `update.bat status` を実行します。
+2. `partial_update_detected` が true の場合、`docs/user/ja/update.md` の復旧手順を確認します。
+3. DB migration 失敗時は backup directory を確認します。
+
+更新処理は `user_data/` の設定、DB、動画、スクリーンショット、エクスポート、ログを削除しない設計です。
+
+## 認識候補が間違っている
+
+1. `/recognition/candidates` で候補を確認します。
+2. 正しい候補は confirm、誤りは correct または reject します。
+3. 低信頼候補は自動で match metadata を上書きしません。
+
+## 統計が期待と違う
+
+1. `/statistics/summary` で result count を確認します。
+2. 空欄や未知の result は `unknown` に分類されます。
+3. Win rate は `win / (win + loss + draw)` で計算され、unknown は分母に入りません。
+4. deck/opponent の集計は trim と case-insensitive key に基づきます。

--- a/docs/user/ja/usage.md
+++ b/docs/user/ja/usage.md
@@ -1,43 +1,43 @@
 # 使い方
 
-← [日本語ユーザードキュメント](index.md)
+-> [日本語ユーザードキュメント](index.md)
 
-このページは、録画からアップロードまでの基本的な使い方をまとめます。
-
-ステータス注記: このページには、未リリースの手順や UI 名称が含まれる可能性があります。利用可否は [ロードマップ](../../roadmap.md) で確認してください。
+このページは録画、キュー、メタデータ、認識候補、統計の基本的な利用方法をまとめます。
 
 ## 自動録画
 
-システムは自動的に次の処理を行う想定です。
+自動録画は detection/template matching の結果に基づきます。認識候補 API は録画トリガではありません。
 
-- デュエル開始を検知
-- 録画開始
-- デュエル終了を検知
-- アップロードキューを作成
+基本フロー:
 
-## 手動操作（概要）
+1. duel start を検出します。
+2. Worker recording state が `starting` になります。
+3. OBS Plugin が OBS 録画開始を要求します。
+4. duel end を検出します。
+5. Worker が upload queue item を作成します。
 
-Dock UI から次の操作ができる想定です。
+## 手動操作
 
-- 手動開始
-- 手動停止
-- リトライ
-- キュー復旧
+OBS Dock から手動 Start/Stop を使えます。失敗時は `/recording/state` と Dock の diagnostic state を確認してください。
 
-## 対戦メモ
+## Match metadata
 
-- 相手デッキの入力
-- メモの追加
-- メタデータ付きでアップロード
+match metadata には deck name、opponent deck、result、rank、DP、memo、title template を保存できます。YouTube upload metadata はこの情報から生成されます。
 
-## 関連ページ
+## 認識候補
 
-- [キュー / 履歴](queue.md)
-- [トラブルシューティング](troubleshooting.md)
+v2.0 以降、Worker は result、rank、DP の認識候補を返せます。候補は自動で match metadata を上書きしません。
 
-## Statistics
+主な操作:
 
-v2.1 では Worker の読み取り専用統計 API を追加します。
+- 候補確認: `/recognition/candidates`
+- 確定: `confirm`
+- 修正: `correct`
+- 却下: `reject`
+
+## 統計
+
+v2.1 以降、Worker は読み取り専用の統計 API を提供します。
 
 - `/statistics/summary`
 - `/statistics/decks`
@@ -48,7 +48,3 @@ v2.1 では Worker の読み取り専用統計 API を追加します。
 統計はローカル SQLite の match metadata と upload queue state から計算されます。match record は書き換えず、OAuth secrets や local media path は返しません。
 
 Result は `win` / `loss` / `draw` / `unknown` に分類します。Win rate は known results のみを分母にします。Memo search は local case-insensitive partial search です。
-
-## TODO
-
-- TODO: 具体的な画面/操作フロー（将来のUI確定後）

--- a/docs/user/ja/youtube-setup.md
+++ b/docs/user/ja/youtube-setup.md
@@ -1,52 +1,50 @@
 # YouTube セットアップ
 
-- [ユーザードキュメント（日本語）に戻る](index.md)
+-> [日本語ユーザードキュメント](index.md)
 
-このページは、YouTube へアップロードするための OAuth セットアップと、安全な運用のための注意点をまとめた「骨子（スケルトン）」です。
+YouTube upload は Worker が管理します。OAuth 情報はローカルの `user_data/` 配下に保存し、リポジトリ、GitHub Pages、release ZIP には含めません。
 
-ステータス注記: このページには、未リリースの手順や UI 名称が含まれる可能性があります。利用可否は [ロードマップ](../../roadmap.md) で確認してください。
+## 必要なファイル
 
-## 事前準備
-
-- Google アカウント
-- アップロード先の YouTube チャンネル
-- PC にインストール済みの OBS Studio
-
-## OAuth セットアップ（概要）
-
-1. アプリ（OBS Plugin / Worker）から Google OAuth でログインします。
-2. 必要な同意画面を確認し、許可します。
-3. OAuth トークンをローカルに保存します。
-
-注: 詳細な手順（Google Cloud 側の設定、同意画面、クライアントIDの作成など）は、実装とドキュメントが揃い次第このページに追記します。
-
-## アップロード設定
-
-- 公開範囲（公開 / 限定公開 / 非公開）
-- タイトル・説明・タグなどのテンプレート
-- デフォルトの動画カテゴリ
-
-注: 設定項目の具体名・保存先は v1.0（YouTube Upload MVP）の設計・実装に合わせて確定します。
-
-## Secrets / Token の安全性（重要）
-
-- OAuth トークンやクライアントシークレット等の機密情報は **git にコミットしない** でください。
-- 機密情報はローカルに保存し、共有・転載・貼り付けを避けてください。
-- リポジトリ規約として、以下のパスは常に git 管理対象外にします（`AGENTS.md` 参照）。
+既定の配置先:
 
 ```text
-config/secrets/
 user_data/config/secrets/
 ```
 
-## TODO
+必要なファイル:
 
-- [ ] Google Cloud 側の OAuth 同意画面 / 認証情報の作成手順を追記
-- [ ] Worker/Plugin からの OAuth 実行フロー（どの画面/操作で開始するか）を追記
-- [ ] トークン保存場所・バックアップ/移行方針を追記
-- [ ] よくある失敗（同意画面の設定ミス、認証情報の種類、権限不足など）を追記
+- `youtube-client-secret.json`
+- `youtube-token.json`
 
-## 次にやること
+## 状態確認
 
-- [初回セットアップ](first-setup.md)
-- [使い方](usage.md)
+```powershell
+Invoke-WebRequest http://127.0.0.1:8787/upload/status | Select-Object -ExpandProperty Content
+```
+
+確認する項目:
+
+- `client_secret_configured`
+- `token_configured`
+- `queue_counts`
+- `manual_actions`
+
+## 失敗時の分類
+
+- quota: `quota_waiting`
+- auth: `need_manual_review`
+- network: `upload_failed`
+- ambiguous: `need_manual_review`
+
+曖昧な失敗では、アップロード済みか判断できない可能性があります。二重アップロード防止のため、手動確認してから retry、discard、mark_uploaded を選択してください。
+
+## 秘密情報の扱い
+
+以下は issue、PR、ログ添付、GitHub Pages、release ZIP に含めないでください。
+
+- OAuth token
+- client secret
+- authorization code
+- bearer token
+- YouTube API response の秘密情報

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -76,7 +76,7 @@ Validate, at a minimum:
 
 - Japanese pages exist for the user-facing topics described by the English user docs.
 - Major sections remain traceable (Japanese may split an English page into multiple guides, but should cover the same core topics).
-- "TODO-only" pages are allowed early, but they should still contain the intended section structure and a link back to the Japanese index.
+- TODO-only pages are not acceptable for released user-facing documentation. Placeholder pages may exist only before the relevant version is released, and they must still contain the intended section structure and a link back to the Japanese index.
 
 ### Automated check (Python)
 
@@ -99,6 +99,9 @@ This check:
 
 Scheduled documentation validation runs from `.github/workflows/docs-validation.yml`.
 It runs weekly and can also be started manually with `workflow_dispatch`.
+
+GitHub Pages publication validation runs from `.github/workflows/pages.yml`.
+It validates Markdown links, validates Japanese user docs coverage, builds `build/docs-site/`, uploads the Pages artifact, and deploys only after those steps pass.
 
 This section defines the recommended **reporting behavior** for scheduled documentation validation runs.
 
@@ -132,4 +135,5 @@ This repository already defines the local commands; a scheduled workflow can run
 ```powershell
 powershell -ExecutionPolicy Bypass -File docs/tools/validate_markdown_links.ps1
 python scripts/validate_jp_user_docs_coverage.py
+python scripts/build_docs_site.py --root . --output build/docs-site
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,13 @@ Allowed responsibilities:
 - local validation helpers
 - future update-flow helpers
 
+Current helpers:
+- `validate_markdown_links.py`
+- `validate_jp_user_docs_coverage.py`
+- `build_docs_site.py`
+
+`build_docs_site.py` creates the GitHub Pages artifact under `build/docs-site/` without copying runtime data, secrets, screenshots, videos, databases, local template images, or game assets.
+
 Scripts must not store:
 - runtime data
 - secrets

--- a/scripts/build_docs_site.py
+++ b/scripts/build_docs_site.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import argparse
+import html
+import re
+import shutil
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = Path("build/docs-site")
+SOURCE_DIRS = (Path("docs/user"),)
+SOURCE_FILES = (
+    Path("README.md"),
+    Path("docs/README.md"),
+    Path("docs/roadmap.md"),
+    Path("docs/release-history.md"),
+    Path("docs/pages.md"),
+)
+EXCLUDED_NAMES = {
+    ".git",
+    "__pycache__",
+    "user_data",
+    "logs",
+    "db",
+    "videos",
+    "screenshots",
+    "exports",
+    "secrets",
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build the GitHub Pages documentation artifact.")
+    parser.add_argument("--root", type=Path, default=Path("."), help="Repository root.")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT, help="Generated site output directory.")
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    output = (root / args.output).resolve()
+    _ensure_inside(root, output)
+    if output.exists():
+        shutil.rmtree(output)
+    output.mkdir(parents=True)
+
+    for source_dir in SOURCE_DIRS:
+        _copy_tree(root / source_dir, output / source_dir)
+    for source_file in SOURCE_FILES:
+        target = output / source_file
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(root / source_file, target)
+
+    (output / ".nojekyll").write_text("", encoding="utf-8")
+    (output / "index.md").write_text(
+        "# OBS Duel Recorder Documentation\n\n"
+        "- [User Documentation](docs/user/index.md)\n"
+        "- [Japanese User Documentation](docs/user/ja/index.md)\n"
+        "- [Roadmap](docs/roadmap.md)\n"
+        "- [Release History](docs/release-history.md)\n"
+        "- [Publication Contract](docs/pages.md)\n",
+        encoding="utf-8",
+    )
+    _render_markdown_site(output)
+    _write_manifest(output)
+    return 0
+
+
+def _copy_tree(source: Path, target: Path) -> None:
+    if not source.exists():
+        raise FileNotFoundError(source)
+    for path in source.rglob("*"):
+        if any(part in EXCLUDED_NAMES for part in path.parts):
+            continue
+        relative = path.relative_to(source)
+        destination = target / relative
+        if path.is_dir():
+            destination.mkdir(parents=True, exist_ok=True)
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, destination)
+
+
+def _write_manifest(output: Path) -> None:
+    files = sorted(
+        path.relative_to(output).as_posix()
+        for path in output.rglob("*")
+        if path.is_file() and path.name != "publication-manifest.txt"
+    )
+    (output / "publication-manifest.txt").write_text(
+        "OBS Duel Recorder GitHub Pages artifact\n\n" + "\n".join(files) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _render_markdown_site(output: Path) -> None:
+    for markdown_path in output.rglob("*.md"):
+        html_path = markdown_path.with_suffix(".html")
+        title = _page_title(markdown_path)
+        html_path.write_text(
+            _html_document(title, _markdown_to_html(markdown_path.read_text(encoding="utf-8"))),
+            encoding="utf-8",
+        )
+
+
+def _page_title(markdown_path: Path) -> str:
+    for line in markdown_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("# "):
+            return line.removeprefix("# ").strip()
+    return markdown_path.stem
+
+
+def _html_document(title: str, body: str) -> str:
+    escaped_title = html.escape(title)
+    return (
+        "<!doctype html>\n"
+        "<html lang=\"ja\">\n"
+        "<head>\n"
+        "  <meta charset=\"utf-8\">\n"
+        "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+        f"  <title>{escaped_title}</title>\n"
+        "  <style>\n"
+        "    body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;line-height:1.65;"
+        "max-width:960px;margin:0 auto;padding:2rem;color:#24292f;background:#fff;}\n"
+        "    a{color:#0969da;} pre{overflow:auto;background:#f6f8fa;padding:1rem;border-radius:6px;}\n"
+        "    code{background:#f6f8fa;padding:.12rem .25rem;border-radius:4px;} pre code{padding:0;}\n"
+        "    table{border-collapse:collapse;} th,td{border:1px solid #d0d7de;padding:.35rem .55rem;}\n"
+        "  </style>\n"
+        "</head>\n"
+        f"<body>\n{body}\n</body>\n"
+        "</html>\n"
+    )
+
+
+def _markdown_to_html(markdown: str) -> str:
+    lines = markdown.splitlines()
+    output: list[str] = []
+    list_open = False
+    code_open = False
+    paragraph: list[str] = []
+
+    def flush_paragraph() -> None:
+        nonlocal paragraph
+        if paragraph:
+            output.append(f"<p>{_inline_markdown(' '.join(paragraph))}</p>")
+            paragraph = []
+
+    def close_list() -> None:
+        nonlocal list_open
+        if list_open:
+            output.append("</ul>")
+            list_open = False
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            flush_paragraph()
+            close_list()
+            if code_open:
+                output.append("</code></pre>")
+                code_open = False
+            else:
+                output.append("<pre><code>")
+                code_open = True
+            continue
+        if code_open:
+            output.append(html.escape(line))
+            continue
+        if not stripped:
+            flush_paragraph()
+            close_list()
+            continue
+        heading = re.match(r"^(#{1,6})\s+(.+)$", stripped)
+        if heading:
+            flush_paragraph()
+            close_list()
+            level = len(heading.group(1))
+            output.append(f"<h{level}>{_inline_markdown(heading.group(2))}</h{level}>")
+            continue
+        bullet = re.match(r"^[-*]\s+(.+)$", stripped)
+        if bullet:
+            flush_paragraph()
+            if not list_open:
+                output.append("<ul>")
+                list_open = True
+            output.append(f"<li>{_inline_markdown(bullet.group(1))}</li>")
+            continue
+        paragraph.append(stripped)
+
+    flush_paragraph()
+    close_list()
+    if code_open:
+        output.append("</code></pre>")
+    return "\n".join(output)
+
+
+def _inline_markdown(text: str) -> str:
+    escaped = html.escape(text)
+    escaped = re.sub(
+        r"\[([^\]]+)\]\(([^)]+\.md)(#[^)]+)?\)",
+        lambda match: _html_link(match.group(1), match.group(2), match.group(3)),
+        escaped,
+    )
+    escaped = re.sub(
+        r"\[([^\]]+)\]\(([^)]+)\)",
+        lambda match: f'<a href="{html.escape(match.group(2), quote=True)}">{match.group(1)}</a>',
+        escaped,
+    )
+    return re.sub(r"`([^`]+)`", r"<code>\1</code>", escaped)
+
+
+def _html_link(label: str, target: str, anchor: str | None) -> str:
+    href = target[:-3] + ".html"
+    if anchor:
+        href += anchor
+    return f'<a href="{html.escape(href, quote=True)}">{label}</a>'
+
+
+def _ensure_inside(root: Path, target: Path) -> None:
+    if target == root or root not in target.parents:
+        raise ValueError(f"Output must be inside repository root: {target}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a GitHub Pages documentation workflow and publication contract.
- Generate a static documentation artifact with HTML entry points and traceable Markdown sources.
- Fill Japanese user-facing FAQ, usage, queue, troubleshooting, and YouTube setup documentation.

## Issue Coverage
- Addresses #356 by defining and validating the Pages publication contract.
- Addresses #357 by completing user setup, troubleshooting, and FAQ docs.
- Addresses #358 by documenting user docs navigation, language coverage, and publication behavior.
- Provides validation evidence toward #359 and progresses parent #326.

## Verification
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `python scripts\build_docs_site.py --root . --output build\docs-site`
- `git diff --check`