### PR TITLE
Record v2.3 tag target

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ obs-duel-recorder/
 - Version: `v2.3.0`
 - Scope: Runtime Optimization
 - Status: released
-- Tag target: pending tag-record PR
+- Tag target: `5c6a8ea7f01d364dcdf9f24e656b1a4d262c3142`
 - Tracking issue: [#327](https://github.com/Tao-pyth/obs-duel-recorder/issues/327)
 - Release record: [docs/release-history.md](docs/release-history.md)
 

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -287,12 +287,12 @@ The version tracking issue may contain the working release summary, but finalize
 - Release readiness checklist: `docs/release/v2.3-release-readiness.md`
 - Runtime baseline: `docs/release/v2.3-runtime-baseline.md`
 - Tag: `v2.3.0`
-- Tag target: pending tag-record PR
+- Tag target: `5c6a8ea7f01d364dcdf9f24e656b1a4d262c3142`
 - Release finalized at: `2026-05-23T15:45:18+09:00`
-- Tag finalized at: pending tag-record PR
+- Tag finalized at: `2026-05-23T15:52:12+09:00`
 - Release summary: `docs/release/v2.3-release-summary.md`
 - Major child issues: #360, #361, #362, #363
 - Major PRs: #384
 - Deferred items: packaging ZIP workflow remains v2.x follow-up under `docs/architecture/packaging.md`; release asset automation and checksum publication remain future packaging work
 - Next version tracking issue: none yet
-- Status: release finalization pending tag record
+- Status: released

--- a/docs/release/v2.3-release-readiness.md
+++ b/docs/release/v2.3-release-readiness.md
@@ -51,14 +51,14 @@ Non-goals:
 
 - [x] Release PR contains no secrets and does not add runtime data, logs, databases, videos, screenshots, or generated media.
 - [x] Release PR updates persistent release docs.
-- [ ] Release PR is merged into `main`.
-- [ ] The merge commit SHA on `main` is recorded for tagging.
+- [x] Release PR is merged into `main`.
+- [x] The merge commit SHA on `main` is recorded for tagging.
 
 ## E. Tagging After Merge
 
-- [ ] Create tag `v2.3.0` pointing to the release merge commit SHA on `main`.
-- [ ] Do not move or overwrite existing tags.
-- [ ] If tooling cannot create the tag, record the intended tag name and target SHA in #327 and release docs.
+- [x] Create tag `v2.3.0` pointing to the release merge commit SHA on `main`.
+- [x] Do not move or overwrite existing tags.
+- [x] Tag target SHA is recorded in #327 and release docs.
 
 ## F. Handoff
 

--- a/docs/release/v2.3-release-summary.md
+++ b/docs/release/v2.3-release-summary.md
@@ -1,14 +1,14 @@
 # v2.3.0 Release Summary - Runtime Optimization
 
-Status: **release finalization pending tag record**
+Status: **released**
 
 - Version tracking issue: #327
 - Release readiness checklist: `docs/release/v2.3-release-readiness.md`
 - Runtime baseline: `docs/release/v2.3-runtime-baseline.md`
 - Tag: `v2.3.0`
-- Tag target: pending tag-record PR
+- Tag target: `5c6a8ea7f01d364dcdf9f24e656b1a4d262c3142`
 - Release finalized at: `2026-05-23T15:45:18+09:00`
-- Tag finalized at: pending tag-record PR
+- Tag finalized at: `2026-05-23T15:52:12+09:00`
 - Next version tracking issue: none yet
 
 ## Completed Scope


### PR DESCRIPTION
## Summary
- Record the pushed `v2.3.0` tag target SHA in README, release history, readiness, and summary docs.
- Mark v2.3 release readiness tagging items complete.

## Issue Coverage
- Completes release-point evidence for #327.

## Verification
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `python scripts\build_docs_site.py --root . --output build\docs-site`
- `git diff --check`