### PR TITLE
Prefer bundled Worker executable for updates

### DIFF
--- a/app/plugin/README.md
+++ b/app/plugin/README.md
@@ -180,7 +180,7 @@ The Dock `Start Recording` and `Stop Recording` buttons use the v0.6 recording-s
 ## Worker Launch Inputs
 
 Defaults:
-- Worker command: `odr-worker`
+- Worker command: bundled `app\worker\odr-worker\odr-worker.exe` when present; developer fallback `odr-worker`
 - Host: `127.0.0.1`
 - Port: `8787`
 - Expected Worker API version: `2.3`
@@ -196,7 +196,9 @@ Startup behavior:
 - The Plugin probes `GET /health` on the configured host/port.
 - If a compatible Worker is already running for the same `user_data_dir`, the Plugin reuses it.
 - If a reachable Worker reports a different runtime root, incompatible API version, or unexpected Worker version, startup is blocked and the Plugin logs diagnostics.
-- If no Worker is reachable, the Plugin starts `odr-worker --host <host> --port <port>` with `ODR_USER_DATA_DIR` in the child process environment.
+- If no Worker is reachable, the Plugin starts the bundled Worker executable when it exists in the release ZIP layout.
+- If the bundled Worker executable is not present, the Plugin falls back to `odr-worker --host <host> --port <port>` for developer checkouts.
+- In both cases, `ODR_USER_DATA_DIR` is set in the child process environment.
 
 Heartbeat behavior:
 - `/health` is the readiness and heartbeat source of truth.

--- a/app/plugin/src/plugin-settings.cpp
+++ b/app/plugin/src/plugin-settings.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace odr::plugin {
 namespace {
@@ -47,6 +48,61 @@ std::wstring parent_directory(const std::wstring &path)
 		return {};
 	}
 	return path.substr(0, pos);
+}
+
+bool file_exists(const std::wstring &path)
+{
+	if (path.empty()) {
+		return false;
+	}
+#ifdef _WIN32
+	const DWORD attributes = GetFileAttributesW(path.c_str());
+	return attributes != INVALID_FILE_ATTRIBUTES && (attributes & FILE_ATTRIBUTE_DIRECTORY) == 0;
+#else
+	return false;
+#endif
+}
+
+std::wstring current_module_path()
+{
+#ifdef _WIN32
+	HMODULE module = nullptr;
+	if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+				 GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+				reinterpret_cast<LPCWSTR>(&current_module_path), &module)) {
+		return {};
+	}
+
+	std::vector<wchar_t> buffer(MAX_PATH);
+	while (true) {
+		const DWORD written = GetModuleFileNameW(module, buffer.data(), static_cast<DWORD>(buffer.size()));
+		if (written == 0) {
+			return {};
+		}
+		if (written < buffer.size() - 1) {
+			return std::wstring(buffer.data(), written);
+		}
+		buffer.resize(buffer.size() * 2);
+	}
+#else
+	return {};
+#endif
+}
+
+std::wstring default_worker_command()
+{
+	const std::wstring plugin_dir = parent_directory(current_module_path());
+	if (plugin_dir.empty()) {
+		return L"odr-worker";
+	}
+
+	const std::wstring app_dir = parent_directory(plugin_dir);
+	const std::wstring packaged_worker = app_dir + L"\\worker\\odr-worker\\odr-worker.exe";
+	if (file_exists(packaged_worker)) {
+		return packaged_worker;
+	}
+
+	return L"odr-worker";
 }
 
 bool ensure_directory(const std::wstring &path)
@@ -277,6 +333,7 @@ WorkerLaunchConfig make_launch_config(const PluginSettings &settings)
 	WorkerLaunchConfig config;
 	config.endpoint = settings.endpoint;
 	config.user_data_dir = settings.user_data_dir;
+	config.command = default_worker_command();
 	return config;
 }
 

--- a/app/worker/odr_worker/__main__.py
+++ b/app/worker/odr_worker/__main__.py
@@ -41,6 +41,14 @@ def _apply_cli_overrides(loaded_config: LoadedWorkerConfig, args: argparse.Names
 
 
 def main(argv: list[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    if argv and argv[0] == "update":
+        from .update_system import main as update_main
+
+        return update_main(argv[1:])
+
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/app/worker/tests/test_update_system.py
+++ b/app/worker/tests/test_update_system.py
@@ -5,6 +5,8 @@ import sqlite3
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 from pathlib import Path
 from unittest import mock
 
@@ -134,6 +136,17 @@ class UpdateSystemTests(unittest.TestCase):
             )
             self.assertEqual(applied.status_code, 200)
             self.assertEqual(applied.json()["status"], "completed")
+
+    def test_worker_cli_dispatches_update_command(self) -> None:
+        from odr_worker.__main__ import main as worker_main
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output = StringIO()
+            with redirect_stdout(output):
+                result = worker_main(["update", "status", "--user-data-dir", str(Path(tmp) / "user_data")])
+
+        self.assertEqual(result, 0)
+        self.assertIn('"status": "idle"', output.getvalue())
 
     def test_backup_is_valid_sqlite_copy(self) -> None:
         from odr_worker.update_system import UpdateManager

--- a/docs/architecture/plugin-worker.md
+++ b/docs/architecture/plugin-worker.md
@@ -128,11 +128,28 @@ Optional:
 
 ### Recommended Invocation
 
-The plugin should prefer invoking the packaged CLI entrypoint when available:
+Packaged releases should prefer invoking the bundled Worker executable:
+
+- `<package>/app/worker/odr-worker/odr-worker.exe --host 127.0.0.1 --port 8787`
+
+The Plugin resolves the bundled executable relative to the Plugin DLL package
+layout:
+
+```text
+app/
+|-- plugin/
+|   `-- obs-duel-recorder.dll
+`-- worker/
+    `-- odr-worker/
+        `-- odr-worker.exe
+```
+
+For developer checkouts, the plugin may fall back to the installed CLI
+entrypoint:
 
 - `odr-worker --host 127.0.0.1 --port 8787`
 
-If the plugin embeds Python or launches via `python -m`, the command must still behave equivalently and use the same `ODR_USER_DATA_DIR`.
+If the plugin embeds Python or launches via `python -m`, the command must still behave equivalently and use the same `ODR_USER_DATA_DIR`. That path is not the normal user install path for packaged releases.
 
 ### Startup Handshake
 

--- a/docs/architecture/update-system.md
+++ b/docs/architecture/update-system.md
@@ -37,6 +37,27 @@ Normal update flow must preserve:
 7. On success, the updater writes `completed` state and updates `installed-version.json`.
 8. On failure, the updater writes `failed` state with backup path and recovery guidance.
 
+## Packaged Worker Entrypoint
+
+Packaged releases must prefer the bundled Worker executable:
+
+```text
+app/worker/odr-worker/odr-worker.exe
+```
+
+`update.bat` runs the bundled executable with the `update` subcommand when it is
+present:
+
+```powershell
+app\worker\odr-worker\odr-worker.exe update validate
+app\worker\odr-worker\odr-worker.exe update apply
+```
+
+The source-based `python -m odr_worker.update_system` path is a developer
+fallback for repository checkouts. If neither the bundled executable nor
+`python` is available, `update.bat` must fail with an actionable diagnostic that
+identifies the expected bundled Worker path.
+
 ## Version Compatibility
 
 - Downgrades are rejected when both current and target versions are SemVer values.

--- a/update.bat
+++ b/update.bat
@@ -2,5 +2,18 @@
 setlocal
 cd /d "%~dp0"
 set "ODR_USER_DATA_DIR=%~dp0user_data"
+set "ODR_WORKER_EXE=%~dp0app\worker\odr-worker\odr-worker.exe"
+if exist "%ODR_WORKER_EXE%" (
+  "%ODR_WORKER_EXE%" update %*
+  exit /b %ERRORLEVEL%
+)
+
+where python >nul 2>nul
+if errorlevel 1 (
+  echo OBS Duel Recorder update failed: bundled Worker executable was not found and python is not available. 1>&2
+  echo Expected bundled Worker: %ODR_WORKER_EXE% 1>&2
+  exit /b 9009
+)
+
 set "PYTHONPATH=%~dp0app\worker;%PYTHONPATH%"
 python -m odr_worker.update_system %*


### PR DESCRIPTION
## Summary
- Prefer the bundled `app/worker/odr-worker/odr-worker.exe` in `update.bat` and plugin Worker launch defaults.
- Add `odr-worker update ...` CLI dispatch so the packaged executable can run updater commands directly.
- Document the packaged Worker entrypoint and developer fallback paths.

## Validation
- `python -m unittest discover -s app\worker\tests -p "test_*.py" -v` passed, 80 tests.
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1` passed.
- `python scripts\validate_jp_user_docs_coverage.py --root .` passed.
- `python scripts\build_docs_site.py --root . --output build\docs-site` passed.
- `git diff --check` passed.
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts\build_worker_exe.ps1 -PythonExe build\worker-bundle-venv\Scripts\python.exe -OutputDir build\worker-real -Clean` passed.
- `build\worker-real\odr-worker\odr-worker.exe update status --user-data-dir build\worker-real-user-data` passed.
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts\build_release_package.ps1 -Version v0.13.0 -PluginDllPath build\plugin\Release\obs-duel-recorder.dll -WorkerBundlePath build\worker-real\odr-worker -OutputDir build\release-real -Clean` passed.
- `cmd /c build\release-smoke-406b\obs-duel-recorder-v0.13.0\update.bat status` passed after expanding the generated ZIP.

Local note: OBS/Qt plugin DLL compilation was not run because this environment does not expose `cl`, `g++`, or `cmake`.