### PR TITLE
Record v0.12 tag target

### DIFF
--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -189,12 +189,13 @@ The version tracking issue may contain the working release summary, but finalize
 - Packaging architecture: `docs/architecture/packaging.md`
 - Packaging workflow: `.github/workflows/release-package.yml`
 - Packaging scripts: `scripts/build_release_package.ps1`, `scripts/validate_release_package.ps1`
-- Tag: `v0.12.0` intended after this release record is merged
-- Intended tag target: pending merge commit of the v0.12 completion PR
+- Tag: `v0.12.0`
+- Tag target: `9853d8e5840b7a7a4f9a993761a1a6538e68d28b`
 - Release finalized at: `2026-05-23T18:30:01+09:00`
+- Tag finalized at: `2026-05-23T18:38:13+09:00`
 - Release summary: `docs/release/v0.12-release-summary.md`
 - Major child issues: none
-- Major PRs: pending v0.12 completion PR
+- Major PRs: #399
 - Packaging evidence: local package build with real `build/plugin/Release/obs-duel-recorder.dll`; CI package builder validation with fixture DLL; ZIP layout validation; external `SHA256SUMS.txt` generation
 - Deferred items: practical install/update verification, runtime data preservation verification, release publication, and practical tag naming decision remain for v1.0
 - Next version tracking issue: practical `v1.0` First Practical OBS Plugin Release

--- a/docs/release/v0.12-release-summary.md
+++ b/docs/release/v0.12-release-summary.md
@@ -9,6 +9,8 @@ GitHub Actions artifacts with a ZIP checksum.
 ## Scope
 
 - Version tracking issue: #396
+- Tag: `v0.12.0`
+- Tag target: `9853d8e5840b7a7a4f9a993761a1a6538e68d28b`
 - Acceptance checklist: `docs/requirements/v0.12-release-packaging-automation-acceptance.md`
 - Release readiness checklist: `docs/release/v0.12-release-readiness.md`
 - Packaging architecture: `docs/architecture/packaging.md`


### PR DESCRIPTION
## Summary

- Record the finalized `v0.12.0` tag target in `docs/release-history.md`.
- Add the `v0.12.0` tag target to the detailed v0.12 release summary.
- Include PR #399 in the v0.12 release record.

## Validation

- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `python scripts\build_docs_site.py --root . --output build\docs-site`
- `git diff --check`

## Notes

The pushed tag is `v0.12.0`, targeting `9853d8e5840b7a7a4f9a993761a1a6538e68d28b`.
