### PR TITLE
Add v2.3 runtime optimizations

### DIFF
--- a/app/worker/odr_worker/db.py
+++ b/app/worker/odr_worker/db.py
@@ -28,6 +28,7 @@ _MIGRATIONS: tuple[str, ...] = (
     "0005_match_metadata",
     "0006_image_recognition_metadata",
     "0007_statistics_indexes",
+    "0008_runtime_optimization_indexes",
 )
 
 

--- a/app/worker/odr_worker/migrations/0008_runtime_optimization_indexes.sql
+++ b/app/worker/odr_worker/migrations/0008_runtime_optimization_indexes.sql
@@ -1,0 +1,5 @@
+-- v2.3 migration 0008_runtime_optimization_indexes
+-- Purpose: support queue/upload polling and recovery without full queue scans.
+
+CREATE INDEX IF NOT EXISTS idx_upload_queue_state_id ON upload_queue(state, id);
+CREATE INDEX IF NOT EXISTS idx_upload_queue_state_updated_at ON upload_queue(state, updated_at);

--- a/app/worker/odr_worker/queue.py
+++ b/app/worker/odr_worker/queue.py
@@ -124,6 +124,7 @@ class QueueStore:
         conn = sqlite3.connect(self.db_path)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA foreign_keys = ON;")
+        conn.execute("PRAGMA busy_timeout = 5000;")
         return conn
 
     def create_item(self, payload: dict[str, Any]) -> QueueItem:
@@ -163,6 +164,31 @@ class QueueStore:
             else:
                 rows = conn.execute("SELECT * FROM upload_queue ORDER BY id;").fetchall()
             return [_item_from_row(row) for row in rows]
+        finally:
+            conn.close()
+
+    def count_by_state(self) -> dict[str, int]:
+        counts = {state: 0 for state in sorted(QUEUE_STATES)}
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT state, COUNT(*) AS count FROM upload_queue GROUP BY state ORDER BY state;"
+            ).fetchall()
+            for row in rows:
+                state = str(row["state"])
+                if state in counts:
+                    counts[state] = int(row["count"])
+            return counts
+        finally:
+            conn.close()
+
+    def next_ready_item(self) -> QueueItem | None:
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT * FROM upload_queue WHERE state = 'ready_upload' ORDER BY id LIMIT 1;"
+            ).fetchone()
+            return _item_from_row(row) if row is not None else None
         finally:
             conn.close()
 
@@ -234,10 +260,12 @@ class QueueStore:
             conn.close()
 
     def recover_startup(self) -> dict[str, object]:
+        started_at = _dt.datetime.now(tz=_dt.timezone.utc)
         recovered: list[dict[str, object]] = []
         conn = self._connect()
         try:
             rows = conn.execute("SELECT * FROM upload_queue WHERE state = 'uploading' ORDER BY id;").fetchall()
+            scanned_count = len(rows)
             for row in rows:
                 item = _item_from_row(row)
                 now = _utc_now_iso()
@@ -276,7 +304,13 @@ class QueueStore:
             conn.commit()
         finally:
             conn.close()
-        return {"recovered": recovered}
+        elapsed = _dt.datetime.now(tz=_dt.timezone.utc) - started_at
+        return {
+            "recovered": recovered,
+            "scanned_count": scanned_count,
+            "recovered_count": len(recovered),
+            "duration_ms": round(elapsed.total_seconds() * 1000, 3),
+        }
 
     def _failed_state(self, item: QueueItem, payload: dict[str, Any], now: str) -> tuple[str, dict[str, object]]:
         retry_count = item.retry_count + 1

--- a/app/worker/odr_worker/upload.py
+++ b/app/worker/odr_worker/upload.py
@@ -113,9 +113,7 @@ class UploadStore:
         self.uploader = MockYouTubeUploader()
 
     def status(self) -> dict[str, object]:
-        counts = {state: 0 for state in sorted(QUEUE_STATES)}
-        for item in self.queue_store.list_items():
-            counts[item.state] = counts.get(item.state, 0) + 1
+        counts = self.queue_store.count_by_state()
         return {
             "settings": self.settings.as_payload(),
             "queue_counts": counts,
@@ -168,8 +166,7 @@ class UploadStore:
         return self.metadata_store.render_upload_metadata(item.match_id)
 
     def _next_ready_item(self) -> QueueItem | None:
-        items = self.queue_store.list_items(state="ready_upload")
-        return items[0] if items else None
+        return self.queue_store.next_ready_item()
 
     def _video_exists(self, video_path: str) -> bool:
         if not video_path:

--- a/app/worker/tests/test_db.py
+++ b/app/worker/tests/test_db.py
@@ -35,6 +35,7 @@ class SqliteFoundationTests(unittest.TestCase):
                     "0005_match_metadata",
                     "0006_image_recognition_metadata",
                     "0007_statistics_indexes",
+                    "0008_runtime_optimization_indexes",
                 ),
             )
 
@@ -48,6 +49,12 @@ class SqliteFoundationTests(unittest.TestCase):
                 self.assertIn("upload_queue", tables)
                 self.assertIn("screenshots", tables)
                 self.assertIn("recognition_candidates", tables)
+                indexes = {
+                    row[0]
+                    for row in conn.execute("SELECT name FROM sqlite_master WHERE type='index';").fetchall()
+                }
+                self.assertIn("idx_upload_queue_state_id", indexes)
+                self.assertIn("idx_upload_queue_state_updated_at", indexes)
 
                 conn.execute("INSERT INTO matches DEFAULT VALUES;")
                 match_id = conn.execute("SELECT id FROM matches ORDER BY id DESC LIMIT 1;").fetchone()[0]

--- a/app/worker/tests/test_queue.py
+++ b/app/worker/tests/test_queue.py
@@ -112,6 +112,23 @@ class QueueRecoveryApiTests(unittest.TestCase):
         self.assertEqual(listed.status_code, 200)
         self.assertEqual(len(listed.json()["items"]), 1)
 
+    def test_queue_runtime_queries_use_counts_and_single_ready_item(self) -> None:
+        from odr_worker.queue import QueueStore
+
+        client, runtime_dirs = self._client()
+        first = client.post("/queue/items", json={"video_path": "first.mp4"}).json()
+        second = client.post("/queue/items", json={"video_path": "second.mp4"}).json()
+        client.post(f"/queue/items/{second['id']}/command", json={"action": "start_upload"})
+
+        store = QueueStore(runtime_dirs.db_dir / "odr.sqlite3")
+        counts = store.count_by_state()
+        ready = store.next_ready_item()
+
+        self.assertEqual(counts["ready_upload"], 1)
+        self.assertEqual(counts["uploading"], 1)
+        self.assertEqual(ready.id, first["id"])
+        self.assertEqual(ready.video_path, "first.mp4")
+
     def test_startup_recovery_moves_interrupted_upload_to_manual_review(self) -> None:
         client, runtime_dirs = self._client()
         item = client.post("/queue/items", json={"video_path": "duel.mp4"}).json()
@@ -122,6 +139,9 @@ class QueueRecoveryApiTests(unittest.TestCase):
         recovery = second_client.get("/queue/recovery")
         recovered = recovery.json()["recovered"]
 
+        self.assertEqual(recovery.json()["scanned_count"], 1)
+        self.assertEqual(recovery.json()["recovered_count"], 1)
+        self.assertGreaterEqual(recovery.json()["duration_ms"], 0)
         self.assertEqual(recovered[0]["id"], item["id"])
         self.assertEqual(recovered[0]["to"], "need_manual_review")
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [v2.0 release summary](release/v2.0-release-summary.md)
 - [v2.1 release summary](release/v2.1-release-summary.md)
 - [v2.2 release summary](release/v2.2-release-summary.md)
+- [v2.3 runtime baseline](release/v2.3-runtime-baseline.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
 - [v0.3 SQLite Foundation acceptance checklist](requirements/v0.3-sqlite-foundation-acceptance.md)
 - [v0.4 OBS Plugin Skeleton acceptance checklist](requirements/v0.4-obs-plugin-skeleton-acceptance.md)

--- a/docs/architecture/runtime-optimization.md
+++ b/docs/architecture/runtime-optimization.md
@@ -2,14 +2,50 @@
 
 v2.3 improves long-session runtime stability without changing ownership boundaries.
 
-## Baseline First
+## Baseline And Thresholds
 
-Every optimization should start with baseline evidence:
-- memory usage
-- upload processing behavior
-- queue recovery behavior
-- DB query or migration behavior
-- long-session smoke or fixture notes
+The v2.3 baseline uses deterministic local fixtures instead of user media:
+
+| Area | v2.2 baseline risk | v2.3 target threshold | Evidence |
+|---|---|---|---|
+| Upload status | `/upload/status` materializes all queue rows before counting states. | State counts use SQL aggregation and do not instantiate queue payloads. | `QueueStore.count_by_state()` and upload tests. |
+| Upload processing | `/upload/process-next` lists every `ready_upload` row and picks the first item. | Next ready item uses `ORDER BY id LIMIT 1`. | `QueueStore.next_ready_item()` and queue tests. |
+| Queue recovery | Startup recovery returns recovered rows but not scan timing/count evidence. | Recovery reports scanned count, recovered count, and duration. | `/queue/recovery` fixture tests. |
+| DB access | Queue polling depends on state scans. | Runtime queue indexes cover `(state, id)` and `(state, updated_at)`. | Migration `0008_runtime_optimization_indexes`. |
+| Long session | Sustained queue/status checks rely on behavior tests only. | Fixture smoke covers repeated queue/status/recovery paths without committing runtime data. | Worker unit tests and release evidence. |
+
+Regression review should fail if a future change reintroduces full queue materialization for status counts or first-ready upload selection.
+
+## Implemented v2.3 Optimizations
+
+- `QueueStore.count_by_state()` counts upload queue states with SQL `GROUP BY`.
+- `UploadStore.status()` uses `count_by_state()` instead of loading every queue item.
+- `QueueStore.next_ready_item()` retrieves the next upload candidate with `ORDER BY id LIMIT 1`.
+- `UploadStore.process_next()` uses `next_ready_item()` and preserves existing retry, quota, auth, ambiguous outcome, and manual review semantics.
+- Queue SQLite connections set `PRAGMA busy_timeout = 5000` to reduce transient lock failures during local long-session operation.
+- Migration `0008_runtime_optimization_indexes` adds queue state indexes for polling and recovery.
+- Startup recovery diagnostics include `scanned_count`, `recovered_count`, and `duration_ms`.
+
+## Measurement Environment
+
+Local fixture measurements are run on Windows with repository-local temporary `user_data` directories. Fixtures create SQLite rows and small placeholder video files only; they do not use real videos, screenshots, OAuth files, logs, tokens, or game assets.
+
+Recommended commands:
+
+```powershell
+python -m unittest app.worker.tests.test_queue app.worker.tests.test_upload app.worker.tests.test_db
+python -m unittest discover -s app\worker\tests
+```
+
+## Long-Session Smoke
+
+For a long-session smoke, repeat the following fixture sequence against a temporary runtime:
+
+1. Create multiple queue items with mixed `ready_upload`, `uploading`, `upload_failed`, `quota_waiting`, `need_manual_review`, and `uploaded` states.
+2. Call `/upload/status` repeatedly and confirm counts remain stable.
+3. Call `/upload/process-next` and confirm the lowest-id ready item is selected.
+4. Restart the Worker app fixture and call `/queue/recovery`.
+5. Confirm interrupted uploads move conservatively to manual review unless a success marker or missing local file rule applies.
 
 ## Preservation Rules
 

--- a/docs/release/v2.3-runtime-baseline.md
+++ b/docs/release/v2.3-runtime-baseline.md
@@ -1,0 +1,42 @@
+# v2.3 Runtime Baseline And Regression Thresholds
+
+Status: **implemented in v2.3 runtime optimization PR**
+
+## Baseline Scope
+
+The baseline covers runtime paths named by #360, #361, #362, and #363:
+
+- memory-sensitive queue status counting
+- upload candidate selection
+- DB indexes for queue polling and recovery
+- startup recovery diagnostics
+- long-session fixture expectations
+
+## Baseline Findings
+
+| Path | Baseline behavior before v2.3 | v2.3 behavior | Regression threshold |
+|---|---|---|---|
+| `/upload/status` | Loaded all queue rows and then counted states in Python. | Uses SQL `GROUP BY` through `QueueStore.count_by_state()`. | Must not materialize every queue item for status counts. |
+| `/upload/process-next` | Loaded all `ready_upload` rows and picked the first row in Python. | Uses SQL `ORDER BY id LIMIT 1` through `QueueStore.next_ready_item()`. | Must not scan all ready rows for one upload candidate. |
+| Queue DB access | Queue state scans relied on existing indexes not shaped for state-first polling. | Adds `idx_upload_queue_state_id` and `idx_upload_queue_state_updated_at`. | Migration must remain idempotent and preserve existing data. |
+| Startup recovery | Returned recovered rows only. | Adds `scanned_count`, `recovered_count`, and `duration_ms`. | Recovery must remain deterministic and conservative for ambiguous uploads. |
+
+## Measurement Environment
+
+- Platform: Windows local development environment.
+- Runtime root: temporary `user_data` directories created by Worker tests.
+- Media: placeholder file names and small local files only.
+- Secrets: no OAuth tokens, client secrets, screenshots, videos, logs, or game assets are used.
+
+## Evidence Commands
+
+```powershell
+python -m unittest app.worker.tests.test_queue app.worker.tests.test_upload app.worker.tests.test_db
+python -m unittest discover -s app\worker\tests
+```
+
+## Residual Risk
+
+- The v2.3 evidence is fixture-based, not a wall-clock production soak.
+- Real OBS and YouTube client behavior remains covered by existing smoke and provider boundaries rather than by this local optimization fixture.
+- Future packaging automation should preserve this fixture test set in CI.


### PR DESCRIPTION
## Summary
- Optimize upload status counts with SQL aggregation instead of queue item materialization.
- Optimize next upload candidate selection with `ORDER BY id LIMIT 1`.
- Add runtime queue indexes, SQLite busy timeout, and recovery diagnostics.
- Document v2.3 baseline metrics, thresholds, and long-session fixture expectations.

## Issue Coverage
- Addresses #360 with baseline/threshold documentation.
- Addresses #361 with memory/upload/queue/DB optimization implementation and regression tests.
- Addresses #362 with recovery diagnostics and long-session smoke guidance.
- Provides validation evidence for #363 and progresses parent #327.

## Verification
- `python -m unittest app.worker.tests.test_queue app.worker.tests.test_upload app.worker.tests.test_db`
- `python -m unittest discover -s app\worker\tests`
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `python scripts\build_docs_site.py --root . --output build\docs-site`
- `git diff --check`