### PR TITLE
Unify versioning by usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ The project is designed around an OBS Plugin + Python Worker architecture.
 | Minor | planned roadmap features |
 | Patch | bug fixes and non-roadmap changes |
 
-Important readiness note:
-- The project is still **pre-v1.0 for practical user readiness** because practical install/update verification and release publication are not complete yet.
-- The OBS Plugin DLL build and real OBS load smoke gate was completed in #387.
-- Existing `v1.x` and `v2.x` tags are historical/internal development milestones, not proof of a user-ready OBS plugin release.
-- Practical user-ready versioning remains on the `v0.x` readiness track until the v1.0 install, update, publication, and tag-naming gates are satisfied.
+Important versioning note:
+- Project versions are assigned only by user-visible usability.
+- The project is still **pre-v1.0** because install/update verification and release publication are not complete yet.
+- The OBS Plugin DLL build, real OBS load smoke, packaging workflow, and checksum gates are complete.
+- Existing `v1.x` and `v2.x` tags are legacy non-product tags from before this rule. They are not part of the active version sequence and are not proof of a usable OBS plugin release.
 
 See [Release and tag policy](docs/release.md).
 
@@ -28,17 +28,16 @@ See [Release and tag policy](docs/release.md).
 
 ## Current Development
 
-Latest practical release status:
-- Practical release package: none yet; the project remains pre-v1.0 for user readiness.
-- Latest completed practical readiness gate: `v0.12` - Release Packaging Automation
-- Latest internal milestone tag: `v2.3.0` - Runtime Optimization
+Latest release status:
+- Released user-ready version: none yet; the project remains pre-v1.0.
+- Latest completed version gate: `v0.12` - Release Packaging Automation
 
 Current development target:
-- `v1.0` - First Practical OBS Plugin Release
+- `v1.0` - First Usable OBS Plugin Release
 - Tracking issue: [#401](https://github.com/Tao-pyth/obs-duel-recorder/issues/401)
 
 Next roadmap target:
-- Practical install/update verification and release publication
+- Install/update verification and release publication
 
 ---
 
@@ -56,7 +55,7 @@ Yu-Gi-Oh! Master Duel assets are not distributed with this software.
 
 Status note: This list includes current foundations and planned roadmap capabilities. For release availability, use [Current Development](#current-development), [Current Status](#current-status), and the [Roadmap](docs/roadmap.md) as the source of truth.
 
-Current released foundation:
+Completed foundation:
 - SQLite runtime storage foundation
 - Worker runtime, health, logging, and migration foundations
 - OBS Plugin skeleton and Worker lifecycle management
@@ -74,7 +73,7 @@ Current released foundation:
 - OBS Plugin DLL build and real OBS load smoke evidence
 
 Planned roadmap capabilities:
-- Practical install/update verification and release publication (`v1.0`)
+- Install/update verification and release publication (`v1.0`)
 
 ---
 
@@ -123,28 +122,26 @@ obs-duel-recorder/
 
 ### Latest Release
 
-- Practical version: none yet
-- Practical status: pre-v1.0; OBS Plugin DLL build/load smoke and packaging automation are complete, practical install/update verification is not complete
-- Latest completed practical readiness gate: [#396](https://github.com/Tao-pyth/obs-duel-recorder/issues/396)
-- Current practical tracking issue: [#401](https://github.com/Tao-pyth/obs-duel-recorder/issues/401)
-- Latest internal milestone: `v2.3.0`
-- Internal milestone tag target: `5c6a8ea7f01d364dcdf9f24e656b1a4d262c3142`
+- Released user-ready version: none yet
+- Status: pre-v1.0; OBS Plugin DLL build/load smoke and packaging automation are complete, install/update verification is not complete
+- Latest completed version gate: [#396](https://github.com/Tao-pyth/obs-duel-recorder/issues/396)
+- Current version tracking issue: [#401](https://github.com/Tao-pyth/obs-duel-recorder/issues/401)
 - Release record: [docs/release-history.md](docs/release-history.md)
 
-### Completed Internal Milestone v2.3
+### Completed Legacy Implementation Work
 
 - SQL aggregation for upload status counts without queue item materialization
 - Single-row next upload candidate selection with `ORDER BY id LIMIT 1`
 - Runtime queue indexes for state-first polling and recovery paths
 - SQLite busy timeout for queue connections
 - Startup recovery diagnostics with scanned count, recovered count, and duration evidence
-- v2.3 runtime baseline, regression threshold, and long-session fixture documentation
+- Runtime baseline, regression threshold, and long-session fixture documentation
 
-### Practical Readiness Gates
+### Version Gates
 
 - `v0.11` - OBS Plugin Real Load Smoke
 - `v0.12` - Release Packaging Automation
-- `v1.0` - First Practical OBS Plugin Release (current)
+- `v1.0` - First Usable OBS Plugin Release (current)
 
 ---
 

--- a/docs/architecture/packaging.md
+++ b/docs/architecture/packaging.md
@@ -1,6 +1,6 @@
 # Packaging
 
-This document defines the release packaging direction for `v0.12 - Release Packaging Automation` on the practical readiness track.
+This document defines the release packaging direction for `v0.12 - Release Packaging Automation` on the active usability-based version sequence.
 
 ## Release ZIP
 

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -4,15 +4,16 @@ This document records completed release outcomes for OBS Duel Recorder.
 
 Use this file as the durable index for release point information. If a release needs more detail, create a version-specific summary under `docs/release/` and link it from this file.
 
-## Practical Readiness Note
+## Usability Versioning Note
 
-As of #389, this history distinguishes practical user-ready releases from historical/internal implementation milestones.
+As of #401, this project uses one active version sequence based on user-visible
+usability.
 
-- #387 records completed OBS Plugin DLL build and real OBS load smoke evidence for the v0.11 practical readiness gate.
-- The project remains pre-v1.0 for practical OBS plugin user readiness until practical install/update verification, release publication, and tag-naming gates are completed.
-- Existing `v1.x` and `v2.x` tags are preserved historical/internal milestone tags.
-- Older `Status: released` entries before this policy note mean "roadmap milestone released" unless a record explicitly says it is a practical user-ready OBS plugin release.
-- Do not interpret `v2.0.0` through `v2.3.0` as proof that an installable OBS plugin release is user-ready.
+- #387 records completed OBS Plugin DLL build and real OBS load smoke evidence for the v0.11 version gate.
+- #396 records completed release packaging automation for the v0.12 version gate.
+- The project remains pre-v1.0 until install/update verification, release publication, and tag-naming gates are completed.
+- Existing `v1.x` and `v2.x` tags created before this policy are legacy non-product tags. They are preserved for auditability, but they are not part of the active product version sequence.
+- Older `Status: released` entries before this policy note mean "legacy implementation record completed" unless a record explicitly says it is a user-ready product release.
 
 ## Recording Policy
 
@@ -179,7 +180,7 @@ The version tracking issue may contain the working release summary, but finalize
 - Smoke evidence: portable OBS 32.1.2 load smoke; Dock display; Worker API `2.3` / Worker version `2.3.0`; manual recording start/stop; overlay Text Source reuse/update; plugin startup/shutdown logs
 - Deferred items: packaging ZIP workflow, release asset automation, and SHA256 checksum publication remain in #396 for v0.12
 - Next version tracking issue: #396
-- Status: practical readiness gate complete; not a packaged user-ready OBS plugin release
+- Status: version gate complete; not a packaged user-ready OBS plugin release
 
 ### v0.12.0 - Release Packaging Automation
 
@@ -197,11 +198,11 @@ The version tracking issue may contain the working release summary, but finalize
 - Major child issues: none
 - Major PRs: #399
 - Packaging evidence: local package build with real `build/plugin/Release/obs-duel-recorder.dll`; CI package builder validation with fixture DLL; ZIP layout validation; external `SHA256SUMS.txt` generation
-- Deferred items: practical install/update verification, runtime data preservation verification, release publication, and practical tag naming decision remain for #401
+- Deferred items: install/update verification, runtime data preservation verification, release publication, and tag naming decision remain for #401
 - Next version tracking issue: #401
-- Status: practical readiness gate complete; not a final user-ready OBS plugin release
+- Status: version gate complete; not a final user-ready OBS plugin release
 
-### v1.0.0 - YouTube Upload MVP
+### Legacy tag v1.0.0 - YouTube Upload MVP
 
 - Version tracking issue: #318
 - Milestone: `v1.0` (not set)
@@ -215,9 +216,9 @@ The version tracking issue may contain the working release summary, but finalize
 - Major PRs: #364
 - Deferred items: Match Metadata remains in #320 for v1.1
 - Next version tracking issue: #320
-- Status: released
+- Status: legacy implementation record; not part of the active usability-based version sequence
 
-### v1.1.0 - Match Metadata
+### Legacy tag v1.1.0 - Match Metadata
 
 - Version tracking issue: #320
 - Milestone: `v1.1` (not set)
@@ -231,9 +232,9 @@ The version tracking issue may contain the working release summary, but finalize
 - Major PRs: #366
 - Deferred items: Export System remains in #321 for v1.2
 - Next version tracking issue: #321
-- Status: released
+- Status: legacy implementation record; not part of the active usability-based version sequence
 
-### v1.2.0 - Export System
+### Legacy tag v1.2.0 - Export System
 
 - Version tracking issue: #321
 - Milestone: `v1.2` (not set)
@@ -247,9 +248,9 @@ The version tracking issue may contain the working release summary, but finalize
 - Major PRs: #368
 - Deferred items: Setup Wizard remains in #322 for v1.3
 - Next version tracking issue: #322
-- Status: released
+- Status: legacy implementation record; not part of the active usability-based version sequence
 
-### v1.3.0 - Setup Wizard
+### Legacy tag v1.3.0 - Setup Wizard
 
 - Version tracking issue: #322
 - Milestone: `v1.3` (not set)
@@ -263,9 +264,9 @@ The version tracking issue may contain the working release summary, but finalize
 - Major PRs: #370
 - Deferred items: Update System remains in #323 for v1.4
 - Next version tracking issue: #323
-- Status: released
+- Status: legacy implementation record; not part of the active usability-based version sequence
 
-### v1.4.0 - Update System
+### Legacy tag v1.4.0 - Update System
 
 - Version tracking issue: #323
 - Milestone: `v1.4` (not set)
@@ -279,9 +280,9 @@ The version tracking issue may contain the working release summary, but finalize
 - Major PRs: #372
 - Deferred items: Advanced Runtime Phase remains in #324 for v2.0
 - Next version tracking issue: #324
-- Status: released
+- Status: legacy implementation record; not part of the active usability-based version sequence
 
-### v2.0.0 - OCR Integration
+### Legacy tag v2.0.0 - OCR Integration
 
 - Version tracking issue: #324
 - Milestone: `v2.0` (not set)
@@ -293,11 +294,11 @@ The version tracking issue may contain the working release summary, but finalize
 - Release summary: `docs/release/v2.0-release-summary.md`
 - Major child issues: #348, #349, #350, #351
 - Major PRs: #375
-- Deferred items: Statistics System remains in #325 for v2.1; GitHub Pages Documentation remains in #326 for v2.2; Runtime Optimization remains in #327 for v2.3; practical OBS plugin smoke was completed later by #387 / v0.11; packaging automation moves to the v0.x practical readiness track
+- Deferred items: Statistics System remains in #325 for v2.1; GitHub Pages Documentation remains in #326 for v2.2; Runtime Optimization remains in #327 for v2.3; OBS plugin smoke was completed later by #387 / v0.11; packaging automation was completed later by #396 / v0.12
 - Next version tracking issue: #325
-- Status: internal milestone complete; not a practical user-ready OBS plugin release
+- Status: legacy implementation record; not part of the active usability-based version sequence
 
-### v2.1.0 - Statistics System
+### Legacy tag v2.1.0 - Statistics System
 
 - Version tracking issue: #325
 - Milestone: `v2.1` (not set)
@@ -309,11 +310,11 @@ The version tracking issue may contain the working release summary, but finalize
 - Release summary: `docs/release/v2.1-release-summary.md`
 - Major child issues: #352, #353, #354, #355
 - Major PRs: #378
-- Deferred items: GitHub Pages Documentation remains in #326 for v2.2; Runtime Optimization remains in #327 for v2.3; practical OBS plugin smoke was completed later by #387 / v0.11; packaging automation moves to the v0.x practical readiness track
+- Deferred items: GitHub Pages Documentation remains in #326 for v2.2; Runtime Optimization remains in #327 for v2.3; OBS plugin smoke was completed later by #387 / v0.11; packaging automation was completed later by #396 / v0.12
 - Next version tracking issue: #326
-- Status: internal milestone complete; not a practical user-ready OBS plugin release
+- Status: legacy implementation record; not part of the active usability-based version sequence
 
-### v2.2.0 - GitHub Pages Documentation
+### Legacy tag v2.2.0 - GitHub Pages Documentation
 
 - Version tracking issue: #326
 - Milestone: `v2.2` (not set)
@@ -325,11 +326,11 @@ The version tracking issue may contain the working release summary, but finalize
 - Release summary: `docs/release/v2.2-release-summary.md`
 - Major child issues: #356, #357, #358, #359
 - Major PRs: #381
-- Deferred items: Runtime Optimization remains in #327 for v2.3; practical OBS plugin smoke was completed later by #387 / v0.11; packaging automation moves to the v0.x practical readiness track
+- Deferred items: Runtime Optimization remains in #327 for v2.3; OBS plugin smoke was completed later by #387 / v0.11; packaging automation was completed later by #396 / v0.12
 - Next version tracking issue: #327
-- Status: internal milestone complete; not a practical user-ready OBS plugin release
+- Status: legacy implementation record; not part of the active usability-based version sequence
 
-### v2.3.0 - Runtime Optimization
+### Legacy tag v2.3.0 - Runtime Optimization
 
 - Version tracking issue: #327
 - Milestone: `v2.3` (not set)
@@ -342,6 +343,6 @@ The version tracking issue may contain the working release summary, but finalize
 - Release summary: `docs/release/v2.3-release-summary.md`
 - Major child issues: #360, #361, #362, #363
 - Major PRs: #384
-- Deferred items: practical OBS plugin smoke was completed later by #387 / v0.11; packaging ZIP workflow, release asset automation, and checksum publication move to v0.12 on the practical readiness track
+- Deferred items: OBS plugin smoke was completed later by #387 / v0.11; packaging ZIP workflow, release asset automation, and checksum publication were completed later by #396 / v0.12
 - Next version tracking issue: none yet
-- Status: internal milestone complete; not a practical user-ready OBS plugin release
+- Status: legacy implementation record; not part of the active usability-based version sequence

--- a/docs/release.md
+++ b/docs/release.md
@@ -19,16 +19,16 @@ vMajor.Minor.Patch
 Examples:
 - `v0.1.0`
 - `v0.2.0`
-- `v1.0.0`
+- `v0.12.0`
 
-## Practical Readiness Policy
+## Usability-Based Versioning Policy
 
-As of #389, version labels are split into two meanings:
+As of #401, OBS Duel Recorder no longer uses separate usability and implementation
+version tracks. A version number is valid for the active product roadmap only
+when it reflects user-visible usability.
 
-- **Practical release track**: user-facing readiness for installing and running the OBS plugin.
-- **Historical/internal milestone track**: implementation milestones that may have tags but do not by themselves prove a user-ready OBS plugin release.
-
-The project is currently **pre-v1.0 on the practical release track**. A practical `v1.0` release requires accepted evidence that:
+The project is currently **pre-v1.0**. A `v1.0` release requires accepted
+evidence that:
 
 - the Plugin DLL can be built in Release configuration (completed by #387 / v0.11),
 - the DLL loads in a real Windows OBS Studio x64 runtime without crashing (completed by #387 / v0.11),
@@ -38,7 +38,11 @@ The project is currently **pre-v1.0 on the practical release track**. A practica
 - release ZIP packaging and checksum assets are reproducible (completed by #396 / v0.12),
 - packaging/update instructions are usable for a normal user.
 
-Existing historical/internal tags such as `v1.0.0` through `v2.3.0` must not be interpreted as practical user-ready release evidence. Do not move or overwrite those tags. If a future practical `v1.0` tag would conflict with an existing historical/internal tag, record the exact naming decision before tagging.
+Existing `v1.x` and `v2.x` tags created before this rule are legacy non-product
+tags. They must not be interpreted as active release versions. Do not move or
+overwrite existing tags without explicit maintainer approval. If a future
+usability-based version conflicts with a legacy tag name, record the exact
+publication/tag naming decision before tagging.
 
 ## Version Terms
 
@@ -46,10 +50,10 @@ Use separate terms for released and in-development versions:
 
 - `released_version`: the latest completed and published version.
 - `current_development_version`: the version currently being developed toward the next release boundary.
-- `practical_readiness_version`: the user-facing readiness track for installable OBS plugin releases.
-- `internal_milestone_version`: the Worker/API or implementation milestone track used for historical development records.
 
-Avoid using a single `current_version` term when it is unclear whether it means a released version or an in-development target.
+Do not introduce a second version term for implementation-only progress. Work
+that is not user-usable may be tracked by issue, PR, or legacy record,
+but it must not become an active product version number.
 
 ## Major and Minor Release Tracking
 
@@ -97,7 +101,8 @@ If a completed release needs a patch boundary, create a small patch tracking iss
 
 Tags are required when a major or minor version is completed and merged into `main`.
 
-For practical readiness releases, tags are required only after the practical readiness gate for that version is met. Internal milestone tags may exist, but they must be documented as internal milestones when practical readiness has not been proven.
+Tags are required only after the usability gate for that version is met.
+Implementation-only work must not create a product version tag.
 
 Required tag points:
 - Major release completion: tag the merged release commit as `vX.0.0`, unless the release plan explicitly defines a different minor or patch number.
@@ -123,9 +128,13 @@ Use a version-scoped readiness checklist before tagging:
 - v0.11: `docs/release/v0.11-release-readiness.md`
 - v0.12: `docs/release/v0.12-release-readiness.md`
 
-The v0.11 readiness checklist is a practical-readiness gate, not a packaged release approval by itself. It was completed together with the OBS real-load smoke evidence tracked by #387 and coordinated through #393.
+The v0.11 readiness checklist is a version gate, not a packaged release
+approval by itself. It was completed together with the OBS real-load smoke
+evidence tracked by #387 and coordinated through #393.
 
-The v0.12 readiness checklist is a completed practical-readiness gate for release packaging automation, release asset automation, SHA256 checksum publication, and v1.0 handoff documentation.
+The v0.12 readiness checklist is a completed version gate for release packaging
+automation, release asset automation, SHA256 checksum publication, and v1.0
+handoff documentation.
 
 Do not retroactively create a `v0.1.0` tag unless explicitly approved.
 
@@ -160,7 +169,7 @@ When a major or minor roadmap milestone is completed:
 6. Create the release tag if the available GitHub tooling supports tag creation.
 7. If tag creation is not available, report the intended tag name and target commit SHA.
 8. Save release point information to persistent release docs.
-9. Confirm version information such as `practical_readiness_version`, `internal_milestone_version`, `released_version`, and `current_development_version` is updated where defined.
+9. Confirm version information such as `released_version` and `current_development_version` is updated where defined.
 10. Confirm the next version tracking issue is created from `docs/roadmap.md`.
 11. Link the next version tracking issue from the completed tracking issue.
 

--- a/docs/release/v0.11-release-summary.md
+++ b/docs/release/v0.11-release-summary.md
@@ -1,6 +1,6 @@
 # v0.11 Release Summary - OBS Plugin Real Load Smoke
 
-Status: **practical readiness gate complete**.
+Status: **version gate complete**.
 
 This is not a packaged user-ready OBS plugin release. It proves the OBS Plugin
 can be built and loaded in a real OBS runtime.

--- a/docs/release/v0.12-release-summary.md
+++ b/docs/release/v0.12-release-summary.md
@@ -1,6 +1,6 @@
 # v0.12 Release Summary - Release Packaging Automation
 
-Status: **practical readiness gate complete**.
+Status: **version gate complete**.
 
 This is not the final user-ready OBS plugin release. It proves that a release
 package can be assembled from the v0.11 Plugin DLL boundary and published as
@@ -31,9 +31,9 @@ GitHub Actions artifacts with a ZIP checksum.
 ## Handoff
 
 - Next version tracking issue: #401
-- Next target: `v1.0 - First Practical OBS Plugin Release`
+- Next target: `v1.0 - First Usable OBS Plugin Release`
 - Deferred to v1.0:
-  - practical install/update verification
+  - install/update verification
   - runtime data preservation verification
   - release publication
-  - practical tag naming decision
+  - tag naming decision

--- a/docs/requirements/v0.11-obs-plugin-real-load-smoke-acceptance.md
+++ b/docs/requirements/v0.11-obs-plugin-real-load-smoke-acceptance.md
@@ -8,7 +8,7 @@ This document defines the acceptance criteria for **v0.11 - OBS Plugin Real Load
 
 ## Scope
 
-v0.11 proves practical OBS plugin readiness with a real Windows OBS runtime:
+v0.11 proves OBS plugin usability with a real Windows OBS runtime:
 - Release build of `obs-duel-recorder.dll`
 - real OBS Studio x64 load smoke
 - Dock visibility confirmation
@@ -44,4 +44,4 @@ v0.11 proves practical OBS plugin readiness with a real Windows OBS runtime:
 - Packaging ZIP workflow.
 - Release asset automation.
 - Worker/API feature expansion.
-- Moving or overwriting historical/internal tags.
+- Moving or overwriting legacy tags.

--- a/docs/requirements/v0.12-release-packaging-automation-acceptance.md
+++ b/docs/requirements/v0.12-release-packaging-automation-acceptance.md
@@ -26,6 +26,6 @@ v0.12 creates a reproducible GitHub Actions based release packaging flow:
 
 ## Non-goals
 
-- Moving or overwriting historical/internal tags.
+- Moving or overwriting legacy tags.
 - Expanding Worker/API feature scope.
-- Declaring practical v1.0 before install/update documentation and packaging evidence are complete.
+- Declaring v1.0 before install/update documentation and packaging evidence are complete.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,15 +1,14 @@
 # Roadmap
 
-## Practical Readiness Note
+## Versioning Note
 
-This roadmap separates practical user readiness from historical/internal development milestones.
+This roadmap uses one version sequence based on user-visible usability.
 
-- The project is currently on the `v0.x` practical readiness track.
-- Existing `v1.x` and `v2.x` tags are historical/internal development milestones.
+- The project is currently pre-v1.0.
+- Existing `v1.x` and `v2.x` tags are legacy non-product tags from before this rule.
 - The `v0.11` gate completed built OBS Plugin DLL, real OBS load smoke evidence, Dock visibility, Worker heartbeat, and basic recording control evidence.
 - The `v0.12` gate completed packaging workflow, release asset automation path, SHA256 checksum generation, and package layout validation.
-- A user-ready `v1.0` practical release still requires practical install/update verification, runtime data preservation verification, and a recorded practical tag naming decision.
-- The exact practical `v1.0` tag naming must be confirmed before tagging because historical/internal `v1.0.0` already exists.
+- A user-ready `v1.0` release still requires install/update verification, runtime data preservation verification, and a recorded tag naming decision because legacy `v1.0.0` already exists.
 
 ---
 
@@ -26,9 +25,10 @@ This roadmap separates practical user readiness from historical/internal develop
 
 ---
 
-# Practical Readiness Track
+# Active Version Roadmap
 
-This is the authoritative roadmap for user-facing readiness.
+This is the authoritative roadmap. Version numbers are assigned only when the
+corresponding usability gate is satisfied.
 
 ---
 
@@ -36,20 +36,20 @@ This is the authoritative roadmap for user-facing readiness.
 
 ### Goals
 
-Reconcile roadmap and versioning with practical OBS plugin readiness.
+Reconcile roadmap and versioning with OBS plugin usability.
 
 ### Planned
 
-- clarify `v0.x` practical readiness status
-- classify existing `v1.x` and `v2.x` tags as historical/internal milestones
-- define practical `v1.0` promotion gates
-- connect OBS real-load smoke evidence to the practical roadmap
+- clarify `v0.x` usability status
+- classify existing `v1.x` and `v2.x` tags as legacy non-product tags
+- define `v1.0` promotion gates
+- connect OBS real-load smoke evidence to the active roadmap
 
 ### Deliverables
 
 - corrected README and roadmap wording
 - release policy clarification
-- release history practical-readiness note
+- release history usability note
 
 ---
 
@@ -101,11 +101,11 @@ Create a reproducible GitHub Actions based release packaging flow.
 
 ---
 
-## v1.0 - First Practical OBS Plugin Release
+## v1.0 - First Usable OBS Plugin Release
 
 ### Goals
 
-Publish the first practical user-ready release after OBS plugin smoke and packaging gates pass.
+Publish the first user-ready release after OBS plugin smoke and packaging gates pass.
 
 ### Planned
 
@@ -113,19 +113,21 @@ Publish the first practical user-ready release after OBS plugin smoke and packag
 - v0.12 packaging automation evidence accepted
 - user-facing install/update documentation verified
 - runtime data preservation rules verified
-- release naming/tagging decision recorded without moving historical tags
+- release naming/tagging decision recorded without moving legacy tags
 
 ### Deliverables
 
-- first practical OBS plugin release package
+- first usable OBS plugin release package
 - user-ready release notes
 - install/update verification evidence
 
 ---
 
-# Historical Internal Milestone Archive
+# Legacy Implementation Archive
 
-The following milestones record internal implementation progress. They are useful development history, but they do not by themselves prove a user-ready OBS plugin release.
+The following records preserve earlier implementation planning. They are not
+part of the active product version sequence unless a record is also listed in
+the Active Version Roadmap above.
 
 ---
 
@@ -352,7 +354,7 @@ Create screenshot capture system.
 
 ---
 
-# v1 - Upload Phase
+# Legacy v1 Records - Upload Phase
 
 Initial usable release phase.
 
@@ -364,7 +366,7 @@ Goals:
 
 ---
 
-## v1.0 - YouTube Upload MVP
+## Legacy record: v1.0 - YouTube Upload MVP
 
 ### Goals
 
@@ -387,7 +389,7 @@ Create automatic YouTube uploads.
 
 ---
 
-## v1.1 - Match Metadata
+## Legacy record: v1.1 - Match Metadata
 
 ### Goals
 
@@ -409,7 +411,7 @@ Support duel metadata management.
 
 ---
 
-## v1.2 - Export System
+## Legacy record: v1.2 - Export System
 
 ### Goals
 
@@ -430,7 +432,7 @@ Support external archive export.
 
 ---
 
-## v1.3 - Setup Wizard
+## Legacy record: v1.3 - Setup Wizard
 
 ### Goals
 
@@ -450,7 +452,7 @@ Improve first-time user onboarding.
 
 ---
 
-## v1.4 - Update System
+## Legacy record: v1.4 - Update System
 
 ### Goals
 
@@ -472,13 +474,13 @@ Create safe runtime update support.
 
 ---
 
-# v2 - Advanced Runtime Phase
+# Legacy v2 Records - Advanced Runtime Phase
 
 Advanced automation and analysis phase.
 
 ---
 
-## v2.0 - OCR Integration
+## Legacy record: v2.0 - OCR Integration
 
 ### Goals
 
@@ -502,7 +504,7 @@ Implementation note:
 
 ---
 
-## v2.1 - Statistics System
+## Legacy record: v2.1 - Statistics System
 
 ### Goals
 
@@ -522,7 +524,7 @@ Create long-term duel analysis support.
 
 ---
 
-## v2.2 - GitHub Pages Documentation
+## Legacy record: v2.2 - GitHub Pages Documentation
 
 ### Goals
 
@@ -542,7 +544,7 @@ Create user-facing documentation site.
 
 ---
 
-## v2.3 - Runtime Optimization
+## Legacy record: v2.3 - Runtime Optimization
 
 ### Goals
 

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -127,9 +127,9 @@ Goals:
 ### v0.10 - Roadmap And Versioning Realignment
 
 - Roadmap: `docs/roadmap.md` -> **v0.10 - Roadmap And Versioning Realignment**
-- Version tracking issue: `#389` - `[Planning] Reconcile roadmap and versioning with v0.x practical readiness`
-- Release policy: `docs/release.md` -> Practical Readiness Policy
-- Release record: `docs/release-history.md` -> Practical Readiness Note
+- Version tracking issue: `#389`
+- Release policy: `docs/release.md` -> Usability-Based Versioning Policy
+- Release record: `docs/release-history.md` -> Usability Versioning Note
 - README status: `README.md` -> Current Development / Current Status
 - Requirements (relevant sections):
   - `docs/requirements/requirements.md` -> Architecture / Platform / Runtime Rules
@@ -165,22 +165,22 @@ Goals:
   - `docs/requirements/requirements.md` -> Packaging Rules / Runtime Rules / Architecture / Platform
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
-### Practical v1.0 - First Practical OBS Plugin Release
+### v1.0 - First Usable OBS Plugin Release
 
-- Roadmap: `docs/roadmap.md` -> **v1.0 - First Practical OBS Plugin Release**
-- Version tracking issue: `#401` - `[Practical v1.0] First Practical OBS Plugin Release tracking`
+- Roadmap: `docs/roadmap.md` -> **v1.0 - First Usable OBS Plugin Release**
+- Version tracking issue: `#401` - `[v1.0] First Usable OBS Plugin Release tracking`
 - Release policy: `docs/release.md`
-- Previous practical readiness item: `#396` - `[v0.12] Release Packaging Automation release tracking`
+- Previous version gate: `#396` - `[v0.12] Release Packaging Automation release tracking`
 - Required evidence:
   - v0.11 OBS plugin real-load smoke accepted
   - v0.12 packaging automation accepted
-  - practical install/update verification
+  - install/update verification
   - runtime data preservation verification
-  - practical tag naming decision
+  - tag naming decision
 
-### Internal v1.0 - YouTube Upload MVP
+### Legacy record: v1.0 - YouTube Upload MVP
 
-- Roadmap: `docs/roadmap.md` -> **v1.0 - YouTube Upload MVP**
+- Roadmap: `docs/roadmap.md` -> **Legacy record: v1.0 - YouTube Upload MVP**
 - Version tracking issue: `#318` - `[v1.0] YouTube Upload MVP release tracking`
 - Acceptance checklist: `docs/requirements/v1.0-youtube-upload-mvp-acceptance.md`
 - Release readiness checklist: `docs/release/v1.0-release-readiness.md`
@@ -191,9 +191,9 @@ Goals:
   - `docs/requirements/requirements.md` -> Upload Rules / Queue States / Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
-### v1.1 - Match Metadata
+### Legacy record: v1.1 - Match Metadata
 
-- Roadmap: `docs/roadmap.md` -> **v1.1 - Match Metadata**
+- Roadmap: `docs/roadmap.md` -> **Legacy record: v1.1 - Match Metadata**
 - Version tracking issue: `#320` - `[v1.1] Match Metadata release tracking`
 - Acceptance checklist: `docs/requirements/v1.1-match-metadata-acceptance.md`
 - Release readiness checklist: `docs/release/v1.1-release-readiness.md`
@@ -205,9 +205,9 @@ Goals:
   - `docs/requirements/requirements.md` -> Match Data / Upload Rules / Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
-### v1.2 - Export System
+### Legacy record: v1.2 - Export System
 
-- Roadmap: `docs/roadmap.md` -> **v1.2 - Export System**
+- Roadmap: `docs/roadmap.md` -> **Legacy record: v1.2 - Export System**
 - Version tracking issue: `#321` - `[v1.2] Export System release tracking`
 - Acceptance checklist: `docs/requirements/v1.2-export-system-acceptance.md`
 - Release readiness checklist: `docs/release/v1.2-release-readiness.md`
@@ -218,9 +218,9 @@ Goals:
   - `docs/requirements/requirements.md` -> Export Rules / Match Data / Queue / Screenshot Rules / Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
-### v1.3 - Setup Wizard
+### Legacy record: v1.3 - Setup Wizard
 
-- Roadmap: `docs/roadmap.md` -> **v1.3 - Setup Wizard**
+- Roadmap: `docs/roadmap.md` -> **Legacy record: v1.3 - Setup Wizard**
 - Version tracking issue: `#322` - `[v1.3] Setup Wizard release tracking`
 - Acceptance checklist: `docs/requirements/v1.3-setup-wizard-acceptance.md`
 - Release readiness checklist: `docs/release/v1.3-release-readiness.md`
@@ -231,9 +231,9 @@ Goals:
   - `docs/requirements/requirements.md` -> Setup Rules / Architecture / Platform / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
-### v1.4 - Update System
+### Legacy record: v1.4 - Update System
 
-- Roadmap: `docs/roadmap.md` -> **v1.4 - Update System**
+- Roadmap: `docs/roadmap.md` -> **Legacy record: v1.4 - Update System**
 - Version tracking issue: `#323` - `[v1.4] Update System release tracking`
 - Acceptance checklist: `docs/requirements/v1.4-update-system-acceptance.md`
 - Release readiness checklist: `docs/release/v1.4-release-readiness.md`
@@ -246,11 +246,11 @@ Goals:
 
 ---
 
-## v2.x
+## Legacy v2 Records
 
-### v2.0 - OCR Integration
+### Legacy record: v2.0 - OCR Integration
 
-- Roadmap: `docs/roadmap.md` -> **v2.0 - OCR Integration**
+- Roadmap: `docs/roadmap.md` -> **Legacy record: v2.0 - OCR Integration**
 - Version tracking issue: `#324` - `[v2.0] OCR Integration release tracking`
 - Acceptance checklist: `docs/requirements/v2.0-ocr-integration-acceptance.md`
 - Release readiness checklist: `docs/release/v2.0-release-readiness.md`
@@ -264,9 +264,9 @@ Goals:
   - `docs/requirements/requirements.md` -> Image Recognition Rules / Upload Rules / Packaging Rules / Detection Rules / Match Data / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
-### v2.1 - Statistics System
+### Legacy record: v2.1 - Statistics System
 
-- Roadmap: `docs/roadmap.md` -> **v2.1 - Statistics System**
+- Roadmap: `docs/roadmap.md` -> **Legacy record: v2.1 - Statistics System**
 - Version tracking issue: `#325` - `[v2.1] Statistics System release tracking`
 - Acceptance checklist: `docs/requirements/v2.1-statistics-system-acceptance.md`
 - Release readiness checklist: `docs/release/v2.1-release-readiness.md`
@@ -277,9 +277,9 @@ Goals:
   - `docs/requirements/requirements.md` -> Statistics Rules / Match Data / Upload Rules / Runtime Rules / Architecture / Platform
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
-### v2.2 - GitHub Pages Documentation
+### Legacy record: v2.2 - GitHub Pages Documentation
 
-- Roadmap: `docs/roadmap.md` -> **v2.2 - GitHub Pages Documentation**
+- Roadmap: `docs/roadmap.md` -> **Legacy record: v2.2 - GitHub Pages Documentation**
 - Version tracking issue: `#326` - `[v2.2] GitHub Pages Documentation release tracking`
 - Acceptance checklist: `docs/requirements/v2.2-github-pages-documentation-acceptance.md`
 - Release readiness checklist: `docs/release/v2.2-release-readiness.md`
@@ -291,9 +291,9 @@ Goals:
   - `docs/README.md` -> Documentation Rules / Validation
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation
 
-### v2.3 - Runtime Optimization
+### Legacy record: v2.3 - Runtime Optimization
 
-- Roadmap: `docs/roadmap.md` -> **v2.3 - Runtime Optimization**
+- Roadmap: `docs/roadmap.md` -> **Legacy record: v2.3 - Runtime Optimization**
 - Version tracking issue: `#327` - `[v2.3] Runtime Optimization release tracking`
 - Acceptance checklist: `docs/requirements/v2.3-runtime-optimization-acceptance.md`
 - Release readiness checklist: `docs/release/v2.3-release-readiness.md`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,7 +18,7 @@ Current helpers:
 
 `build_docs_site.py` creates the GitHub Pages artifact under `build/docs-site/` without copying runtime data, secrets, screenshots, videos, databases, local template images, or game assets.
 
-`build_release_package.ps1` creates the practical release ZIP under `build/release/` from an existing `obs-duel-recorder.dll`, Worker package files, `update.bat`, and the minimum documentation set. It writes `SHA256SUMS.txt` beside the ZIP and calls `validate_release_package.ps1` to reject runtime data, secrets, logs, databases, screenshots, videos, and local game assets.
+`build_release_package.ps1` creates the release ZIP under `build/release/` from an existing `obs-duel-recorder.dll`, Worker package files, `update.bat`, and the minimum documentation set. It writes `SHA256SUMS.txt` beside the ZIP and calls `validate_release_package.ps1` to reject runtime data, secrets, logs, databases, screenshots, videos, and local game assets.
 
 Scripts must not store:
 - runtime data


### PR DESCRIPTION
## Summary

- Remove the practical/internal two-track versioning language.
- Define one active version sequence based only on user-visible usability.
- Reclassify existing `v1.x` / `v2.x` tags as legacy non-product tags, without moving or overwriting tags.
- Rename the current target to `v1.0 - First Usable OBS Plugin Release` and keep #401 as the active tracking issue.
- Update README, release policy, roadmap, release history, traceability, and related release/acceptance docs.

## Validation

- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `python scripts\build_docs_site.py --root . --output build\docs-site`
- `git diff --check`

## Notes

This PR intentionally does not move or delete existing legacy tags. It only changes the active policy and documentation so product versioning is governed by usability evidence.
