### PR TITLE
Record v2.2 tag target

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ obs-duel-recorder/
 - Version: `v2.2.0`
 - Scope: GitHub Pages Documentation
 - Status: released
-- Tag target: pending tag-record PR
+- Tag target: `ab8b18ae63c854addfaaca1c40922118360d2907`
 - Tracking issue: [#326](https://github.com/Tao-pyth/obs-duel-recorder/issues/326)
 - Release record: [docs/release-history.md](docs/release-history.md)
 

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -270,12 +270,12 @@ The version tracking issue may contain the working release summary, but finalize
 - Milestone: `v2.2` (not set)
 - Release readiness checklist: `docs/release/v2.2-release-readiness.md`
 - Tag: `v2.2.0`
-- Tag target: pending tag-record PR
+- Tag target: `ab8b18ae63c854addfaaca1c40922118360d2907`
 - Release finalized at: `2026-05-23T15:20:28+09:00`
-- Tag finalized at: pending tag-record PR
+- Tag finalized at: `2026-05-23T15:30:14+09:00`
 - Release summary: `docs/release/v2.2-release-summary.md`
 - Major child issues: #356, #357, #358, #359
 - Major PRs: #381
 - Deferred items: Runtime Optimization remains in #327 for v2.3; packaging ZIP workflow remains v2.x follow-up under `docs/architecture/packaging.md`
 - Next version tracking issue: #327
-- Status: release finalization pending tag record
+- Status: released

--- a/docs/release/v2.2-release-readiness.md
+++ b/docs/release/v2.2-release-readiness.md
@@ -52,14 +52,14 @@ Non-goals:
 
 - [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
 - [x] Release PR updates persistent release docs.
-- [ ] Release PR is merged into `main`.
-- [ ] The merge commit SHA on `main` is recorded for tagging.
+- [x] Release PR is merged into `main`.
+- [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## E. Tagging After Merge
 
-- [ ] Create tag `v2.2.0` pointing to the release merge commit SHA on `main`.
-- [ ] Do not move or overwrite existing tags.
-- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #326 and release docs.
+- [x] Create tag `v2.2.0` pointing to the release merge commit SHA on `main`.
+- [x] Do not move or overwrite existing tags.
+- [x] Tag target SHA is recorded in #326 and release docs.
 
 ## F. Handoff
 

--- a/docs/release/v2.2-release-summary.md
+++ b/docs/release/v2.2-release-summary.md
@@ -1,13 +1,13 @@
 # v2.2.0 Release Summary - GitHub Pages Documentation
 
-Status: **release finalization pending tag record**
+Status: **released**
 
 - Version tracking issue: #326
 - Release readiness checklist: `docs/release/v2.2-release-readiness.md`
 - Tag: `v2.2.0`
-- Tag target: pending tag-record PR
+- Tag target: `ab8b18ae63c854addfaaca1c40922118360d2907`
 - Release finalized at: `2026-05-23T15:20:28+09:00`
-- Tag finalized at: pending tag-record PR
+- Tag finalized at: `2026-05-23T15:30:14+09:00`
 - Next version tracking issue: #327
 
 ## Completed Scope


### PR DESCRIPTION
## Summary
- Record the pushed `v2.2.0` tag target SHA in README, release history, readiness, and summary docs.
- Mark v2.2 release readiness tagging items complete.

## Issue Coverage
- Completes release-point evidence for #326.

## Verification
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `python scripts\build_docs_site.py --root . --output build\docs-site`
- `git diff --check`