### PR TITLE
Add v2.4 packaging automation roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Latest released version:
 - `v2.3.0` - Runtime Optimization
 
 Current development target:
-- Post-v2.3 roadmap planning
+- `v2.4` - Release Packaging Automation
 - Tracking issue: none yet
 
 Next roadmap target:
-- Later v2.x roadmap work after v2.3 is tracked in GitHub issues.
+- Later v2.x roadmap work after v2.4 is tracked in GitHub issues.
 
 ---
 
@@ -65,7 +65,7 @@ Current released foundation:
 - Runtime queue/upload optimization, DB indexes, and recovery diagnostics
 
 Planned roadmap capabilities:
-- GitHub Actions based packaging and SHA256 checksum assets (`v2.0+`)
+- GitHub Actions based packaging and SHA256 checksum assets (`v2.4`)
 
 ---
 
@@ -132,7 +132,8 @@ obs-duel-recorder/
 
 ### Planned After v2.3
 
-- Later roadmap items include packaging automation and release asset hardening.
+- `v2.4` - Release Packaging Automation
+- Later roadmap items include release asset hardening after packaging automation is verified.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -446,6 +446,29 @@ Improve long-term runtime stability.
 
 ---
 
+## v2.4 - Release Packaging Automation
+
+### Goals
+
+Create a reproducible GitHub Actions based release packaging flow.
+
+### Planned
+
+- packaging ZIP workflow
+- release asset automation
+- SHA256 checksum publication
+- release artifact layout validation
+- update.bat-compatible package contents
+
+### Deliverables
+
+- GitHub Actions generated release ZIP
+- release asset upload procedure
+- published checksum evidence
+- documented package layout
+
+---
+
 # Future Considerations
 
 Potential future features:


### PR DESCRIPTION
## Summary
- Add `v2.4 - Release Packaging Automation` to the roadmap.
- Move GitHub Actions packaging, release asset automation, and SHA256 checksum publication from `v2.0+` wording to `v2.4`.
- Update README current development and planned roadmap capability wording.

## Verification
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`