### PR TITLE
Realign roadmap with v0 practical readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,27 @@ The project is designed around an OBS Plugin + Python Worker architecture.
 | Minor | planned roadmap features |
 | Patch | bug fixes and non-roadmap changes |
 
-Major and minor release completions are tagged as `vMajor.Minor.Patch`. See [Release and tag policy](docs/release.md).
+Important readiness note:
+- The project is still **pre-v1.0 for practical user readiness** because the OBS Plugin DLL has not yet been built and smoke-tested in a real OBS runtime.
+- Existing `v1.x` and `v2.x` tags are historical/internal development milestones, not proof of a user-ready OBS plugin release.
+- Practical user-ready versioning resumes on the `v0.x` readiness track until the v1.0 OBS plugin smoke gate is satisfied.
+
+See [Release and tag policy](docs/release.md).
 
 ---
 
 ## Current Development
 
-Latest released version:
-- `v2.3.0` - Runtime Optimization
+Latest practical release status:
+- Practical release: none yet; the project remains `v0.x` / pre-v1.0 for user readiness.
+- Latest internal milestone tag: `v2.3.0` - Runtime Optimization
 
 Current development target:
-- `v2.4` - Release Packaging Automation
-- Tracking issue: none yet
+- `v0.11` - OBS Plugin Real Load Smoke
+- Tracking issue: [#387](https://github.com/Tao-pyth/obs-duel-recorder/issues/387)
 
 Next roadmap target:
-- Later v2.x roadmap work after v2.4 is tracked in GitHub issues.
+- `v0.12` - Release Packaging Automation
 
 ---
 
@@ -65,7 +71,8 @@ Current released foundation:
 - Runtime queue/upload optimization, DB indexes, and recovery diagnostics
 
 Planned roadmap capabilities:
-- GitHub Actions based packaging and SHA256 checksum assets (`v2.4`)
+- OBS Plugin DLL build and real OBS load smoke (`v0.11`)
+- GitHub Actions based packaging and SHA256 checksum assets (`v0.12`)
 
 ---
 
@@ -114,14 +121,14 @@ obs-duel-recorder/
 
 ### Latest Release
 
-- Version: `v2.3.0`
-- Scope: Runtime Optimization
-- Status: released
-- Tag target: `5c6a8ea7f01d364dcdf9f24e656b1a4d262c3142`
-- Tracking issue: [#327](https://github.com/Tao-pyth/obs-duel-recorder/issues/327)
+- Practical version: none yet
+- Practical status: pre-v1.0; OBS Plugin DLL build/load smoke is not complete
+- Current practical tracking issue: [#387](https://github.com/Tao-pyth/obs-duel-recorder/issues/387)
+- Latest internal milestone: `v2.3.0`
+- Internal milestone tag target: `5c6a8ea7f01d364dcdf9f24e656b1a4d262c3142`
 - Release record: [docs/release-history.md](docs/release-history.md)
 
-### Completed in v2.3
+### Completed Internal Milestone v2.3
 
 - SQL aggregation for upload status counts without queue item materialization
 - Single-row next upload candidate selection with `ORDER BY id LIMIT 1`
@@ -130,10 +137,11 @@ obs-duel-recorder/
 - Startup recovery diagnostics with scanned count, recovered count, and duration evidence
 - v2.3 runtime baseline, regression threshold, and long-session fixture documentation
 
-### Planned After v2.3
+### Practical Readiness Gates
 
-- `v2.4` - Release Packaging Automation
-- Later roadmap items include release asset hardening after packaging automation is verified.
+- `v0.11` - OBS Plugin Real Load Smoke
+- `v0.12` - Release Packaging Automation
+- `v1.0` - First Practical OBS Plugin Release
 
 ---
 

--- a/app/plugin/README.md
+++ b/app/plugin/README.md
@@ -18,7 +18,9 @@ The Plugin must not:
 - directly manipulate SQLite
 - directly upload to YouTube
 
-## Current v2.3 Runtime Optimization
+## Current Internal v2.3 Runtime Optimization
+
+Readiness note: `v2.3` is the internal Worker/API compatibility milestone. It is not a practical user-ready release claim until the Plugin DLL is built and smoke-tested in a real OBS runtime.
 
 The current scaffold keeps the v0.5 overlay surface, v0.6 manual recording lifecycle controls, v0.7 queue recovery API compatibility, v0.8 template detection API compatibility, v0.9 screenshot API compatibility, v1.0 upload API compatibility, v1.1 match metadata API compatibility, v1.2 export API compatibility, v1.3 setup wizard API compatibility, v1.4 update API compatibility, v2.0 image recognition API compatibility, v2.1 statistics API compatibility, v2.2 documentation publication compatibility, and v2.3 runtime optimization compatibility:
 
@@ -46,7 +48,7 @@ The current scaffold keeps the v0.5 overlay surface, v0.6 manual recording lifec
 - Require a v2.0-compatible Worker for recognition candidate analysis and manual review audit records.
 - Require a v2.1-compatible Worker for read-only match/upload statistics and memo search.
 - Require a v2.2-compatible Worker/Plugin version pair for the documented GitHub Pages release line.
-- Require a v2.3-compatible Worker for optimized queue/upload polling and recovery diagnostics.
+- Require a v2.3-compatible internal Worker API for optimized queue/upload polling and recovery diagnostics.
 
 Current non-goals:
 - Full control UI beyond the v0.6 manual start/stop controls.
@@ -185,6 +187,8 @@ Defaults:
 - Expected Worker version: `2.3.0`
 - Heartbeat interval: 2000 ms
 - Heartbeat timeout threshold: 3 consecutive failed probes
+
+These Worker values are internal compatibility gates. They do not replace the practical release gate that requires a built DLL and real OBS load smoke evidence.
 
 Startup behavior:
 - On OBS frontend ready, the Plugin loads `plugin-settings.json` and starts the Worker manager.

--- a/docs/architecture/packaging.md
+++ b/docs/architecture/packaging.md
@@ -1,6 +1,6 @@
 # Packaging
 
-This document defines the release packaging direction for v2.0+.
+This document defines the release packaging direction for `v0.12 - Release Packaging Automation` on the practical readiness track.
 
 ## Release ZIP
 

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -4,6 +4,15 @@ This document records completed release outcomes for OBS Duel Recorder.
 
 Use this file as the durable index for release point information. If a release needs more detail, create a version-specific summary under `docs/release/` and link it from this file.
 
+## Practical Readiness Note
+
+As of #389, this history distinguishes practical user-ready releases from historical/internal implementation milestones.
+
+- The project remains pre-v1.0 for practical OBS plugin user readiness until #387 or its successor records real OBS load smoke evidence.
+- Existing `v1.x` and `v2.x` tags are preserved historical/internal milestone tags.
+- Older `Status: released` entries before this policy note mean "roadmap milestone released" unless a record explicitly says it is a practical user-ready OBS plugin release.
+- Do not interpret `v2.0.0` through `v2.3.0` as proof that an installable OBS plugin release is user-ready.
+
 ## Recording Policy
 
 For each completed release, record at least:
@@ -244,9 +253,9 @@ The version tracking issue may contain the working release summary, but finalize
 - Release summary: `docs/release/v2.0-release-summary.md`
 - Major child issues: #348, #349, #350, #351
 - Major PRs: #375
-- Deferred items: Statistics System remains in #325 for v2.1; GitHub Pages Documentation remains in #326 for v2.2; Runtime Optimization remains in #327 for v2.3; packaging ZIP workflow remains v2.x follow-up under `docs/architecture/packaging.md`
+- Deferred items: Statistics System remains in #325 for v2.1; GitHub Pages Documentation remains in #326 for v2.2; Runtime Optimization remains in #327 for v2.3; practical OBS plugin smoke remains in #387; packaging automation moves to the v0.x practical readiness track
 - Next version tracking issue: #325
-- Status: released
+- Status: internal milestone complete; not a practical user-ready OBS plugin release
 
 ### v2.1.0 - Statistics System
 
@@ -260,9 +269,9 @@ The version tracking issue may contain the working release summary, but finalize
 - Release summary: `docs/release/v2.1-release-summary.md`
 - Major child issues: #352, #353, #354, #355
 - Major PRs: #378
-- Deferred items: GitHub Pages Documentation remains in #326 for v2.2; Runtime Optimization remains in #327 for v2.3; packaging ZIP workflow remains v2.x follow-up under `docs/architecture/packaging.md`
+- Deferred items: GitHub Pages Documentation remains in #326 for v2.2; Runtime Optimization remains in #327 for v2.3; practical OBS plugin smoke remains in #387; packaging automation moves to the v0.x practical readiness track
 - Next version tracking issue: #326
-- Status: released
+- Status: internal milestone complete; not a practical user-ready OBS plugin release
 
 ### v2.2.0 - GitHub Pages Documentation
 
@@ -276,9 +285,9 @@ The version tracking issue may contain the working release summary, but finalize
 - Release summary: `docs/release/v2.2-release-summary.md`
 - Major child issues: #356, #357, #358, #359
 - Major PRs: #381
-- Deferred items: Runtime Optimization remains in #327 for v2.3; packaging ZIP workflow remains v2.x follow-up under `docs/architecture/packaging.md`
+- Deferred items: Runtime Optimization remains in #327 for v2.3; practical OBS plugin smoke remains in #387; packaging automation moves to the v0.x practical readiness track
 - Next version tracking issue: #327
-- Status: released
+- Status: internal milestone complete; not a practical user-ready OBS plugin release
 
 ### v2.3.0 - Runtime Optimization
 
@@ -293,6 +302,6 @@ The version tracking issue may contain the working release summary, but finalize
 - Release summary: `docs/release/v2.3-release-summary.md`
 - Major child issues: #360, #361, #362, #363
 - Major PRs: #384
-- Deferred items: packaging ZIP workflow remains v2.x follow-up under `docs/architecture/packaging.md`; release asset automation and checksum publication remain future packaging work
+- Deferred items: practical OBS plugin smoke remains in #387; packaging ZIP workflow, release asset automation, and checksum publication move to v0.12 on the practical readiness track
 - Next version tracking issue: none yet
-- Status: released
+- Status: internal milestone complete; not a practical user-ready OBS plugin release

--- a/docs/release.md
+++ b/docs/release.md
@@ -21,12 +21,32 @@ Examples:
 - `v0.2.0`
 - `v1.0.0`
 
+## Practical Readiness Policy
+
+As of #389, version labels are split into two meanings:
+
+- **Practical release track**: user-facing readiness for installing and running the OBS plugin.
+- **Historical/internal milestone track**: implementation milestones that may have tags but do not by themselves prove a user-ready OBS plugin release.
+
+The project is currently **pre-v1.0 on the practical release track**. A practical `v1.0` release requires accepted evidence that:
+
+- the Plugin DLL can be built in Release configuration,
+- the DLL loads in a real Windows OBS Studio x64 runtime without crashing,
+- the OBS Duel Recorder Dock appears,
+- Worker heartbeat and compatibility checks pass,
+- basic manual recording start/stop behavior is smoke-tested,
+- packaging/update instructions are usable for a normal user.
+
+Existing historical/internal tags such as `v1.0.0` through `v2.3.0` must not be interpreted as practical user-ready release evidence. Do not move or overwrite those tags. If a future practical `v1.0` tag would conflict with an existing historical/internal tag, record the exact naming decision before tagging.
+
 ## Version Terms
 
 Use separate terms for released and in-development versions:
 
 - `released_version`: the latest completed and published version.
 - `current_development_version`: the version currently being developed toward the next release boundary.
+- `practical_readiness_version`: the user-facing readiness track for installable OBS plugin releases.
+- `internal_milestone_version`: the Worker/API or implementation milestone track used for historical development records.
 
 Avoid using a single `current_version` term when it is unclear whether it means a released version or an in-development target.
 
@@ -75,6 +95,8 @@ If a completed release needs a patch boundary, create a small patch tracking iss
 ## When Tags Are Required
 
 Tags are required when a major or minor version is completed and merged into `main`.
+
+For practical readiness releases, tags are required only after the practical readiness gate for that version is met. Internal milestone tags may exist, but they must be documented as internal milestones when practical readiness has not been proven.
 
 Required tag points:
 - Major release completion: tag the merged release commit as `vX.0.0`, unless the release plan explicitly defines a different minor or patch number.
@@ -131,7 +153,7 @@ When a major or minor roadmap milestone is completed:
 6. Create the release tag if the available GitHub tooling supports tag creation.
 7. If tag creation is not available, report the intended tag name and target commit SHA.
 8. Save release point information to persistent release docs.
-9. Confirm version information such as `released_version` and `current_development_version` is updated where defined.
+9. Confirm version information such as `practical_readiness_version`, `internal_milestone_version`, `released_version`, and `current_development_version` is updated where defined.
 10. Confirm the next version tracking issue is created from `docs/roadmap.md`.
 11. Link the next version tracking issue from the completed tracking issue.
 

--- a/docs/release/v2.0-release-summary.md
+++ b/docs/release/v2.0-release-summary.md
@@ -1,6 +1,8 @@
 # v2.0.0 Release Summary - OCR Integration
 
-Status: **released**
+Status: **internal milestone complete**
+
+Practical readiness note: this tag does not prove a user-ready OBS plugin release. Real OBS Plugin DLL build/load smoke remains tracked separately by #387.
 
 - Version tracking issue: #324
 - Release readiness checklist: `docs/release/v2.0-release-readiness.md`
@@ -36,4 +38,5 @@ Status: **released**
 - Statistics System remains in #325 for v2.1.
 - GitHub Pages Documentation remains in #326 for v2.2.
 - Runtime Optimization remains in #327 for v2.3.
-- Packaging ZIP workflow and checksum automation remain governed by `docs/architecture/packaging.md` for v2.x follow-up.
+- Practical OBS plugin smoke remains in #387.
+- Packaging ZIP workflow and checksum automation move to the v0.x practical readiness track.

--- a/docs/release/v2.1-release-summary.md
+++ b/docs/release/v2.1-release-summary.md
@@ -1,6 +1,8 @@
 # v2.1.0 Release Summary - Statistics System
 
-Status: **released**
+Status: **internal milestone complete**
+
+Practical readiness note: this tag does not prove a user-ready OBS plugin release. Real OBS Plugin DLL build/load smoke remains tracked separately by #387.
 
 - Version tracking issue: #325
 - Release readiness checklist: `docs/release/v2.1-release-readiness.md`
@@ -33,4 +35,5 @@ Status: **released**
 
 - GitHub Pages Documentation remains in #326 for v2.2.
 - Runtime Optimization remains in #327 for v2.3.
-- Packaging ZIP workflow remains v2.x follow-up under `docs/architecture/packaging.md`.
+- Practical OBS plugin smoke remains in #387.
+- Packaging ZIP workflow moves to the v0.x practical readiness track.

--- a/docs/release/v2.2-release-summary.md
+++ b/docs/release/v2.2-release-summary.md
@@ -1,6 +1,8 @@
 # v2.2.0 Release Summary - GitHub Pages Documentation
 
-Status: **released**
+Status: **internal milestone complete**
+
+Practical readiness note: this tag does not prove a user-ready OBS plugin release. Real OBS Plugin DLL build/load smoke remains tracked separately by #387.
 
 - Version tracking issue: #326
 - Release readiness checklist: `docs/release/v2.2-release-readiness.md`
@@ -31,4 +33,5 @@ Status: **released**
 ## Deferred Items
 
 - Runtime Optimization remains in #327 for v2.3.
-- Packaging ZIP workflow remains v2.x follow-up under `docs/architecture/packaging.md`.
+- Practical OBS plugin smoke remains in #387.
+- Packaging ZIP workflow moves to the v0.x practical readiness track.

--- a/docs/release/v2.3-release-summary.md
+++ b/docs/release/v2.3-release-summary.md
@@ -1,6 +1,8 @@
 # v2.3.0 Release Summary - Runtime Optimization
 
-Status: **released**
+Status: **internal milestone complete**
+
+Practical readiness note: this tag does not prove a user-ready OBS plugin release. Real OBS Plugin DLL build/load smoke remains tracked separately by #387.
 
 - Version tracking issue: #327
 - Release readiness checklist: `docs/release/v2.3-release-readiness.md`
@@ -32,5 +34,5 @@ Status: **released**
 
 ## Deferred Items
 
-- Packaging ZIP workflow remains v2.x follow-up under `docs/architecture/packaging.md`.
-- GitHub Actions release asset automation and checksum publication remain future packaging work.
+- Practical OBS plugin smoke remains in #387.
+- Packaging ZIP workflow, GitHub Actions release asset automation, and checksum publication move to v0.12 on the practical readiness track.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,5 +1,16 @@
 # Roadmap
 
+## Practical Readiness Note
+
+This roadmap separates practical user readiness from historical/internal development milestones.
+
+- The project is currently on the `v0.x` practical readiness track.
+- Existing `v1.x` and `v2.x` tags are historical/internal development milestones.
+- A user-ready `v1.0` practical release requires a built OBS Plugin DLL, real OBS load smoke evidence, Dock visibility, Worker heartbeat, and basic recording control evidence.
+- The exact practical `v1.0` tag naming must be confirmed before tagging because historical/internal `v1.0.0` already exists.
+
+---
+
 ## Versioning Policy
 
 - Major:
@@ -10,6 +21,108 @@
 
 - Patch:
   bug fixes, runtime fixes, migration fixes, non-roadmap changes
+
+---
+
+# Practical Readiness Track
+
+This is the authoritative roadmap for user-facing readiness.
+
+---
+
+## v0.10 - Roadmap And Versioning Realignment
+
+### Goals
+
+Reconcile roadmap and versioning with practical OBS plugin readiness.
+
+### Planned
+
+- clarify `v0.x` practical readiness status
+- classify existing `v1.x` and `v2.x` tags as historical/internal milestones
+- define practical `v1.0` promotion gates
+- connect OBS real-load smoke evidence to the practical roadmap
+
+### Deliverables
+
+- corrected README and roadmap wording
+- release policy clarification
+- release history practical-readiness note
+
+---
+
+## v0.11 - OBS Plugin Real Load Smoke
+
+### Goals
+
+Prove that the plugin can be built and loaded in a real OBS runtime.
+
+### Planned
+
+- Release build of `obs-duel-recorder.dll`
+- real OBS Studio x64 load smoke
+- Dock visibility confirmation
+- plugin startup/shutdown log confirmation
+- Worker heartbeat and v2.3 internal API compatibility confirmation
+- manual recording start/stop smoke
+- overlay Text Source creation/reuse smoke
+
+### Deliverables
+
+- real OBS smoke evidence linked from #387
+- confirmed plugin DLL path and build command
+- redaction-checked smoke report
+
+---
+
+## v0.12 - Release Packaging Automation
+
+### Goals
+
+Create a reproducible GitHub Actions based release packaging flow.
+
+### Planned
+
+- packaging ZIP workflow
+- release asset automation
+- SHA256 checksum publication
+- release artifact layout validation
+- update.bat-compatible package contents
+
+### Deliverables
+
+- GitHub Actions generated release ZIP
+- release asset upload procedure
+- published checksum evidence
+- documented package layout
+
+---
+
+## v1.0 - First Practical OBS Plugin Release
+
+### Goals
+
+Publish the first practical user-ready release after OBS plugin smoke and packaging gates pass.
+
+### Planned
+
+- v0.11 real OBS plugin smoke evidence accepted
+- v0.12 packaging automation evidence accepted
+- user-facing install/update documentation verified
+- runtime data preservation rules verified
+- release naming/tagging decision recorded without moving historical tags
+
+### Deliverables
+
+- first practical OBS plugin release package
+- user-ready release notes
+- install/update verification evidence
+
+---
+
+# Historical Internal Milestone Archive
+
+The following milestones record internal implementation progress. They are useful development history, but they do not by themselves prove a user-ready OBS plugin release.
 
 ---
 
@@ -443,29 +556,6 @@ Improve long-term runtime stability.
 ### Deliverables
 
 - long-session runtime stability
-
----
-
-## v2.4 - Release Packaging Automation
-
-### Goals
-
-Create a reproducible GitHub Actions based release packaging flow.
-
-### Planned
-
-- packaging ZIP workflow
-- release asset automation
-- SHA256 checksum publication
-- release artifact layout validation
-- update.bat-compatible package contents
-
-### Deliverables
-
-- GitHub Actions generated release ZIP
-- release asset upload procedure
-- published checksum evidence
-- documented package layout
 
 ---
 


### PR DESCRIPTION
## Summary
- Reclassify existing `v1.x`/`v2.x` tags as historical/internal milestones rather than practical user-ready releases.
- Add the practical readiness track: `v0.10` roadmap realignment, `v0.11` OBS Plugin real load smoke, `v0.12` packaging automation, and practical `v1.0` gate.
- Update README, release policy, release history, v2.x summaries, packaging docs, and plugin README to distinguish internal Worker/API compatibility from OBS plugin user readiness.

## Issue Coverage
- Closes #389.
- Connects #387 to the `v0.11` practical readiness gate.

## Verification
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `python scripts\build_docs_site.py --root . --output build\docs-site`
- `git diff --check`