### PR TITLE
Add v0.11 OBS smoke environment check

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -80,6 +80,7 @@ Architecture documents describe technical behavior and responsibility boundaries
 - [Statistics](architecture/statistics.md)
 - [Runtime optimization](architecture/runtime-optimization.md)
 - [Upload provider](architecture/upload-provider.md)
+- [v0.11 OBS plugin smoke procedure](architecture/v0.11-obs-plugin-smoke.md)
 - [v0.5 OBS overlay smoke procedure](architecture/v0.5-overlay-smoke.md)
 - [v0.6 recording-state smoke procedure](architecture/v0.6-recording-state-smoke.md)
 

--- a/docs/architecture/v0.11-obs-plugin-smoke.md
+++ b/docs/architecture/v0.11-obs-plugin-smoke.md
@@ -1,0 +1,83 @@
+# v0.11 OBS Plugin Smoke Procedure
+
+This procedure collects the minimum environment and build evidence for
+`v0.11 - OBS Plugin Real Load Smoke`.
+
+Authoritative tracking:
+- Version tracking issue: #393
+- Smoke evidence gate: #387
+- Acceptance checklist: `docs/requirements/v0.11-obs-plugin-real-load-smoke-acceptance.md`
+- Release readiness checklist: `docs/release/v0.11-release-readiness.md`
+
+## Environment Check
+
+Run from the repository root:
+
+```powershell
+powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts\check_v0_11_obs_smoke_env.ps1 `
+  -ObsPrefix "C:\Path\To\obs-studio-or-sdk" `
+  -ObsFrontendApiDir "C:\Path\To\obs-studio-build\frontend\api" `
+  -ObsDepsPrefix "C:\Path\To\obs-deps-x64" `
+  -W32PthreadsPrefix "C:\Path\To\obs-studio-build\deps\w32-pthreads" `
+  -CMakeModulePath "C:\Path\To\obs-studio-src\cmake\finders" `
+  -ObsRuntimePath "C:\Path\To\obs64.exe" `
+  -QtPrefix "C:\Path\To\Qt\6.x.x\msvc2022_64"
+```
+
+When `-ObsPrefix` points at an OBS source build directory, the script attempts
+to infer `frontend\api`, `deps\w32-pthreads`, `.deps\obs-deps-*-x64`, and
+`cmake\finders` from the adjacent OBS source layout.
+
+The check records:
+- CMake availability
+- Visual Studio 2022 C++ toolchain availability
+- OBS Studio x64 runtime availability
+- `libobsConfig.cmake`
+- `obs-frontend-apiConfig.cmake`
+- `w32-pthreadsConfig.cmake`
+- OBS dependency headers such as SIMDe
+- OBS CMake finder modules
+- `Qt6Config.cmake`
+- duplicate `PATH` / `Path` environment-key risk for MSBuild
+- `build/plugin/Release/obs-duel-recorder.dll`
+
+## Configure And Build
+
+If the environment contains both `PATH` and `Path`, MSBuild can fail while
+launching `CL.exe`. Use a sanitized Developer Command Prompt for the build:
+
+```cmd
+set PATH=
+set Path=C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\Git\cmd
+call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=x64 -host_arch=x64
+"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -S app/plugin -B build/plugin -G "Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH="<obs-prefix>;<qt-prefix>"
+cmake --build build/plugin --config Release
+```
+
+For OBS source build trees, include the frontend API package, OBS dependency
+prefix, w32-pthreads package, and OBS finder modules in addition to Qt:
+
+```cmd
+"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -S app/plugin -B build/plugin -G "Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH="<obs-build>;<obs-build>\frontend\api;<obs-build>\deps\w32-pthreads;<obs-source>\.deps\obs-deps-2025-08-23-x64;<qt-prefix>" -DCMAKE_MODULE_PATH="<obs-source>\cmake\finders"
+cmake --build build/plugin --config Release
+```
+
+Expected artifact:
+
+```text
+build/plugin/Release/obs-duel-recorder.dll
+```
+
+## OBS Load Smoke
+
+After the DLL exists:
+- install or copy it into a real OBS Studio x64 plugin load path,
+- start OBS Studio x64,
+- confirm OBS does not crash,
+- confirm the `OBS Duel Recorder` Dock appears,
+- confirm startup and shutdown logs,
+- confirm Worker heartbeat and v2.3 compatibility,
+- smoke-test manual recording start/stop,
+- smoke-test overlay Text Source creation or reuse.
+
+Post a redaction-checked smoke report to #387.

--- a/docs/release/v0.11-release-readiness.md
+++ b/docs/release/v0.11-release-readiness.md
@@ -10,6 +10,7 @@ Quick links:
 - Version tracking issue: #393
 - Smoke evidence gate: #387
 - Acceptance checklist: `docs/requirements/v0.11-obs-plugin-real-load-smoke-acceptance.md`
+- Smoke procedure: `docs/architecture/v0.11-obs-plugin-smoke.md`
 
 Non-goals:
 - Completing v0.12 Release Packaging Automation.
@@ -20,6 +21,7 @@ Non-goals:
 ## A. Environment Readiness
 
 - [ ] Windows x64 environment is recorded.
+- [ ] `scripts/check_v0_11_obs_smoke_env.ps1` output is recorded.
 - [ ] Visual Studio 2022 C++ build tools are available.
 - [ ] CMake is available.
 - [ ] OBS Studio x64 is installed and version is recorded.

--- a/docs/requirements/v0.11-obs-plugin-real-load-smoke-acceptance.md
+++ b/docs/requirements/v0.11-obs-plugin-real-load-smoke-acceptance.md
@@ -2,6 +2,7 @@
 
 This document defines the acceptance criteria for **v0.11 - OBS Plugin Real Load Smoke** as described in:
 - `docs/roadmap.md`
+- `docs/architecture/v0.11-obs-plugin-smoke.md`
 - #393
 - #387
 
@@ -34,6 +35,7 @@ v0.11 proves practical OBS plugin readiness with a real Windows OBS runtime:
 
 - Plugin build command and output artifact path.
 - OBS version, Windows version, toolchain, OBS SDK/development path, and Qt path.
+- `scripts/check_v0_11_obs_smoke_env.ps1` output.
 - OBS or ODR log excerpts for startup, shutdown, Dock, Worker heartbeat, and compatibility checks.
 - Redaction-ready smoke report linked from #387.
 

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -142,6 +142,7 @@ Goals:
 - Smoke evidence gate: `#387` - `[Verification] OBS Plugin DLL build and real OBS load smoke confirmation`
 - Acceptance checklist: `docs/requirements/v0.11-obs-plugin-real-load-smoke-acceptance.md`
 - Release readiness checklist: `docs/release/v0.11-release-readiness.md`
+- Smoke procedure: `docs/architecture/v0.11-obs-plugin-smoke.md`
 - Plugin scaffold/build notes: `app/plugin/README.md`
 - Worker API contract: `docs/architecture/worker-api.md`
 - Requirements (relevant sections):

--- a/scripts/check_v0_11_obs_smoke_env.ps1
+++ b/scripts/check_v0_11_obs_smoke_env.ps1
@@ -1,0 +1,247 @@
+param(
+    [string]$ObsPrefix = "",
+    [string]$ObsFrontendApiDir = "",
+    [string]$ObsDepsPrefix = "",
+    [string]$W32PthreadsPrefix = "",
+    [string]$CMakeModulePath = "",
+    [string]$ObsRuntimePath = "",
+    [string]$QtPrefix = "",
+    [string]$BuildDir = "build/plugin",
+    [ValidateSet("Debug", "Release", "RelWithDebInfo")]
+    [string]$Configuration = "Release",
+    [switch]$AttemptConfigure
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-CommandPath {
+    param([string]$Name)
+    $command = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($null -eq $command) {
+        return ""
+    }
+    return $command.Source
+}
+
+function Test-AnyPath {
+    param([string[]]$Paths)
+    foreach ($path in $Paths) {
+        if (Test-Path -LiteralPath $path) {
+            return $path
+        }
+    }
+    return ""
+}
+
+function Find-FirstFile {
+    param(
+        [string]$Root,
+        [string]$Filter
+    )
+    if ([string]::IsNullOrWhiteSpace($Root) -or -not (Test-Path -LiteralPath $Root)) {
+        return ""
+    }
+    $match = Get-ChildItem -LiteralPath $Root -Filter $Filter -Recurse -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($null -eq $match) {
+        return ""
+    }
+    return $match.FullName
+}
+
+function Add-CheckLine {
+    param(
+        [System.Collections.Generic.List[string]]$Lines,
+        [string]$Label,
+        [bool]$Passed,
+        [string]$Detail = ""
+    )
+    $mark = if ($Passed) { "PASS" } else { "FAIL" }
+    if ([string]::IsNullOrWhiteSpace($Detail)) {
+        $Lines.Add("- ${mark}: $Label")
+    } else {
+        $Lines.Add("- ${mark}: $Label - $Detail")
+    }
+}
+
+$repoRoot = (Get-Location).Path
+$repoParent = Split-Path -Parent $repoRoot
+
+if (-not [string]::IsNullOrWhiteSpace($ObsPrefix) -and (Test-Path -LiteralPath $ObsPrefix)) {
+    if ([string]::IsNullOrWhiteSpace($ObsFrontendApiDir)) {
+        $candidate = Join-Path $ObsPrefix "frontend\api"
+        if (Test-Path -LiteralPath $candidate) {
+            $ObsFrontendApiDir = $candidate
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($W32PthreadsPrefix)) {
+        $candidate = Join-Path $ObsPrefix "deps\w32-pthreads"
+        if (Test-Path -LiteralPath $candidate) {
+            $W32PthreadsPrefix = $candidate
+        }
+    }
+
+    $sourceRootCandidate = Split-Path -Parent $ObsPrefix
+    if ([string]::IsNullOrWhiteSpace($CMakeModulePath)) {
+        $candidate = Join-Path $sourceRootCandidate "cmake\finders"
+        if (Test-Path -LiteralPath $candidate) {
+            $CMakeModulePath = $candidate
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($ObsDepsPrefix)) {
+        $candidate = Get-ChildItem -LiteralPath (Join-Path $sourceRootCandidate ".deps") -Directory -Filter "obs-deps-*-x64" -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if ($null -ne $candidate) {
+            $ObsDepsPrefix = $candidate.FullName
+        }
+    }
+}
+
+$knownCmake = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe"
+$cmake = Get-CommandPath "cmake"
+if ([string]::IsNullOrWhiteSpace($cmake) -and (Test-Path -LiteralPath $knownCmake)) {
+    $cmake = $knownCmake
+}
+
+$vswhere = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+$vsInstall = ""
+if (Test-Path -LiteralPath $vswhere) {
+    $vsInstall = (& $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath) -join ""
+}
+
+$cl = Get-CommandPath "cl"
+if ([string]::IsNullOrWhiteSpace($cl) -and -not [string]::IsNullOrWhiteSpace($vsInstall)) {
+    $cl = Test-AnyPath @(
+        (Join-Path $vsInstall "VC\Tools\MSVC\14.44.35207\bin\Hostx64\x64\cl.exe")
+    )
+    if ([string]::IsNullOrWhiteSpace($cl)) {
+        $cl = Find-FirstFile (Join-Path $vsInstall "VC\Tools\MSVC") "cl.exe"
+    }
+}
+
+$obs64 = $ObsRuntimePath
+if ([string]::IsNullOrWhiteSpace($obs64)) {
+    $obs64 = Get-CommandPath "obs64"
+}
+if ([string]::IsNullOrWhiteSpace($obs64)) {
+    $obs64 = Test-AnyPath @(
+        "C:\Program Files\obs-studio\bin\64bit\obs64.exe",
+        "C:\Program Files (x86)\obs-studio\bin\64bit\obs64.exe",
+        "C:\obs-studio\bin\64bit\obs64.exe",
+        (Join-Path $repoParent "_smoke\tools\obs-studio-32.1.2\bin\64bit\obs64.exe")
+    )
+}
+
+$knownQtRoot = Test-AnyPath @("C:\Qt", $QtPrefix)
+$libobsConfig = Find-FirstFile $ObsPrefix "libobsConfig.cmake"
+$frontendConfig = Find-FirstFile $ObsFrontendApiDir "obs-frontend-apiConfig.cmake"
+if ([string]::IsNullOrWhiteSpace($frontendConfig)) {
+    $frontendConfig = Find-FirstFile $ObsPrefix "obs-frontend-apiConfig.cmake"
+}
+$w32PthreadsConfig = Find-FirstFile $W32PthreadsPrefix "w32-pthreadsConfig.cmake"
+$simdeHeaders = Find-FirstFile $ObsDepsPrefix "simde-common.h"
+$moduleFinder = Find-FirstFile $CMakeModulePath "FindSIMDe.cmake"
+$qtConfig = Find-FirstFile $QtPrefix "Qt6Config.cmake"
+$artifact = Join-Path $BuildDir "$Configuration/obs-duel-recorder.dll"
+
+$cmdPathOutput = (cmd.exe /d /s /c "set path") -split "`r?`n"
+$pathKeys = @($cmdPathOutput | Where-Object { $_ -match "^(PATH|Path)=" })
+$hasDuplicatePathKeys = $pathKeys.Count -gt 1
+
+$lines = New-Object System.Collections.Generic.List[string]
+$lines.Add("# v0.11 OBS Smoke Environment Check")
+$lines.Add("")
+$lines.Add("Generated: $(Get-Date -Format o)")
+$lines.Add("Repository: $repoRoot")
+$lines.Add("")
+$lines.Add("## Inputs")
+$lines.Add("")
+$lines.Add("- ObsPrefix: $ObsPrefix")
+$lines.Add("- ObsFrontendApiDir: $ObsFrontendApiDir")
+$lines.Add("- ObsDepsPrefix: $ObsDepsPrefix")
+$lines.Add("- W32PthreadsPrefix: $W32PthreadsPrefix")
+$lines.Add("- CMakeModulePath: $CMakeModulePath")
+$lines.Add("- ObsRuntimePath: $ObsRuntimePath")
+$lines.Add("- QtPrefix: $QtPrefix")
+$lines.Add("- BuildDir: $BuildDir")
+$lines.Add("- Configuration: $Configuration")
+$lines.Add("")
+$lines.Add("## Checks")
+$lines.Add("")
+Add-CheckLine $lines "CMake is available" (-not [string]::IsNullOrWhiteSpace($cmake)) $cmake
+Add-CheckLine $lines "Visual Studio 2022 C++ install is detectable" (-not [string]::IsNullOrWhiteSpace($vsInstall)) $vsInstall
+Add-CheckLine $lines "MSVC cl.exe is available" (-not [string]::IsNullOrWhiteSpace($cl)) $cl
+Add-CheckLine $lines "OBS Studio x64 is installed" (-not [string]::IsNullOrWhiteSpace($obs64)) $obs64
+Add-CheckLine $lines "OBS libobs CMake package is available" (-not [string]::IsNullOrWhiteSpace($libobsConfig)) $libobsConfig
+Add-CheckLine $lines "OBS frontend API CMake package is available" (-not [string]::IsNullOrWhiteSpace($frontendConfig)) $frontendConfig
+Add-CheckLine $lines "OBS w32-pthreads CMake package is available" (-not [string]::IsNullOrWhiteSpace($w32PthreadsConfig)) $w32PthreadsConfig
+Add-CheckLine $lines "OBS deps SIMDe headers are available" (-not [string]::IsNullOrWhiteSpace($simdeHeaders)) $simdeHeaders
+Add-CheckLine $lines "OBS CMake finder modules are available" (-not [string]::IsNullOrWhiteSpace($moduleFinder)) $moduleFinder
+Add-CheckLine $lines "Qt root is detectable in a common location" (-not [string]::IsNullOrWhiteSpace($knownQtRoot)) $knownQtRoot
+Add-CheckLine $lines "Qt6 CMake package is available" (-not [string]::IsNullOrWhiteSpace($qtConfig)) $qtConfig
+Add-CheckLine $lines "PowerShell process has a single PATH key for MSBuild" (-not $hasDuplicatePathKeys) (($pathKeys -join "; "))
+Add-CheckLine $lines "Plugin DLL artifact exists" (Test-Path -LiteralPath $artifact) $artifact
+
+$lines.Add("")
+$lines.Add("## Configure Command")
+$lines.Add("")
+$lines.Add('Use a sanitized Developer Command Prompt when the environment contains both PATH and Path:')
+$lines.Add("")
+$lines.Add('```cmd')
+$lines.Add('set PATH=')
+$lines.Add('set Path=C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\Git\cmd')
+$lines.Add('call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=x64 -host_arch=x64')
+$lines.Add('"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -S app/plugin -B build/plugin -G "Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH="<obs-prefix>;<obs-frontend-api-dir>;<w32-pthreads-prefix>;<obs-deps-prefix>;<qt-prefix>" -DCMAKE_MODULE_PATH="<obs-source>\cmake\finders"')
+$lines.Add('cmake --build build/plugin --config Release')
+$lines.Add('```')
+
+if ($AttemptConfigure) {
+    $lines.Add("")
+    $lines.Add("## Configure Attempt")
+    $lines.Add("")
+    if ([string]::IsNullOrWhiteSpace($cmake)) {
+        $lines.Add("- SKIP: cmake is unavailable.")
+    } elseif ([string]::IsNullOrWhiteSpace($vsInstall)) {
+        $lines.Add("- SKIP: Visual Studio Build Tools install was not found.")
+    } else {
+        $prefixes = New-Object System.Collections.Generic.List[string]
+        if (-not [string]::IsNullOrWhiteSpace($ObsPrefix)) {
+            $prefixes.Add($ObsPrefix)
+        }
+        if (-not [string]::IsNullOrWhiteSpace($ObsFrontendApiDir)) {
+            $prefixes.Add($ObsFrontendApiDir)
+        }
+        if (-not [string]::IsNullOrWhiteSpace($W32PthreadsPrefix)) {
+            $prefixes.Add($W32PthreadsPrefix)
+        }
+        if (-not [string]::IsNullOrWhiteSpace($ObsDepsPrefix)) {
+            $prefixes.Add($ObsDepsPrefix)
+        }
+        if (-not [string]::IsNullOrWhiteSpace($QtPrefix)) {
+            $prefixes.Add($QtPrefix)
+        }
+        $args = @("-S", "app/plugin", "-B", $BuildDir, "-G", "Visual Studio 17 2022", "-A", "x64")
+        if ($prefixes.Count -gt 0) {
+            $args += "-DCMAKE_PREFIX_PATH=$($prefixes -join ';')"
+        }
+        if (-not [string]::IsNullOrWhiteSpace($CMakeModulePath)) {
+            $args += "-DCMAKE_MODULE_PATH=$CMakeModulePath"
+        }
+        $vsDevCmd = Join-Path $vsInstall "Common7\Tools\VsDevCmd.bat"
+        $safePath = "C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\Git\cmd"
+        $cmakeArgs = @($args | ForEach-Object {
+            if ($_ -match "\s|;") {
+                '"' + ($_ -replace '"', '\"') + '"'
+            } else {
+                $_
+            }
+        }) -join " "
+        $commandLine = "set PATH=& set Path=$safePath& call `"$vsDevCmd`" -arch=x64 -host_arch=x64 && `"$cmake`" $cmakeArgs"
+        $lines.Add("- Command: $commandLine")
+        & cmd.exe /d /s /c $commandLine
+        $lines.Add("- Exit code: $LASTEXITCODE")
+    }
+}
+
+$lines | ForEach-Object { Write-Output $_ }


### PR DESCRIPTION
## Summary

- add `scripts/check_v0_11_obs_smoke_env.ps1` for v0.11 OBS smoke environment detection
- document the v0.11 OBS plugin smoke procedure, including sanitized VS Developer Command Prompt usage
- link the smoke procedure from docs index, traceability, acceptance, and release readiness docs
- support OBS source build tree inputs for `libobs`, `obs-frontend-api`, `w32-pthreads`, OBS deps, finder modules, Qt 6, and portable OBS runtime

## Local smoke evidence

- Generated `build/plugin/Release/obs-duel-recorder.dll`
- Verified environment check resolves existing `_smoke` OBS build tree, Qt 6.8.3, OBS runtime, and the generated DLL
- Launched portable OBS 32.1.2 with the generated plugin DLL
- OBS log confirmed:
  - `OBS Duel Recorder plugin startup`
  - `OBS Duel Recorder frontend ready`
  - `OBS Duel Recorder dock registered id=obs-duel-recorder-status`
  - overlay Text Source reuse and update lines
  - Worker reuse with API `2.3` and Worker version `2.3.0`
  - heartbeat baseline

## Remaining v0.11 smoke gaps

- graceful OBS shutdown log was not captured because automated close did not exit OBS cleanly
- manual recording start/stop controls were not exercised interactively

## Validation

- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `python scripts\build_docs_site.py --root . --output build\docs-site`
- `git diff --check`

Progresses #393.
Progresses #387.