### PR TITLE
Link practical v1 tracking issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Latest practical release status:
 
 Current development target:
 - `v1.0` - First Practical OBS Plugin Release
+- Tracking issue: [#401](https://github.com/Tao-pyth/obs-duel-recorder/issues/401)
 
 Next roadmap target:
 - Practical install/update verification and release publication
@@ -125,7 +126,7 @@ obs-duel-recorder/
 - Practical version: none yet
 - Practical status: pre-v1.0; OBS Plugin DLL build/load smoke and packaging automation are complete, practical install/update verification is not complete
 - Latest completed practical readiness gate: [#396](https://github.com/Tao-pyth/obs-duel-recorder/issues/396)
-- Current practical tracking target: `v1.0` - First Practical OBS Plugin Release
+- Current practical tracking issue: [#401](https://github.com/Tao-pyth/obs-duel-recorder/issues/401)
 - Latest internal milestone: `v2.3.0`
 - Internal milestone tag target: `5c6a8ea7f01d364dcdf9f24e656b1a4d262c3142`
 - Release record: [docs/release-history.md](docs/release-history.md)

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -197,8 +197,8 @@ The version tracking issue may contain the working release summary, but finalize
 - Major child issues: none
 - Major PRs: #399
 - Packaging evidence: local package build with real `build/plugin/Release/obs-duel-recorder.dll`; CI package builder validation with fixture DLL; ZIP layout validation; external `SHA256SUMS.txt` generation
-- Deferred items: practical install/update verification, runtime data preservation verification, release publication, and practical tag naming decision remain for v1.0
-- Next version tracking issue: practical `v1.0` First Practical OBS Plugin Release
+- Deferred items: practical install/update verification, runtime data preservation verification, release publication, and practical tag naming decision remain for #401
+- Next version tracking issue: #401
 - Status: practical readiness gate complete; not a final user-ready OBS plugin release
 
 ### v1.0.0 - YouTube Upload MVP

--- a/docs/release/v0.12-release-summary.md
+++ b/docs/release/v0.12-release-summary.md
@@ -30,6 +30,7 @@ GitHub Actions artifacts with a ZIP checksum.
 
 ## Handoff
 
+- Next version tracking issue: #401
 - Next target: `v1.0 - First Practical OBS Plugin Release`
 - Deferred to v1.0:
   - practical install/update verification

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -168,6 +168,7 @@ Goals:
 ### Practical v1.0 - First Practical OBS Plugin Release
 
 - Roadmap: `docs/roadmap.md` -> **v1.0 - First Practical OBS Plugin Release**
+- Version tracking issue: `#401` - `[Practical v1.0] First Practical OBS Plugin Release tracking`
 - Release policy: `docs/release.md`
 - Previous practical readiness item: `#396` - `[v0.12] Release Packaging Automation release tracking`
 - Required evidence:


### PR DESCRIPTION
## Summary

- Link new practical v1.0 tracking issue #401 from README, release history, v0.12 summary, and traceability.
- Keep practical v1.0 distinct from historical/internal `v1.0.0`.

## Validation

- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `python scripts\build_docs_site.py --root . --output build\docs-site`
- `git diff --check`
