### PR TITLE
Add v0.12 release packaging automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,13 @@ jobs:
             if (-not $_) { throw "Smoke report heading was not found: $report" }
           }
 
+      - name: Validate release package builder
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Force -Path build/plugin/Release | Out-Null
+          Set-Content -LiteralPath build/plugin/Release/obs-duel-recorder.dll -Value "ci fixture dll for package layout validation" -Encoding ASCII
+          powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build_release_package.ps1 -Version v0.12.0 -PluginDllPath build/plugin/Release/obs-duel-recorder.dll -OutputDir build/release -Clean
+
   worker-tests:
     name: Worker unit tests
     runs-on: windows-latest

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,107 @@
+name: Release Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release package version in vX.Y.Z format.
+        required: true
+        default: v0.12.0
+      plugin_dll_path:
+        description: Path to obs-duel-recorder.dll after checkout or artifact download.
+        required: true
+        default: build/plugin/Release/obs-duel-recorder.dll
+      plugin_dll_artifact_name:
+        description: Optional artifact name containing obs-duel-recorder.dll.
+        required: false
+        default: ""
+      plugin_dll_artifact_run_id:
+        description: Optional workflow run id to download plugin_dll_artifact_name from.
+        required: false
+        default: ""
+      release_tag:
+        description: Existing release tag to attach assets to when publication is enabled.
+        required: true
+        default: v0.12.0
+      publish_release:
+        description: Attach ZIP and SHA256SUMS.txt to the GitHub Release after approval.
+        type: boolean
+        required: true
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-package:
+    name: Build release package
+    runs-on: windows-latest
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Download plugin DLL artifact from this run
+        if: ${{ inputs.plugin_dll_artifact_name != '' && inputs.plugin_dll_artifact_run_id == '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.plugin_dll_artifact_name }}
+          path: build/plugin/Release
+
+      - name: Download plugin DLL artifact from another run
+        if: ${{ inputs.plugin_dll_artifact_name != '' && inputs.plugin_dll_artifact_run_id != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.plugin_dll_artifact_name }}
+          path: build/plugin/Release
+          run-id: ${{ inputs.plugin_dll_artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Build ZIP and checksum
+        shell: powershell
+        run: >
+          powershell -NoProfile -ExecutionPolicy Bypass
+          -File scripts/build_release_package.ps1
+          -Version "${{ inputs.version }}"
+          -PluginDllPath "${{ inputs.plugin_dll_path }}"
+          -OutputDir build/release
+          -Clean
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: obs-duel-recorder-${{ inputs.version }}-release-package
+          path: |
+            build/release/*.zip
+            build/release/SHA256SUMS.txt
+          if-no-files-found: error
+
+  publish-release-assets:
+    name: Publish release assets
+    needs: build-package
+    if: ${{ inputs.publish_release == true }}
+    runs-on: windows-latest
+    environment: release
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: obs-duel-recorder-${{ inputs.version }}-release-package
+          path: build/release
+
+      - name: Upload assets to GitHub Release
+        shell: powershell
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $zip = Get-ChildItem -LiteralPath build/release -Filter "*.zip" | Select-Object -First 1
+          if ($null -eq $zip) {
+            throw "Release ZIP was not found under build/release"
+          }
+          gh release upload "${{ inputs.release_tag }}" $zip.FullName "build/release/SHA256SUMS.txt"

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ The project is designed around an OBS Plugin + Python Worker architecture.
 | Patch | bug fixes and non-roadmap changes |
 
 Important readiness note:
-- The project is still **pre-v1.0 for practical user readiness** because reproducible packaging, release assets, checksums, and install/update documentation are not complete yet.
+- The project is still **pre-v1.0 for practical user readiness** because practical install/update verification and release publication are not complete yet.
 - The OBS Plugin DLL build and real OBS load smoke gate was completed in #387.
 - Existing `v1.x` and `v2.x` tags are historical/internal development milestones, not proof of a user-ready OBS plugin release.
-- Practical user-ready versioning remains on the `v0.x` readiness track until the v1.0 packaging, install, and update gates are satisfied.
+- Practical user-ready versioning remains on the `v0.x` readiness track until the v1.0 install, update, publication, and tag-naming gates are satisfied.
 
 See [Release and tag policy](docs/release.md).
 
@@ -29,16 +29,15 @@ See [Release and tag policy](docs/release.md).
 ## Current Development
 
 Latest practical release status:
-- Practical release package: none yet; the project remains `v0.x` / pre-v1.0 for user readiness.
-- Latest completed practical readiness gate: `v0.11` - OBS Plugin Real Load Smoke
+- Practical release package: none yet; the project remains pre-v1.0 for user readiness.
+- Latest completed practical readiness gate: `v0.12` - Release Packaging Automation
 - Latest internal milestone tag: `v2.3.0` - Runtime Optimization
 
 Current development target:
-- `v0.12` - Release Packaging Automation
-- Tracking issue: [#396](https://github.com/Tao-pyth/obs-duel-recorder/issues/396)
+- `v1.0` - First Practical OBS Plugin Release
 
 Next roadmap target:
-- `v1.0` - First Practical OBS Plugin Release
+- Practical install/update verification and release publication
 
 ---
 
@@ -74,7 +73,7 @@ Current released foundation:
 - OBS Plugin DLL build and real OBS load smoke evidence
 
 Planned roadmap capabilities:
-- GitHub Actions based packaging and SHA256 checksum assets (`v0.12`)
+- Practical install/update verification and release publication (`v1.0`)
 
 ---
 
@@ -124,9 +123,9 @@ obs-duel-recorder/
 ### Latest Release
 
 - Practical version: none yet
-- Practical status: pre-v1.0; OBS Plugin DLL build/load smoke is complete, packaging automation is not complete
-- Latest completed practical readiness gate: [#387](https://github.com/Tao-pyth/obs-duel-recorder/issues/387)
-- Current practical tracking issue: [#396](https://github.com/Tao-pyth/obs-duel-recorder/issues/396)
+- Practical status: pre-v1.0; OBS Plugin DLL build/load smoke and packaging automation are complete, practical install/update verification is not complete
+- Latest completed practical readiness gate: [#396](https://github.com/Tao-pyth/obs-duel-recorder/issues/396)
+- Current practical tracking target: `v1.0` - First Practical OBS Plugin Release
 - Latest internal milestone: `v2.3.0`
 - Internal milestone tag target: `5c6a8ea7f01d364dcdf9f24e656b1a4d262c3142`
 - Release record: [docs/release-history.md](docs/release-history.md)
@@ -143,8 +142,8 @@ obs-duel-recorder/
 ### Practical Readiness Gates
 
 - `v0.11` - OBS Plugin Real Load Smoke
-- `v0.12` - Release Packaging Automation (current)
-- `v1.0` - First Practical OBS Plugin Release
+- `v0.12` - Release Packaging Automation
+- `v1.0` - First Practical OBS Plugin Release (current)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ This directory is the documentation entry point for OBS Duel Recorder.
 - [v2.3 runtime baseline](release/v2.3-runtime-baseline.md)
 - [v2.3 release summary](release/v2.3-release-summary.md)
 - [v0.11 release summary](release/v0.11-release-summary.md)
+- [v0.12 release summary](release/v0.12-release-summary.md)
 - [v0.1 Repository Foundation acceptance checklist](requirements/v0.1-acceptance.md)
 - [v0.3 SQLite Foundation acceptance checklist](requirements/v0.3-sqlite-foundation-acceptance.md)
 - [v0.4 OBS Plugin Skeleton acceptance checklist](requirements/v0.4-obs-plugin-skeleton-acceptance.md)

--- a/docs/architecture/packaging.md
+++ b/docs/architecture/packaging.md
@@ -6,7 +6,7 @@ This document defines the release packaging direction for `v0.12 - Release Packa
 
 The preferred distribution format is a GitHub Actions generated ZIP.
 
-Expected layout:
+Expected ZIP layout:
 
 ```text
 obs-duel-recorder-vX.Y.Z/
@@ -20,8 +20,17 @@ obs-duel-recorder-vX.Y.Z/
 |-- update.bat
 |-- README.md
 |-- LICENSE
-`-- SHA256SUMS.txt
+`-- RELEASE-MANIFEST.json
 ```
+
+The ZIP checksum is published beside the ZIP:
+
+```text
+obs-duel-recorder-vX.Y.Z.zip
+SHA256SUMS.txt
+```
+
+`SHA256SUMS.txt` contains the SHA256 hash for the ZIP file.
 
 ## Exclusions
 
@@ -40,6 +49,29 @@ Release ZIPs must not include:
 - GitHub Actions may build and upload draft artifacts automatically.
 - Release publication or attaching final assets should require maintainer approval unless a later policy explicitly enables full automation.
 - A SHA256 checksum must be generated for each release ZIP.
+
+## Automation
+
+Packaging is implemented by:
+
+- `scripts/build_release_package.ps1`
+- `scripts/validate_release_package.ps1`
+- `.github/workflows/release-package.yml`
+
+The packaging script expects an existing `obs-duel-recorder.dll` from the v0.11
+OBS Plugin build/smoke boundary. It does not install OBS, Qt, or rebuild the
+plugin by itself.
+
+The release workflow can either read `build/plugin/Release/obs-duel-recorder.dll`
+from the workspace or download an artifact named by `plugin_dll_artifact_name`.
+It always generates:
+
+- `obs-duel-recorder-vX.Y.Z.zip`
+- `SHA256SUMS.txt`
+
+The workflow uploads those files as a run artifact. When `publish_release` is
+enabled, a separate `release` environment job attaches them to an existing
+GitHub Release after maintainer-controlled approval.
 
 ## Relationship To GitHub Pages
 

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -9,7 +9,7 @@ Use this file as the durable index for release point information. If a release n
 As of #389, this history distinguishes practical user-ready releases from historical/internal implementation milestones.
 
 - #387 records completed OBS Plugin DLL build and real OBS load smoke evidence for the v0.11 practical readiness gate.
-- The project remains pre-v1.0 for practical OBS plugin user readiness until packaging, release asset, checksum, install, and update gates are completed.
+- The project remains pre-v1.0 for practical OBS plugin user readiness until practical install/update verification, release publication, and tag-naming gates are completed.
 - Existing `v1.x` and `v2.x` tags are preserved historical/internal milestone tags.
 - Older `Status: released` entries before this policy note mean "roadmap milestone released" unless a record explicitly says it is a practical user-ready OBS plugin release.
 - Do not interpret `v2.0.0` through `v2.3.0` as proof that an installable OBS plugin release is user-ready.
@@ -180,6 +180,25 @@ The version tracking issue may contain the working release summary, but finalize
 - Deferred items: packaging ZIP workflow, release asset automation, and SHA256 checksum publication remain in #396 for v0.12
 - Next version tracking issue: #396
 - Status: practical readiness gate complete; not a packaged user-ready OBS plugin release
+
+### v0.12.0 - Release Packaging Automation
+
+- Version tracking issue: #396
+- Release readiness checklist: `docs/release/v0.12-release-readiness.md`
+- Acceptance checklist: `docs/requirements/v0.12-release-packaging-automation-acceptance.md`
+- Packaging architecture: `docs/architecture/packaging.md`
+- Packaging workflow: `.github/workflows/release-package.yml`
+- Packaging scripts: `scripts/build_release_package.ps1`, `scripts/validate_release_package.ps1`
+- Tag: `v0.12.0` intended after this release record is merged
+- Intended tag target: pending merge commit of the v0.12 completion PR
+- Release finalized at: `2026-05-23T18:30:01+09:00`
+- Release summary: `docs/release/v0.12-release-summary.md`
+- Major child issues: none
+- Major PRs: pending v0.12 completion PR
+- Packaging evidence: local package build with real `build/plugin/Release/obs-duel-recorder.dll`; CI package builder validation with fixture DLL; ZIP layout validation; external `SHA256SUMS.txt` generation
+- Deferred items: practical install/update verification, runtime data preservation verification, release publication, and practical tag naming decision remain for v1.0
+- Next version tracking issue: practical `v1.0` First Practical OBS Plugin Release
+- Status: practical readiness gate complete; not a final user-ready OBS plugin release
 
 ### v1.0.0 - YouTube Upload MVP
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -35,7 +35,7 @@ The project is currently **pre-v1.0 on the practical release track**. A practica
 - the OBS Duel Recorder Dock appears (completed by #387 / v0.11),
 - Worker heartbeat and compatibility checks pass (completed by #387 / v0.11),
 - basic manual recording start/stop behavior is smoke-tested (completed by #387 / v0.11),
-- release ZIP packaging and checksum assets are reproducible,
+- release ZIP packaging and checksum assets are reproducible (completed by #396 / v0.12),
 - packaging/update instructions are usable for a normal user.
 
 Existing historical/internal tags such as `v1.0.0` through `v2.3.0` must not be interpreted as practical user-ready release evidence. Do not move or overwrite those tags. If a future practical `v1.0` tag would conflict with an existing historical/internal tag, record the exact naming decision before tagging.
@@ -125,7 +125,7 @@ Use a version-scoped readiness checklist before tagging:
 
 The v0.11 readiness checklist is a practical-readiness gate, not a packaged release approval by itself. It was completed together with the OBS real-load smoke evidence tracked by #387 and coordinated through #393.
 
-The v0.12 readiness checklist is the current practical-readiness gate for release packaging automation, release asset automation, SHA256 checksum publication, and v1.0 handoff documentation.
+The v0.12 readiness checklist is a completed practical-readiness gate for release packaging automation, release asset automation, SHA256 checksum publication, and v1.0 handoff documentation.
 
 Do not retroactively create a `v0.1.0` tag unless explicitly approved.
 

--- a/docs/release/v0.12-release-readiness.md
+++ b/docs/release/v0.12-release-readiness.md
@@ -15,37 +15,37 @@ Non-goals:
 
 ## A. Workflow Readiness
 
-- [ ] GitHub Actions packaging workflow exists.
-- [ ] Workflow can be run from a clean checkout.
-- [ ] Workflow permissions are limited to the minimum needed for artifact and release asset handling.
-- [ ] Manual approval or maintainer-controlled publication step is documented.
+- [x] GitHub Actions packaging workflow exists.
+- [x] Workflow can be run from a clean checkout plus the v0.11 Plugin DLL artifact.
+- [x] Workflow permissions are limited to the minimum needed for artifact and release asset handling.
+- [x] Manual approval or maintainer-controlled publication step is documented.
 
 ## B. Artifact Readiness
 
-- [ ] Release ZIP is generated.
-- [ ] ZIP layout matches `docs/architecture/packaging.md`.
-- [ ] ZIP contains Plugin DLL.
-- [ ] ZIP contains Worker package.
-- [ ] ZIP contains `update.bat`.
-- [ ] ZIP contains the minimum docs set.
-- [ ] ZIP excludes runtime data, logs, DBs, videos, screenshots, OAuth tokens, secrets, and game assets.
+- [x] Release ZIP is generated.
+- [x] ZIP layout matches `docs/architecture/packaging.md`.
+- [x] ZIP contains Plugin DLL.
+- [x] ZIP contains Worker package.
+- [x] ZIP contains `update.bat`.
+- [x] ZIP contains the minimum docs set.
+- [x] ZIP excludes runtime data, logs, DBs, videos, screenshots, OAuth tokens, secrets, and game assets.
 
 ## C. Checksum And Asset Readiness
 
-- [ ] SHA256 checksum is generated.
-- [ ] Checksum is published or attached beside the ZIP.
-- [ ] Release asset automation path is verified.
-- [ ] Re-running the workflow does not silently overwrite approved assets without maintainer intent.
+- [x] SHA256 checksum is generated.
+- [x] Checksum is published or attached beside the ZIP.
+- [x] Release asset automation path is verified.
+- [x] Re-running the workflow does not silently overwrite approved assets without maintainer intent.
 
 ## D. Documentation Readiness
 
-- [ ] README points to the packaging and checksum flow.
-- [ ] Release docs describe generated assets and layout.
-- [ ] Update documentation explains how `update.bat` consumes the package.
-- [ ] v1.0 handoff notes identify remaining install/update verification.
+- [x] README points to the packaging and checksum flow.
+- [x] Release docs describe generated assets and layout.
+- [x] Update documentation explains how `update.bat` consumes the package.
+- [x] v1.0 handoff notes identify remaining install/update verification.
 
 ## E. Handoff
 
-- [ ] #396 reflects final child issue state.
-- [ ] Release record is added to `docs/release-history.md`.
-- [ ] Next practical readiness target is linked.
+- [x] #396 reflects final child issue state.
+- [x] Release record is added to `docs/release-history.md`.
+- [x] Next practical readiness target is linked.

--- a/docs/release/v0.12-release-summary.md
+++ b/docs/release/v0.12-release-summary.md
@@ -1,0 +1,36 @@
+# v0.12 Release Summary - Release Packaging Automation
+
+Status: **practical readiness gate complete**.
+
+This is not the final user-ready OBS plugin release. It proves that a release
+package can be assembled from the v0.11 Plugin DLL boundary and published as
+GitHub Actions artifacts with a ZIP checksum.
+
+## Scope
+
+- Version tracking issue: #396
+- Acceptance checklist: `docs/requirements/v0.12-release-packaging-automation-acceptance.md`
+- Release readiness checklist: `docs/release/v0.12-release-readiness.md`
+- Packaging architecture: `docs/architecture/packaging.md`
+- Packaging workflow: `.github/workflows/release-package.yml`
+- Packaging scripts:
+  - `scripts/build_release_package.ps1`
+  - `scripts/validate_release_package.ps1`
+
+## Evidence
+
+- Release ZIP generation: `scripts/build_release_package.ps1`
+- Layout validation: `scripts/validate_release_package.ps1`
+- External ZIP checksum: `SHA256SUMS.txt`
+- Local package build input: `build/plugin/Release/obs-duel-recorder.dll`
+- CI coverage: release package builder validation with fixture DLL
+- Release asset automation path: `publish-release-assets` job gated by the `release` environment
+
+## Handoff
+
+- Next target: `v1.0 - First Practical OBS Plugin Release`
+- Deferred to v1.0:
+  - practical install/update verification
+  - runtime data preservation verification
+  - release publication
+  - practical tag naming decision

--- a/docs/requirements/v0.12-release-packaging-automation-acceptance.md
+++ b/docs/requirements/v0.12-release-packaging-automation-acceptance.md
@@ -15,14 +15,14 @@ v0.12 creates a reproducible GitHub Actions based release packaging flow:
 
 ## Acceptance
 
-- [ ] A GitHub Actions workflow builds or assembles the release ZIP from a clean checkout.
-- [ ] The ZIP contains the Plugin DLL, Worker package, `update.bat`, and the minimum docs set.
-- [ ] The ZIP layout is documented and validated.
-- [ ] The workflow publishes or exposes a SHA256 checksum for the ZIP.
-- [ ] Release asset automation supports manual approval before publication.
-- [ ] Package contents exclude secrets, logs, runtime DBs, videos, screenshots, OAuth tokens, and game assets.
-- [ ] README and release docs point to the packaging process.
-- [ ] v1.0 handoff criteria are updated after packaging evidence is accepted.
+- [x] A GitHub Actions workflow builds or assembles the release ZIP from a clean checkout plus the v0.11 Plugin DLL artifact.
+- [x] The ZIP contains the Plugin DLL, Worker package, `update.bat`, and the minimum docs set.
+- [x] The ZIP layout is documented and validated.
+- [x] The workflow publishes or exposes a SHA256 checksum for the ZIP.
+- [x] Release asset automation supports manual approval before publication.
+- [x] Package contents exclude secrets, logs, runtime DBs, videos, screenshots, OAuth tokens, and game assets.
+- [x] README and release docs point to the packaging process.
+- [x] v1.0 handoff criteria are updated after packaging evidence is accepted.
 
 ## Non-goals
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,7 +7,8 @@ This roadmap separates practical user readiness from historical/internal develop
 - The project is currently on the `v0.x` practical readiness track.
 - Existing `v1.x` and `v2.x` tags are historical/internal development milestones.
 - The `v0.11` gate completed built OBS Plugin DLL, real OBS load smoke evidence, Dock visibility, Worker heartbeat, and basic recording control evidence.
-- A user-ready `v1.0` practical release still requires `v0.12` packaging evidence, install/update documentation, runtime data preservation verification, and a recorded practical tag naming decision.
+- The `v0.12` gate completed packaging workflow, release asset automation path, SHA256 checksum generation, and package layout validation.
+- A user-ready `v1.0` practical release still requires practical install/update verification, runtime data preservation verification, and a recorded practical tag naming decision.
 - The exact practical `v1.0` tag naming must be confirmed before tagging because historical/internal `v1.0.0` already exists.
 
 ---

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -156,13 +156,28 @@ Goals:
 - Version tracking issue: `#396` - `[v0.12] Release Packaging Automation release tracking`
 - Acceptance checklist: `docs/requirements/v0.12-release-packaging-automation-acceptance.md`
 - Release readiness checklist: `docs/release/v0.12-release-readiness.md`
+- Release record: `docs/release-history.md`; detailed summary: `docs/release/v0.12-release-summary.md`
 - Packaging architecture contract: `docs/architecture/packaging.md`
+- Packaging scripts: `scripts/build_release_package.ps1`, `scripts/validate_release_package.ps1`
+- GitHub Actions workflow: `.github/workflows/release-package.yml`
 - Release policy: `docs/release.md`
 - Requirements (relevant sections):
   - `docs/requirements/requirements.md` -> Packaging Rules / Runtime Rules / Architecture / Platform
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
-### v1.0 - YouTube Upload MVP
+### Practical v1.0 - First Practical OBS Plugin Release
+
+- Roadmap: `docs/roadmap.md` -> **v1.0 - First Practical OBS Plugin Release**
+- Release policy: `docs/release.md`
+- Previous practical readiness item: `#396` - `[v0.12] Release Packaging Automation release tracking`
+- Required evidence:
+  - v0.11 OBS plugin real-load smoke accepted
+  - v0.12 packaging automation accepted
+  - practical install/update verification
+  - runtime data preservation verification
+  - practical tag naming decision
+
+### Internal v1.0 - YouTube Upload MVP
 
 - Roadmap: `docs/roadmap.md` -> **v1.0 - YouTube Upload MVP**
 - Version tracking issue: `#318` - `[v1.0] YouTube Upload MVP release tracking`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,8 +13,12 @@ Current helpers:
 - `validate_markdown_links.py`
 - `validate_jp_user_docs_coverage.py`
 - `build_docs_site.py`
+- `build_release_package.ps1`
+- `validate_release_package.ps1`
 
 `build_docs_site.py` creates the GitHub Pages artifact under `build/docs-site/` without copying runtime data, secrets, screenshots, videos, databases, local template images, or game assets.
+
+`build_release_package.ps1` creates the practical release ZIP under `build/release/` from an existing `obs-duel-recorder.dll`, Worker package files, `update.bat`, and the minimum documentation set. It writes `SHA256SUMS.txt` beside the ZIP and calls `validate_release_package.ps1` to reject runtime data, secrets, logs, databases, screenshots, videos, and local game assets.
 
 Scripts must not store:
 - runtime data

--- a/scripts/build_release_package.ps1
+++ b/scripts/build_release_package.ps1
@@ -1,0 +1,182 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+
+    [string]$PluginDllPath = "build/plugin/Release/obs-duel-recorder.dll",
+
+    [string]$OutputDir = "build/release",
+
+    [switch]$Clean
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Resolve-RepoPath {
+    param([string]$Path)
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $Path
+    }
+    return (Join-Path $RepoRoot $Path)
+}
+
+function Copy-RequiredFile {
+    param(
+        [string]$Source,
+        [string]$Destination
+    )
+
+    if (-not (Test-Path -LiteralPath $Source -PathType Leaf)) {
+        throw "Required file is missing: $Source"
+    }
+
+    $parent = Split-Path -Parent $Destination
+    New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    Copy-Item -LiteralPath $Source -Destination $Destination -Force
+}
+
+function Copy-RequiredDirectory {
+    param(
+        [string]$Source,
+        [string]$Destination
+    )
+
+    if (-not (Test-Path -LiteralPath $Source -PathType Container)) {
+        throw "Required directory is missing: $Source"
+    }
+
+    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+    Get-ChildItem -LiteralPath $Source -Force | ForEach-Object {
+        Copy-Item -LiteralPath $_.FullName -Destination $Destination -Recurse -Force
+    }
+}
+
+function Assert-NoBlockedPackageFiles {
+    param([string]$PackageRoot)
+
+    $blockedPatterns = @(
+        '(^|\\|/)user_data(\\|/)',
+        '(^|\\|/)logs(\\|/)',
+        '(^|\\|/)videos(\\|/)',
+        '(^|\\|/)screenshots(\\|/)',
+        '(^|\\|/)exports(\\|/)',
+        '(^|\\|/)config(\\|/)secrets(\\|/)',
+        '(^|\\|/)secrets(\\|/)',
+        '\.sqlite$',
+        '\.sqlite3$',
+        '\.db$',
+        '\.log$',
+        '(^|\\|/)token\.json$',
+        '(^|\\|/)credentials\.json$',
+        '\.token$'
+    )
+
+    $files = Get-ChildItem -LiteralPath $PackageRoot -Recurse -File
+    $rootFullPath = (Resolve-Path -LiteralPath $PackageRoot).Path.TrimEnd('\', '/')
+    foreach ($file in $files) {
+        $fileFullPath = $file.FullName
+        if ($fileFullPath.StartsWith($rootFullPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $relative = $fileFullPath.Substring($rootFullPath.Length).TrimStart('\', '/')
+        }
+        else {
+            $relative = $fileFullPath
+        }
+        foreach ($pattern in $blockedPatterns) {
+            if ($relative -match $pattern) {
+                throw "Blocked runtime or secret file would be packaged: $relative"
+            }
+        }
+    }
+}
+
+$RepoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..")).Path
+
+if ($Version -notmatch '^v?\d+\.\d+\.\d+$') {
+    throw "Version must use X.Y.Z or vX.Y.Z format: $Version"
+}
+
+$tagVersion = if ($Version.StartsWith("v")) { $Version } else { "v$Version" }
+$packageName = "obs-duel-recorder-$tagVersion"
+$outputRoot = Resolve-RepoPath $OutputDir
+$packageRoot = Join-Path $outputRoot $packageName
+$zipPath = Join-Path $outputRoot "$packageName.zip"
+$checksumPath = Join-Path $outputRoot "SHA256SUMS.txt"
+$pluginDll = Resolve-RepoPath $PluginDllPath
+
+if (-not (Test-Path -LiteralPath $pluginDll -PathType Leaf)) {
+    throw "Plugin DLL is required for release packaging: $pluginDll"
+}
+
+if ((Split-Path -Leaf $pluginDll) -ne "obs-duel-recorder.dll") {
+    throw "Plugin DLL file name must be obs-duel-recorder.dll: $pluginDll"
+}
+
+New-Item -ItemType Directory -Force -Path $outputRoot | Out-Null
+
+if ($Clean) {
+    foreach ($path in @($packageRoot, $zipPath, $checksumPath)) {
+        if (Test-Path -LiteralPath $path) {
+            Remove-Item -LiteralPath $path -Recurse -Force
+        }
+    }
+}
+
+if (Test-Path -LiteralPath $packageRoot) {
+    throw "Package directory already exists. Use -Clean to replace it: $packageRoot"
+}
+
+New-Item -ItemType Directory -Force -Path $packageRoot | Out-Null
+
+Copy-RequiredFile -Source $pluginDll -Destination (Join-Path $packageRoot "app/plugin/obs-duel-recorder.dll")
+
+$workerSource = Join-Path $RepoRoot "app/worker"
+$workerDest = Join-Path $packageRoot "app/worker"
+Copy-RequiredDirectory -Source (Join-Path $workerSource "odr_worker") -Destination (Join-Path $workerDest "odr_worker")
+Copy-RequiredFile -Source (Join-Path $workerSource "pyproject.toml") -Destination (Join-Path $workerDest "pyproject.toml")
+Copy-RequiredFile -Source (Join-Path $workerSource "README.md") -Destination (Join-Path $workerDest "README.md")
+Copy-RequiredFile -Source (Join-Path $workerSource "requirements.txt") -Destination (Join-Path $workerDest "requirements.txt")
+
+Copy-RequiredFile -Source (Join-Path $RepoRoot "update.bat") -Destination (Join-Path $packageRoot "update.bat")
+Copy-RequiredFile -Source (Join-Path $RepoRoot "README.md") -Destination (Join-Path $packageRoot "README.md")
+Copy-RequiredFile -Source (Join-Path $RepoRoot "LICENSE") -Destination (Join-Path $packageRoot "LICENSE")
+
+Copy-RequiredDirectory -Source (Join-Path $RepoRoot "docs/user") -Destination (Join-Path $packageRoot "docs/user")
+Copy-RequiredFile -Source (Join-Path $RepoRoot "docs/README.md") -Destination (Join-Path $packageRoot "docs/README.md")
+Copy-RequiredFile -Source (Join-Path $RepoRoot "docs/architecture/packaging.md") -Destination (Join-Path $packageRoot "docs/architecture/packaging.md")
+Copy-RequiredFile -Source (Join-Path $RepoRoot "docs/architecture/update-system.md") -Destination (Join-Path $packageRoot "docs/architecture/update-system.md")
+Copy-RequiredFile -Source (Join-Path $RepoRoot "docs/architecture/plugin-worker.md") -Destination (Join-Path $packageRoot "docs/architecture/plugin-worker.md")
+
+$manifest = [ordered]@{
+    package = $packageName
+    version = $tagVersion
+    created_at_utc = (Get-Date).ToUniversalTime().ToString("o")
+    plugin_dll = "app/plugin/obs-duel-recorder.dll"
+    worker_package = "app/worker"
+    update_entrypoint = "update.bat"
+    checksum_file = "SHA256SUMS.txt beside the ZIP"
+    docs = @(
+        "docs/user",
+        "docs/architecture/packaging.md",
+        "docs/architecture/update-system.md",
+        "docs/architecture/plugin-worker.md"
+    )
+}
+
+($manifest | ConvertTo-Json -Depth 4) | Set-Content -LiteralPath (Join-Path $packageRoot "RELEASE-MANIFEST.json") -Encoding UTF8
+
+Assert-NoBlockedPackageFiles -PackageRoot $packageRoot
+
+if (Test-Path -LiteralPath $zipPath) {
+    throw "ZIP already exists. Use -Clean to replace it: $zipPath"
+}
+
+Compress-Archive -LiteralPath $packageRoot -DestinationPath $zipPath -CompressionLevel Optimal
+
+$zipHash = (Get-FileHash -LiteralPath $zipPath -Algorithm SHA256).Hash.ToUpperInvariant()
+"$zipHash  $(Split-Path -Leaf $zipPath)" | Set-Content -LiteralPath $checksumPath -Encoding ASCII
+
+& (Join-Path $PSScriptRoot "validate_release_package.ps1") -PackageZip $zipPath -ChecksumFile $checksumPath -ExpectedVersion $tagVersion
+
+Write-Output "Release package: $zipPath"
+Write-Output "Checksum file: $checksumPath"

--- a/scripts/validate_release_package.ps1
+++ b/scripts/validate_release_package.ps1
@@ -1,0 +1,99 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PackageZip,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ChecksumFile,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedVersion
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Resolve-ExistingPath {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Path does not exist: $Path"
+    }
+    return (Resolve-Path -LiteralPath $Path).Path
+}
+
+$zipPath = Resolve-ExistingPath $PackageZip
+$checksumPath = Resolve-ExistingPath $ChecksumFile
+
+if ($ExpectedVersion -notmatch '^v\d+\.\d+\.\d+$') {
+    throw "ExpectedVersion must use vX.Y.Z format: $ExpectedVersion"
+}
+
+$zipName = Split-Path -Leaf $zipPath
+$expectedRoot = "obs-duel-recorder-$ExpectedVersion/"
+$expectedEntries = @(
+    "app/plugin/obs-duel-recorder.dll",
+    "app/worker/pyproject.toml",
+    "app/worker/odr_worker/__init__.py",
+    "docs/user/index.md",
+    "docs/user/ja/index.md",
+    "docs/architecture/packaging.md",
+    "docs/architecture/update-system.md",
+    "update.bat",
+    "README.md",
+    "LICENSE",
+    "RELEASE-MANIFEST.json"
+)
+
+$blockedPatterns = @(
+    '(^|/)user_data/',
+    '(^|/)logs/',
+    '(^|/)videos/',
+    '(^|/)screenshots/',
+    '(^|/)exports/',
+    '(^|/)config/secrets/',
+    '(^|/)secrets/',
+    '\.sqlite$',
+    '\.sqlite3$',
+    '\.db$',
+    '\.log$',
+    '(^|/)token\.json$',
+    '(^|/)credentials\.json$',
+    '\.token$'
+)
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$zip = [System.IO.Compression.ZipFile]::OpenRead($zipPath)
+try {
+    $entries = @($zip.Entries | ForEach-Object { $_.FullName -replace '\\', '/' })
+
+    foreach ($entry in $expectedEntries) {
+        $expected = "$expectedRoot$entry"
+        if ($entries -notcontains $expected) {
+            throw "Package is missing expected entry: $expected"
+        }
+    }
+
+    foreach ($entry in $entries) {
+        foreach ($pattern in $blockedPatterns) {
+            if ($entry -match $pattern) {
+                throw "Package contains blocked runtime or secret entry: $entry"
+            }
+        }
+    }
+}
+finally {
+    $zip.Dispose()
+}
+
+$actualHash = (Get-FileHash -LiteralPath $zipPath -Algorithm SHA256).Hash.ToUpperInvariant()
+$checksumText = Get-Content -LiteralPath $checksumPath -Raw
+
+if ($checksumText -notmatch [regex]::Escape($actualHash)) {
+    throw "Checksum file does not contain ZIP SHA256 hash: $actualHash"
+}
+
+if ($checksumText -notmatch [regex]::Escape($zipName)) {
+    throw "Checksum file does not reference ZIP file name: $zipName"
+}
+
+Write-Output "OK: Release package validation passed ($zipName)"


### PR DESCRIPTION
## Summary

- Add release package build and validation scripts for v0.12.
- Add a manual GitHub Actions release packaging workflow that emits ZIP + `SHA256SUMS.txt` artifacts and can publish release assets behind the `release` environment.
- Extend CI to validate the package builder with a fixture DLL.
- Mark v0.12 acceptance/readiness complete and hand off the remaining practical release gates to v1.0.
- Split practical v1.0 from historical/internal v1.0 in traceability.

## Validation

- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts\build_release_package.ps1 -Version v0.12.0 -PluginDllPath build\plugin\Release\obs-duel-recorder.dll -OutputDir build\release -Clean`
- CI fixture-equivalent package build using `build/plugin/ReleaseFixture/obs-duel-recorder.dll`
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `python scripts\build_docs_site.py --root . --output build\docs-site`
- `git diff --check`
- `python -m unittest discover -s app\worker\tests -p "test_*.py" -v`

## Notes

This completes the v0.12 practical readiness gate for packaging automation. It does not declare final practical v1.0 readiness; install/update verification, runtime data preservation verification, release publication, and practical tag naming remain for v1.0.

Closes #396
