### PR TITLE
Add Worker executable packaging path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path build/plugin/Release | Out-Null
           Set-Content -LiteralPath build/plugin/Release/obs-duel-recorder.dll -Value "ci fixture dll for package layout validation" -Encoding ASCII
-          powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build_release_package.ps1 -Version v0.12.0 -PluginDllPath build/plugin/Release/obs-duel-recorder.dll -OutputDir build/release -Clean
+          New-Item -ItemType Directory -Force -Path build/worker/odr-worker | Out-Null
+          Set-Content -LiteralPath build/worker/odr-worker/odr-worker.exe -Value "ci fixture worker exe for package layout validation" -Encoding ASCII
+          powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build_release_package.ps1 -Version v0.13.0 -PluginDllPath build/plugin/Release/obs-duel-recorder.dll -WorkerBundlePath build/worker/odr-worker -OutputDir build/release -Clean
 
   worker-tests:
     name: Worker unit tests
@@ -67,3 +69,25 @@ jobs:
 
       - name: Run Worker tests
         run: python -m unittest discover -s app/worker/tests -p "test_*.py" -v
+
+  worker-bundle:
+    name: Worker executable build
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: app/worker/pyproject.toml
+
+      - name: Install Worker bundle dependencies
+        run: python -m pip install "./app/worker[bundle]"
+
+      - name: Build Worker executable
+        shell: powershell
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build_worker_exe.ps1 -OutputDir build/worker -Clean

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -44,6 +44,24 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: app/worker/pyproject.toml
+
+      - name: Install Worker bundle dependencies
+        run: python -m pip install "./app/worker[bundle]"
+
+      - name: Build Worker executable
+        shell: powershell
+        run: >
+          powershell -NoProfile -ExecutionPolicy Bypass
+          -File scripts/build_worker_exe.ps1
+          -OutputDir build/worker
+          -Clean
+
       - name: Download plugin DLL artifact from this run
         if: ${{ inputs.plugin_dll_artifact_name != '' && inputs.plugin_dll_artifact_run_id == '' }}
         uses: actions/download-artifact@v4
@@ -67,6 +85,7 @@ jobs:
           -File scripts/build_release_package.ps1
           -Version "${{ inputs.version }}"
           -PluginDllPath "${{ inputs.plugin_dll_path }}"
+          -WorkerBundlePath build/worker/odr-worker
           -OutputDir build/release
           -Clean
 

--- a/app/worker/odr_worker/exe_main.py
+++ b/app/worker/odr_worker/exe_main.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from odr_worker.__main__ import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/worker/pyproject.toml
+++ b/app/worker/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
 test = [
   "httpx>=0.27",
 ]
+bundle = [
+  "pyinstaller>=6.0",
+]
 
 [project.scripts]
 odr-worker = "odr_worker.__main__:main"

--- a/docs/architecture/packaging.md
+++ b/docs/architecture/packaging.md
@@ -14,6 +14,8 @@ obs-duel-recorder-vX.Y.Z/
 |   |-- plugin/
 |   |   `-- obs-duel-recorder.dll
 |   `-- worker/
+|       |-- odr-worker/
+|       |   `-- odr-worker.exe
 |       `-- <worker package files>
 |-- docs/
 |   `-- <minimal install/update/user docs>
@@ -62,9 +64,16 @@ The packaging script expects an existing `obs-duel-recorder.dll` from the v0.11
 OBS Plugin build/smoke boundary. It does not install OBS, Qt, or rebuild the
 plugin by itself.
 
+The packaging script also expects a bundled Worker executable directory,
+normally created by `scripts/build_worker_exe.ps1` under
+`build/worker/odr-worker/`. The bundled executable is the normal user path for
+packaged releases; source-based Worker execution is kept as a developer
+fallback.
+
 The release workflow can either read `build/plugin/Release/obs-duel-recorder.dll`
 from the workspace or download an artifact named by `plugin_dll_artifact_name`.
-It always generates:
+It builds the bundled Worker executable before creating the release package and
+always generates:
 
 - `obs-duel-recorder-vX.Y.Z.zip`
 - `SHA256SUMS.txt`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,11 +14,21 @@ Current helpers:
 - `validate_jp_user_docs_coverage.py`
 - `build_docs_site.py`
 - `build_release_package.ps1`
+- `build_worker_exe.ps1`
 - `validate_release_package.ps1`
 
 `build_docs_site.py` creates the GitHub Pages artifact under `build/docs-site/` without copying runtime data, secrets, screenshots, videos, databases, local template images, or game assets.
 
-`build_release_package.ps1` creates the release ZIP under `build/release/` from an existing `obs-duel-recorder.dll`, Worker package files, `update.bat`, and the minimum documentation set. It writes `SHA256SUMS.txt` beside the ZIP and calls `validate_release_package.ps1` to reject runtime data, secrets, logs, databases, screenshots, videos, and local game assets.
+`build_worker_exe.ps1` creates the bundled Windows Worker executable under `build/worker/odr-worker/` using PyInstaller. Install the Worker bundle dependency first:
+
+```powershell
+python -m pip install "./app/worker[bundle]"
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build_worker_exe.ps1 -OutputDir build/worker -Clean
+```
+
+Use `-PythonExe <path-to-python.exe>` when building from an isolated virtual environment.
+
+`build_release_package.ps1` creates the release ZIP under `build/release/` from an existing `obs-duel-recorder.dll`, the bundled Worker executable, Worker source fallback files, `update.bat`, and the minimum documentation set. It writes `SHA256SUMS.txt` beside the ZIP and calls `validate_release_package.ps1` to reject runtime data, secrets, logs, databases, screenshots, videos, and local game assets.
 
 Scripts must not store:
 - runtime data

--- a/scripts/build_release_package.ps1
+++ b/scripts/build_release_package.ps1
@@ -4,6 +4,8 @@ param(
 
     [string]$PluginDllPath = "build/plugin/Release/obs-duel-recorder.dll",
 
+    [string]$WorkerBundlePath = "build/worker/odr-worker",
+
     [string]$OutputDir = "build/release",
 
     [switch]$Clean
@@ -103,6 +105,8 @@ $packageRoot = Join-Path $outputRoot $packageName
 $zipPath = Join-Path $outputRoot "$packageName.zip"
 $checksumPath = Join-Path $outputRoot "SHA256SUMS.txt"
 $pluginDll = Resolve-RepoPath $PluginDllPath
+$workerBundle = Resolve-RepoPath $WorkerBundlePath
+$workerExe = Join-Path $workerBundle "odr-worker.exe"
 
 if (-not (Test-Path -LiteralPath $pluginDll -PathType Leaf)) {
     throw "Plugin DLL is required for release packaging: $pluginDll"
@@ -110,6 +114,14 @@ if (-not (Test-Path -LiteralPath $pluginDll -PathType Leaf)) {
 
 if ((Split-Path -Leaf $pluginDll) -ne "obs-duel-recorder.dll") {
     throw "Plugin DLL file name must be obs-duel-recorder.dll: $pluginDll"
+}
+
+if (-not (Test-Path -LiteralPath $workerBundle -PathType Container)) {
+    throw "Worker executable bundle is required for release packaging: $workerBundle"
+}
+
+if (-not (Test-Path -LiteralPath $workerExe -PathType Leaf)) {
+    throw "Worker executable is required for release packaging: $workerExe"
 }
 
 New-Item -ItemType Directory -Force -Path $outputRoot | Out-Null
@@ -129,6 +141,7 @@ if (Test-Path -LiteralPath $packageRoot) {
 New-Item -ItemType Directory -Force -Path $packageRoot | Out-Null
 
 Copy-RequiredFile -Source $pluginDll -Destination (Join-Path $packageRoot "app/plugin/obs-duel-recorder.dll")
+Copy-RequiredDirectory -Source $workerBundle -Destination (Join-Path $packageRoot "app/worker/odr-worker")
 
 $workerSource = Join-Path $RepoRoot "app/worker"
 $workerDest = Join-Path $packageRoot "app/worker"
@@ -152,7 +165,8 @@ $manifest = [ordered]@{
     version = $tagVersion
     created_at_utc = (Get-Date).ToUniversalTime().ToString("o")
     plugin_dll = "app/plugin/obs-duel-recorder.dll"
-    worker_package = "app/worker"
+    worker_executable = "app/worker/odr-worker/odr-worker.exe"
+    worker_source_fallback = "app/worker/odr_worker"
     update_entrypoint = "update.bat"
     checksum_file = "SHA256SUMS.txt beside the ZIP"
     docs = @(

--- a/scripts/build_worker_exe.ps1
+++ b/scripts/build_worker_exe.ps1
@@ -1,0 +1,85 @@
+param(
+    [string]$PythonExe = "python",
+
+    [string]$OutputDir = "build/worker",
+
+    [switch]$Clean
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Resolve-RepoPath {
+    param([string]$Path)
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $Path
+    }
+    return (Join-Path $RepoRoot $Path)
+}
+
+$RepoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..")).Path
+$outputRoot = Resolve-RepoPath $OutputDir
+$workerBundleRoot = Join-Path $outputRoot "odr-worker"
+$workRoot = Join-Path $RepoRoot "build/pyinstaller/odr-worker"
+$entryPoint = Join-Path $RepoRoot "app/worker/odr_worker/exe_main.py"
+$workerPath = Join-Path $RepoRoot "app/worker"
+$migrationsPath = Join-Path $RepoRoot "app/worker/odr_worker/migrations"
+$exePath = Join-Path $workerBundleRoot "odr-worker.exe"
+
+if (-not (Test-Path -LiteralPath $entryPoint -PathType Leaf)) {
+    throw "Worker entrypoint was not found: $entryPoint"
+}
+
+if (-not (Test-Path -LiteralPath $migrationsPath -PathType Container)) {
+    throw "Worker migrations directory was not found: $migrationsPath"
+}
+
+if ($Clean) {
+    foreach ($path in @($workerBundleRoot, $workRoot)) {
+        if (Test-Path -LiteralPath $path) {
+            Remove-Item -LiteralPath $path -Recurse -Force
+        }
+    }
+}
+
+New-Item -ItemType Directory -Force -Path $outputRoot | Out-Null
+New-Item -ItemType Directory -Force -Path $workRoot | Out-Null
+
+$addData = "$migrationsPath;odr_worker/migrations"
+$args = @(
+    "-m", "PyInstaller",
+    "--noconfirm",
+    "--clean",
+    "--onedir",
+    "--name", "odr-worker",
+    "--distpath", $outputRoot,
+    "--workpath", $workRoot,
+    "--specpath", $workRoot,
+    "--paths", $workerPath,
+    "--add-data", $addData,
+    "--collect-submodules", "uvicorn",
+    "--collect-submodules", "fastapi",
+    "--collect-submodules", "starlette",
+    "--collect-submodules", "pydantic",
+    "--collect-submodules", "pydantic_core",
+    $entryPoint
+)
+
+& $PythonExe @args
+
+if ($LASTEXITCODE -ne 0) {
+    throw "PyInstaller failed with exit code $LASTEXITCODE"
+}
+
+if (-not (Test-Path -LiteralPath $exePath -PathType Leaf)) {
+    throw "Worker executable was not created: $exePath"
+}
+
+$versionOutput = & $exePath --version
+if ($LASTEXITCODE -ne 0) {
+    throw "Worker executable version check failed with exit code $LASTEXITCODE"
+}
+
+Write-Output "Worker executable: $exePath"
+Write-Output "Worker version: $versionOutput"

--- a/scripts/validate_release_package.ps1
+++ b/scripts/validate_release_package.ps1
@@ -32,6 +32,7 @@ $zipName = Split-Path -Leaf $zipPath
 $expectedRoot = "obs-duel-recorder-$ExpectedVersion/"
 $expectedEntries = @(
     "app/plugin/obs-duel-recorder.dll",
+    "app/worker/odr-worker/odr-worker.exe",
     "app/worker/pyproject.toml",
     "app/worker/odr_worker/__init__.py",
     "docs/user/index.md",


### PR DESCRIPTION
## Summary

- Add a PyInstaller-based `scripts/build_worker_exe.ps1` path for `build/worker/odr-worker/odr-worker.exe`.
- Make release packaging require and include the bundled Worker executable while preserving Worker source fallback files.
- Update release workflow and CI validation so packaged releases build/validate the Worker executable path.
- Document the bundled Worker executable package layout.

## Issues

- Progresses #405.
- Supports #404 / v0.13 Practical Distribution Readiness.

## Validation

- `build\worker-bundle-venv\Scripts\python.exe -m pip install "./app/worker[bundle]"`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\build_worker_exe.ps1 -PythonExe build\worker-bundle-venv\Scripts\python.exe -OutputDir build\worker-real -Clean`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\build_release_package.ps1 -Version v0.13.0 -PluginDllPath build\plugin\Release\obs-duel-recorder.dll -WorkerBundlePath build\worker-real\odr-worker -OutputDir build\release-real -Clean`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\build_release_package.ps1 -Version v0.13.0 -PluginDllPath build\plugin\Release\obs-duel-recorder.dll -WorkerBundlePath build\worker\odr-worker -OutputDir build\release -Clean` fixture layout validation
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `python scripts\build_docs_site.py --root . --output build\docs-site`
- `python -m unittest discover -s app\worker\tests -p "test_*.py" -v`
- `git diff --check`
