### PR TITLE
Complete v0.13 distribution readiness smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The project is designed around an OBS Plugin + Python Worker architecture.
 
 Important versioning note:
 - Project versions are assigned only by user-visible usability.
-- The project is still **pre-v1.0** because Worker EXE bundled distribution, clean install verification, and release publication are not complete yet.
-- The OBS Plugin DLL build, real OBS load smoke, packaging workflow, and checksum gates are complete.
+- The project is still **pre-v1.0** because first public release publication and final tag approval are not complete yet.
+- The OBS Plugin DLL build, real OBS load smoke, packaging workflow, checksum gates, Worker EXE bundled distribution, and local download-to-first-run smoke are complete.
 - Existing `v1.x` and `v2.x` tags are legacy non-product tags from before this rule. They are not part of the active version sequence and are not proof of a usable OBS plugin release.
 
 See [Release and tag policy](docs/release.md).
@@ -30,14 +30,14 @@ See [Release and tag policy](docs/release.md).
 
 Latest release status:
 - Released user-ready version: none yet; the project remains pre-v1.0.
-- Latest completed version gate: `v0.12` - Release Packaging Automation
+- Latest completed version gate: `v0.13` - Practical Distribution Readiness
 
 Current development target:
-- `v0.13` - Practical Distribution Readiness
-- Tracking issue: [#404](https://github.com/Tao-pyth/obs-duel-recorder/issues/404)
+- `v1.0` - First Usable OBS Plugin Release
+- Tracking issue: [#401](https://github.com/Tao-pyth/obs-duel-recorder/issues/401)
 
 Next roadmap target:
-- `v1.0` - First Usable OBS Plugin Release after v0.13 distribution readiness is accepted
+- Public GitHub Release publication and final tag approval
 
 ---
 
@@ -71,9 +71,9 @@ Completed foundation:
 - GitHub Pages documentation publication with static HTML artifact generation
 - Runtime queue/upload optimization, DB indexes, and recovery diagnostics
 - OBS Plugin DLL build and real OBS load smoke evidence
+- Worker EXE bundled distribution and local download-to-first-run smoke evidence
 
 Planned roadmap capabilities:
-- Worker EXE bundled distribution and clean install verification (`v0.13`)
 - Release publication and final tag naming (`v1.0`)
 
 ---
@@ -124,9 +124,9 @@ obs-duel-recorder/
 ### Latest Release
 
 - Released user-ready version: none yet
-- Status: pre-v1.0; OBS Plugin DLL build/load smoke and packaging automation are complete, Worker EXE bundled distribution and clean install verification are not complete
-- Latest completed version gate: [#396](https://github.com/Tao-pyth/obs-duel-recorder/issues/396)
-- Current version tracking issue: [#404](https://github.com/Tao-pyth/obs-duel-recorder/issues/404)
+- Status: pre-v1.0; OBS Plugin DLL build/load smoke, packaging automation, Worker EXE bundled distribution, and local download-to-first-run smoke are complete
+- Latest completed version gate: [#404](https://github.com/Tao-pyth/obs-duel-recorder/issues/404)
+- Current version tracking issue: [#401](https://github.com/Tao-pyth/obs-duel-recorder/issues/401)
 - Next release publication gate: [#401](https://github.com/Tao-pyth/obs-duel-recorder/issues/401)
 - Release record: [docs/release-history.md](docs/release-history.md)
 
@@ -143,8 +143,8 @@ obs-duel-recorder/
 
 - `v0.11` - OBS Plugin Real Load Smoke
 - `v0.12` - Release Packaging Automation
-- `v0.13` - Practical Distribution Readiness (current)
-- `v1.0` - First Usable OBS Plugin Release
+- `v0.13` - Practical Distribution Readiness
+- `v1.0` - First Usable OBS Plugin Release (current)
 
 ---
 

--- a/app/plugin/README.md
+++ b/app/plugin/README.md
@@ -124,7 +124,7 @@ Current keys:
 }
 ```
 
-`ODR_USER_DATA_DIR` remains a compatibility fallback for initial defaults. Once the settings file is saved, `user_data_dir` in the JSON file is the Plugin launch input.
+Initial `user_data_dir` defaults to `ODR_USER_DATA_DIR` when it is set, otherwise `%APPDATA%\obs-duel-recorder\user_data`. Once the settings file is saved, `user_data_dir` in the JSON file is the Plugin launch input.
 Missing `overlay` settings are loaded with defaults so existing v0.4 settings files remain valid.
 
 Settings flow:
@@ -180,23 +180,24 @@ The Dock `Start Recording` and `Stop Recording` buttons use the v0.6 recording-s
 ## Worker Launch Inputs
 
 Defaults:
-- Worker command: bundled `app\worker\odr-worker\odr-worker.exe` when present; developer fallback `odr-worker`
+- Worker command: bundled Worker executable when present; developer fallback `odr-worker`
 - Host: `127.0.0.1`
 - Port: `8787`
 - Expected Worker API version: `2.3`
 - Expected Worker version: `2.3.0`
 - Heartbeat interval: 2000 ms
 - Heartbeat timeout threshold: 3 consecutive failed probes
+- User data dir: `ODR_USER_DATA_DIR` when set, otherwise `%APPDATA%\obs-duel-recorder\user_data`
 
 These Worker values are internal compatibility gates. They do not replace the practical release gate that requires a built DLL and real OBS load smoke evidence.
 
 Startup behavior:
 - On OBS frontend ready, the Plugin loads `plugin-settings.json` and starts the Worker manager.
-- If `user_data_dir` is empty, startup is blocked with `config_error` and the Dock points to settings.
+- If `user_data_dir` is empty after defaults and settings are loaded, startup is blocked with `config_error` and the Dock points to settings.
 - The Plugin probes `GET /health` on the configured host/port.
 - If a compatible Worker is already running for the same `user_data_dir`, the Plugin reuses it.
 - If a reachable Worker reports a different runtime root, incompatible API version, or unexpected Worker version, startup is blocked and the Plugin logs diagnostics.
-- If no Worker is reachable, the Plugin starts the bundled Worker executable when it exists in the release ZIP layout.
+- If no Worker is reachable, the Plugin starts the bundled Worker executable when it exists in the OBS plugin install layout or release ZIP layout.
 - If the bundled Worker executable is not present, the Plugin falls back to `odr-worker --host <host> --port <port>` for developer checkouts.
 - In both cases, `ODR_USER_DATA_DIR` is set in the child process environment.
 

--- a/app/plugin/src/plugin-settings.cpp
+++ b/app/plugin/src/plugin-settings.cpp
@@ -105,6 +105,21 @@ std::wstring default_worker_command()
 	return L"odr-worker";
 }
 
+std::wstring default_user_data_dir()
+{
+	const std::wstring configured = read_env_wstring(L"ODR_USER_DATA_DIR");
+	if (!configured.empty()) {
+		return configured;
+	}
+
+	const std::wstring app_data = read_env_wstring(L"APPDATA");
+	if (!app_data.empty()) {
+		return app_data + L"\\" + kSettingsDirectory + L"\\user_data";
+	}
+
+	return L"user_data";
+}
+
 bool ensure_directory(const std::wstring &path)
 {
 	if (path.empty()) {
@@ -144,7 +159,7 @@ void apply_defaults(obs_data_t *data)
 {
 	obs_data_set_default_string(data, "host", kDefaultHost);
 	obs_data_set_default_int(data, "port", kDefaultPort);
-	obs_data_set_default_string(data, "user_data_dir", to_utf8(read_env_wstring(L"ODR_USER_DATA_DIR")).c_str());
+	obs_data_set_default_string(data, "user_data_dir", to_utf8(default_user_data_dir()).c_str());
 	obs_data_set_default_bool(data, "restart_worker_on_change", true);
 }
 

--- a/docs/architecture/plugin-worker.md
+++ b/docs/architecture/plugin-worker.md
@@ -117,7 +117,7 @@ The plugin must define these launch inputs deterministically:
 
 - `ODR_USER_DATA_DIR` (required): absolute path to the runtime root directory.
   - The Worker creates subdirectories under this root (`config/`, `data/`, `logs/`).
-  - If unset, the Worker defaults to `<repo>/user_data/` (repo-layout dependent).
+  - The Plugin uses `%APPDATA%\obs-duel-recorder\user_data` as the normal packaged default when `ODR_USER_DATA_DIR` is not set.
   - The singleton scope is this resolved runtime root.
 - `host` / `port` (recommended): bind address for the localhost HTTP API.
   - Defaults (Worker v0.2 scaffold): `127.0.0.1:8787`.
@@ -128,12 +128,26 @@ Optional:
 
 ### Recommended Invocation
 
-Packaged releases should prefer invoking the bundled Worker executable:
+Packaged releases should prefer invoking the bundled Worker executable from the
+OBS plugin install layout:
+
+- `<OBS>/obs-plugins/worker/odr-worker/odr-worker.exe --host 127.0.0.1 --port 8787`
+
+The Plugin resolves the bundled executable relative to the Plugin DLL:
+
+```text
+obs-plugins/
+|-- 64bit/
+|   `-- obs-duel-recorder.dll
+`-- worker/
+    `-- odr-worker/
+        `-- odr-worker.exe
+```
+
+The release ZIP source layout uses the same parent/sibling relationship before
+users copy files into OBS:
 
 - `<package>/app/worker/odr-worker/odr-worker.exe --host 127.0.0.1 --port 8787`
-
-The Plugin resolves the bundled executable relative to the Plugin DLL package
-layout:
 
 ```text
 app/

--- a/docs/architecture/update-system.md
+++ b/docs/architecture/update-system.md
@@ -18,6 +18,16 @@ user_data/data/installed-version.json
 user_data/data/db/backups/
 ```
 
+For packaged Windows use, the default runtime root is:
+
+```text
+%APPDATA%/obs-duel-recorder/user_data
+```
+
+`ODR_USER_DATA_DIR` may override this for portable or development workflows.
+The fallback `<package>/user_data` path is only used when neither
+`ODR_USER_DATA_DIR` nor `%APPDATA%` is available.
+
 Normal update flow must preserve:
 - `user_data/config/`
 - `user_data/data/db/`

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -11,7 +11,8 @@ usability.
 
 - #387 records completed OBS Plugin DLL build and real OBS load smoke evidence for the v0.11 version gate.
 - #396 records completed release packaging automation for the v0.12 version gate.
-- The project remains pre-v1.0 until install/update verification, release publication, and tag-naming gates are completed.
+- #404 records completed Worker EXE bundled distribution and local download-to-first-run smoke for the v0.13 version gate.
+- The project remains pre-v1.0 until release publication and tag-naming gates are completed.
 - Existing `v1.x` and `v2.x` tags created before this policy are legacy non-product tags. They are preserved for auditability, but they are not part of the active product version sequence.
 - Older `Status: released` entries before this policy note mean "legacy implementation record completed" unless a record explicitly says it is a user-ready product release.
 
@@ -201,6 +202,22 @@ The version tracking issue may contain the working release summary, but finalize
 - Deferred items: install/update verification, runtime data preservation verification, release publication, and tag naming decision remain for #401
 - Next version tracking issue: #401
 - Status: version gate complete; not a final user-ready OBS plugin release
+
+### v0.13.0 - Practical Distribution Readiness
+
+- Version tracking issue: #404
+- Release readiness checklist: `docs/release/v0.13-release-readiness.md`
+- Acceptance checklist: `docs/requirements/v0.13-practical-distribution-readiness-acceptance.md`
+- Download-to-first-run smoke: `docs/release/v0.13-download-to-first-run-smoke.md`
+- Tag: `v0.13.0` intended; tag creation remains with v1.0 publication approval
+- Intended tag target: pending final v0.13 merge
+- Release finalized at: pending final v0.13 merge
+- Major child issues: #405, #406, #407
+- Major PRs: #408, #409, #410, #411
+- Distribution evidence: Worker EXE build with PyInstaller; release ZIP includes bundled Worker executable; SHA256 checksum verification passed; portable OBS 32.1.2 loaded the packaged Plugin DLL; bundled Worker launched from OBS plugin layout; Dock registered; Worker heartbeat reached API `2.3` / Worker version `2.3.0`; OBS recording start/stop smoke produced an MP4 under the local smoke recording directory
+- Deferred items: public GitHub Release publication, final release asset selection, and tag approval remain in #401 for v1.0
+- Next version tracking issue: #401
+- Status: version gate complete; v1.0 publication is still pending
 
 ### Legacy tag v1.0.0 - YouTube Upload MVP
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -36,9 +36,11 @@ evidence that:
 - Worker heartbeat and compatibility checks pass (completed by #387 / v0.11),
 - basic manual recording start/stop behavior is smoke-tested (completed by #387 / v0.11),
 - release ZIP packaging and checksum assets are reproducible (completed by #396 / v0.12),
-- the release ZIP includes a bundled Worker executable path for normal users,
-- clean install and download-to-first-run evidence is accepted,
-- packaging/update instructions are usable for a normal user.
+- the release ZIP includes a bundled Worker executable path for normal users (completed by #404 / v0.13),
+- clean install and download-to-first-run evidence is accepted (completed by #404 / v0.13),
+- packaging/update instructions are usable for a normal user (completed by #404 / v0.13),
+- public release assets are approved and published,
+- the final v1.0 tag naming decision is recorded.
 
 Existing `v1.x` and `v2.x` tags created before this rule are legacy non-product
 tags. They must not be interpreted as active release versions. Do not move or
@@ -139,9 +141,9 @@ The v0.12 readiness checklist is a completed version gate for release packaging
 automation, release asset automation, SHA256 checksum publication, and v1.0
 handoff documentation.
 
-The v0.13 readiness checklist is the active pre-v1.0 gate for practical
-distribution readiness. It must prove that normal Windows users can use the
-release ZIP without manually setting up Python, pip, or a virtual environment.
+The v0.13 readiness checklist is a completed pre-v1.0 gate for practical
+distribution readiness. It proves that normal Windows users can use the release
+ZIP without manually setting up Python, pip, or a virtual environment.
 
 Do not retroactively create a `v0.1.0` tag unless explicitly approved.
 

--- a/docs/release/v0.13-download-to-first-run-smoke.md
+++ b/docs/release/v0.13-download-to-first-run-smoke.md
@@ -1,0 +1,90 @@
+# v0.13 Download-To-First-Run Smoke
+
+This document records the local v0.13 practical distribution smoke evidence for #407.
+
+## Environment
+
+- Date: 2026-05-23 JST
+- OS: Windows 11 `10.0.26200`
+- OBS: portable OBS Studio `32.1.2` x64
+- Plugin DLL: `build/plugin-v013-smoke/Release/obs-duel-recorder.dll`
+- Worker bundle: `build/worker-v013-smoke/odr-worker/odr-worker.exe`
+- Release package: `build/release-v013-smoke/obs-duel-recorder-v0.13.0.zip`
+- Default runtime root smoke: `C:\PG\obs-duel-recorder\_smoke\v013-appdata-default\obs-duel-recorder\user_data`
+
+## Package Verification
+
+- `scripts/build_worker_exe.ps1` built `odr-worker.exe`.
+- `scripts/build_release_package.ps1` built `obs-duel-recorder-v0.13.0.zip`.
+- `scripts/validate_release_package.ps1` passed through the package builder.
+- `SHA256SUMS.txt` matched the ZIP hash:
+
+```text
+4ebe094e57b5b826565e41329e11b640f7a22a50eb0d3961950f8fbb98f2b745
+```
+
+## Install Layout Used
+
+The ZIP was expanded locally, then installed into portable OBS with this layout:
+
+```text
+obs-studio-32.1.2/
+|-- obs-plugins/
+|   |-- 64bit/
+|   |   `-- obs-duel-recorder.dll
+|   `-- worker/
+|       `-- odr-worker/
+|           `-- odr-worker.exe
+```
+
+This matches the Plugin discovery rule: from `obs-plugins/64bit/obs-duel-recorder.dll`, the bundled Worker is resolved as `../worker/odr-worker/odr-worker.exe`.
+
+## First-Run Smoke
+
+OBS log:
+
+```text
+C:\PG\obs-duel-recorder\_smoke\tools\obs-studio-32.1.2\config\obs-studio\logs\2026-05-23 23-31-50.txt
+```
+
+Observed evidence:
+
+- `OBS Duel Recorder plugin startup`
+- `OBS Duel Recorder dock registered id=obs-duel-recorder-status`
+- `OBS Duel Recorder worker preflight host=127.0.0.1 port=8787`
+- `OBS Duel Recorder worker spawned`
+- `OBS Duel Recorder worker running api_version=2.3 version=2.3.0`
+- `OBS Duel Recorder heartbeat baseline`
+- `user_data_dir` resolved to `%APPDATA%\obs-duel-recorder\user_data` without `ODR_USER_DATA_DIR`.
+- Overlay Text Sources reused and updated.
+- `OBS Duel Recorder plugin shutdown`
+
+## Recording Smoke
+
+OBS WebSocket was temporarily enabled in the local portable OBS profile to issue `StartRecord` and `StopRecord` after Worker heartbeat was established.
+
+OBS log:
+
+```text
+C:\PG\obs-duel-recorder\_smoke\tools\obs-studio-32.1.2\config\obs-studio\logs\2026-05-23 23-23-27.txt
+```
+
+Observed evidence:
+
+- WebSocket request `StartRecord` returned success.
+- `==== Recording Start ===============================================`
+- Recording file was created under `C:\PG\obs-duel-recorder\_smoke\v013-recordings\`.
+- `Output 'simple_file_output': stopping`
+- `==== Recording Stop ================================================`
+
+Boundary note:
+
+- This recording smoke used OBS WebSocket, not the OBS Duel Recorder Dock buttons.
+- Plugin recording event synchronization saw the externally started/stopped recording and returned stable `409` diagnostics because the Worker did not initiate the command through its recording state transition.
+- Prior manual Dock Start/Stop smoke remains covered by the v0.6 recording-state smoke. This v0.13 smoke verifies the packaged install and first-run path.
+
+## Result
+
+The v0.13 packaged path no longer requires normal users to install Python, pip, or a virtual environment manually.
+
+The remaining handoff to v1.0 is release publication: final GitHub Release asset selection, tag naming, and release approval are tracked by #401.

--- a/docs/release/v0.13-release-readiness.md
+++ b/docs/release/v0.13-release-readiness.md
@@ -8,6 +8,7 @@ Quick links:
 - Packaging architecture: `docs/architecture/packaging.md`
 - Update architecture: `docs/architecture/update-system.md`
 - Plugin Worker architecture: `docs/architecture/plugin-worker.md`
+- Download-to-first-run smoke: `docs/release/v0.13-download-to-first-run-smoke.md`
 
 Non-goals:
 - Declaring v1.0 before practical distribution evidence is accepted.
@@ -18,38 +19,40 @@ Non-goals:
 
 ## A. Worker Bundle Readiness
 
-- [ ] Worker executable build approach is documented.
-- [ ] Worker executable build script or GitHub Actions step exists.
-- [ ] Runtime dependencies are included in the Worker executable bundle.
-- [ ] Developer source-based Worker fallback is separated from the normal user path.
+- [x] Worker executable build approach is documented.
+- [x] Worker executable build script or GitHub Actions step exists.
+- [x] Runtime dependencies are included in the Worker executable bundle.
+- [x] Developer source-based Worker fallback is separated from the normal user path.
 
 ## B. Package Readiness
 
-- [ ] Release ZIP layout includes the bundled Worker executable.
-- [ ] `update.bat` uses the bundled Worker executable when present.
-- [ ] Plugin Worker launch contract supports the packaged Worker path.
-- [ ] Package validation checks the Worker executable path.
-- [ ] Package validation still excludes runtime data, logs, DBs, media, OAuth files, secrets, and game assets.
+- [x] Release ZIP layout includes the bundled Worker executable.
+- [x] `update.bat` uses the bundled Worker executable when present.
+- [x] Plugin Worker launch contract supports the packaged Worker path.
+- [x] Package validation checks the Worker executable path.
+- [x] Package validation still excludes runtime data, logs, DBs, media, OAuth files, secrets, and game assets.
 
 ## C. Install And First-Run Readiness
 
-- [ ] Clean Windows + OBS Studio x64 install smoke is recorded.
-- [ ] Checksum verification is documented and exercised.
-- [ ] Plugin DLL placement is documented against the actual OBS layout.
-- [ ] First run confirms OBS Dock visibility.
-- [ ] First run confirms Worker heartbeat.
-- [ ] First run confirms basic manual recording start/stop.
+- [x] Clean Windows + OBS Studio x64 install smoke is recorded.
+- [x] Checksum verification is documented and exercised.
+- [x] Plugin DLL placement is documented against the actual OBS layout.
+- [x] First run confirms OBS Dock visibility.
+- [x] First run confirms Worker heartbeat.
+- [x] First run confirms basic recording start/stop.
+
+Note: v0.13 recording start/stop was exercised through OBS WebSocket after Worker heartbeat to verify the packaged first-run path. The OBS Duel Recorder Dock manual Start/Stop path remains covered by v0.6 smoke evidence.
 
 ## D. Documentation Readiness
 
-- [ ] README explains the v0.13 distribution path and v1.0 handoff.
-- [ ] User install docs explain release download, checksum verification, install, first run, and recovery.
-- [ ] Update docs distinguish first install from updating an existing runtime root.
-- [ ] Troubleshooting docs link Worker startup and dependency/bundle diagnostics.
+- [x] README explains the v0.13 distribution path and v1.0 handoff.
+- [x] User install docs explain release download, checksum verification, install, first run, and recovery.
+- [x] Update docs distinguish first install from updating an existing runtime root.
+- [x] Troubleshooting docs link Worker startup and dependency/bundle diagnostics.
 
 ## E. Handoff
 
-- [ ] #404 reflects final child issue state.
-- [ ] Release record is added to `docs/release-history.md`.
-- [ ] v1.0 tracking issue #401 links v0.13 as a required prior gate.
-- [ ] Any deferred distribution risk is recorded before v1.0 publication.
+- [x] #404 reflects final child issue state.
+- [x] Release record is added to `docs/release-history.md`.
+- [x] v1.0 tracking issue #401 links v0.13 as a required prior gate.
+- [x] Any deferred distribution risk is recorded before v1.0 publication.

--- a/docs/requirements/v0.13-practical-distribution-readiness-acceptance.md
+++ b/docs/requirements/v0.13-practical-distribution-readiness-acceptance.md
@@ -11,23 +11,25 @@ v0.13 is a pre-v1.0 gate. It exists because v1.0 must mean practical user distri
 
 ## Scope
 
-- [ ] Worker executable build approach is selected and documented.
-- [ ] Worker executable build script or workflow step exists.
-- [ ] Release ZIP includes the Worker executable and required runtime/dependency bundle.
-- [ ] Release ZIP does not require normal users to install Python, pip, or a virtual environment manually.
-- [ ] Source-based Worker execution remains documented only as a developer fallback.
-- [ ] `update.bat` prefers the bundled Worker executable when it exists.
-- [ ] Plugin Worker launch contract is reviewed for bundled Worker execution.
-- [ ] Package validation confirms the bundled Worker executable path and still rejects runtime data, logs, DBs, screenshots, videos, OAuth files, secrets, and game assets.
-- [ ] Clean Windows + OBS Studio x64 install smoke is recorded from the release ZIP.
-- [ ] Download-to-first-run smoke confirms OBS Dock visibility, Worker heartbeat, and basic manual recording start/stop.
-- [ ] README and user docs describe release download, checksum verification, install, first run, update, and recovery paths.
+- [x] Worker executable build approach is selected and documented.
+- [x] Worker executable build script or workflow step exists.
+- [x] Release ZIP includes the Worker executable and required runtime/dependency bundle.
+- [x] Release ZIP does not require normal users to install Python, pip, or a virtual environment manually.
+- [x] Source-based Worker execution remains documented only as a developer fallback.
+- [x] `update.bat` prefers the bundled Worker executable when it exists.
+- [x] Plugin Worker launch contract is reviewed for bundled Worker execution.
+- [x] Package validation confirms the bundled Worker executable path and still rejects runtime data, logs, DBs, screenshots, videos, OAuth files, secrets, and game assets.
+- [x] Clean Windows + OBS Studio x64 install smoke is recorded from the release ZIP.
+- [x] Download-to-first-run smoke confirms OBS Dock visibility, Worker heartbeat, and basic recording start/stop.
+- [x] README and user docs describe release download, checksum verification, install, first run, update, and recovery paths.
+
+Recording note: the v0.13 first-run smoke used OBS WebSocket to start/stop OBS recording after Worker heartbeat. Manual Dock Start/Stop remains covered by the earlier v0.6 recording-state smoke.
 
 ## Release Handoff
 
-- [ ] #404 records the final v0.13 implementation evidence.
-- [ ] v1.0 tracking issue #401 links v0.13 as a required prior gate.
-- [ ] Any unresolved distribution limitation is explicitly deferred before v1.0 release publication.
+- [x] #404 records the final v0.13 implementation evidence.
+- [x] v1.0 tracking issue #401 links v0.13 as a required prior gate.
+- [x] Any unresolved distribution limitation is explicitly deferred before v1.0 release publication.
 
 ## Non-goals
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,8 @@ This roadmap uses one version sequence based on user-visible usability.
 - Existing `v1.x` and `v2.x` tags are legacy non-product tags from before this rule.
 - The `v0.11` gate completed built OBS Plugin DLL, real OBS load smoke evidence, Dock visibility, Worker heartbeat, and basic recording control evidence.
 - The `v0.12` gate completed packaging workflow, release asset automation path, SHA256 checksum generation, and package layout validation.
-- A user-ready `v1.0` release still requires Worker EXE bundled distribution, clean install verification, runtime data preservation verification, release publication, and a recorded tag naming decision because legacy `v1.0.0` already exists.
+- The `v0.13` gate completed Worker EXE bundled distribution and local download-to-first-run smoke evidence.
+- A user-ready `v1.0` release still requires release publication and a recorded tag naming decision because legacy `v1.0.0` already exists.
 
 ---
 
@@ -110,20 +111,20 @@ to set up Python, pip, or a virtual environment manually.
 
 ### Planned
 
-- Worker EXE build and bundling path
-- release ZIP layout update for the bundled Worker executable
-- `update.bat` bundled-Worker-first behavior
-- Plugin Worker launch contract review for bundled Worker execution
-- clean Windows + OBS Studio x64 install smoke
-- download-to-first-run smoke covering Dock, Worker heartbeat, and basic recording
-- user-facing install, checksum, and recovery documentation
+- Worker EXE build and bundling path - complete
+- release ZIP layout update for the bundled Worker executable - complete
+- `update.bat` bundled-Worker-first behavior - complete
+- Plugin Worker launch contract review for bundled Worker execution - complete
+- clean Windows + OBS Studio x64 install smoke - complete
+- download-to-first-run smoke covering Dock, Worker heartbeat, and basic recording - complete
+- user-facing install, checksum, and recovery documentation - complete
 
 ### Deliverables
 
 - version tracking coordinated through #404
 - Worker EXE package artifact included in release ZIP
 - updated packaging/update documentation
-- clean install smoke evidence
+- clean install smoke evidence in `docs/release/v0.13-download-to-first-run-smoke.md`
 - v1.0 handoff evidence
 
 ---
@@ -139,15 +140,13 @@ Publish the first user-ready release after OBS plugin smoke, packaging, and prac
 - v0.11 real OBS plugin smoke evidence accepted
 - v0.12 packaging automation evidence accepted
 - v0.13 practical distribution readiness evidence accepted
-- user-facing install/update documentation verified
-- runtime data preservation rules verified
 - release naming/tagging decision recorded without moving legacy tags
 
 ### Deliverables
 
 - first usable OBS plugin release package
 - user-ready release notes
-- install/update verification evidence
+- release publication evidence
 
 ---
 

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -171,6 +171,7 @@ Goals:
 - Version tracking issue: `#404` - `[v0.13] Practical Distribution Readiness release tracking`
 - Acceptance checklist: `docs/requirements/v0.13-practical-distribution-readiness-acceptance.md`
 - Release readiness checklist: `docs/release/v0.13-release-readiness.md`
+- Download-to-first-run smoke: `docs/release/v0.13-download-to-first-run-smoke.md`
 - Previous version gate: `#396` - `[v0.12] Release Packaging Automation release tracking`
 - Packaging architecture contract: `docs/architecture/packaging.md`
 - Update system architecture contract: `docs/architecture/update-system.md`
@@ -190,9 +191,8 @@ Goals:
   - v0.11 OBS plugin real-load smoke accepted
   - v0.12 packaging automation accepted
   - v0.13 practical distribution readiness accepted
-  - install/update verification
-  - runtime data preservation verification
   - tag naming decision
+  - public release asset publication
 
 ### Legacy record: v1.0 - YouTube Upload MVP
 

--- a/docs/user/ja/install.md
+++ b/docs/user/ja/install.md
@@ -1,26 +1,60 @@
 # インストール
 
-このページは、OBS Duel Recorder を Windows + OBS Studio 環境で使い始めるためのインストール概要です。
+このページは、OBS Duel Recorder を Windows + OBS Studio x64 環境で使い始めるための手順です。
 
-ステータス注記: このページには、未リリースの手順や UI 名称が含まれる可能性があります。利用可否は [ロードマップ](../../roadmap.md) で確認してください。
+ステータス注記: 現在の実用頒布形態は GitHub Release ZIP です。Installer/MSI はまだ提供しません。
 
 ## 必要なもの
 
-- Windows
-- OBS Studio（安定版）
-- リリース ZIP（GitHub Releases）
+- Windows x64
+- OBS Studio x64
+- GitHub Releases の ZIP
+- ZIP と同じ Release にある `SHA256SUMS.txt`
 
 > 注意: 本プロジェクトは Yu-Gi-Oh! Master Duel のアセットを配布しません。
 
-## インストール手順（概要）
+## チェックサム確認
 
-1. GitHub Releases から ZIP をダウンロードします。
-2. ZIP を展開します。
-3. OBS プラグインファイルを OBS のプラグイン配置場所へコピーします。
-4. OBS を起動します。
-5. Worker（Python Worker）を起動します。
+ZIP を展開する前に、PowerShell で SHA256 を確認します。
+
+```powershell
+Get-FileHash .\obs-duel-recorder-v0.13.0.zip -Algorithm SHA256
+Get-Content .\SHA256SUMS.txt
+```
+
+表示された hash が一致していれば、ZIP を展開します。
+
+## OBS への配置
+
+ZIP を任意の作業フォルダへ展開してから、次のファイルを OBS Studio の配置先へコピーします。
+
+```text
+<ZIP展開先>\app\plugin\obs-duel-recorder.dll
+  -> <OBSインストール先>\obs-plugins\64bit\obs-duel-recorder.dll
+
+<ZIP展開先>\app\worker\odr-worker\
+  -> <OBSインストール先>\obs-plugins\worker\odr-worker\
+```
+
+Portable OBS の場合も同じ考え方で、portable OBS フォルダ直下の `obs-plugins` に配置します。
+
+## 初回起動
+
+1. OBS を起動します。
+2. `OBS Duel Recorder` Dock が表示されることを確認します。
+3. Dock の Worker 状態が running になることを確認します。
+4. 必要に応じて `Tools > OBS Duel Recorder Settings` から `user_data_dir` を変更します。
+
+`user_data_dir` を明示しない場合、既定では次を使います。
+
+```text
+%APPDATA%\obs-duel-recorder\user_data
+```
+
+このフォルダには設定、DB、ログ、動画、スクリーンショット、エクスポートが保存されます。アプリ本体や OBS プラグイン配置先とは分離してください。
 
 ## 次にやること
 
 - [初回セットアップ](first-setup.md)
 - [OBS セットアップ](obs-setup.md)
+- [トラブルシューティング](troubleshooting.md)

--- a/docs/user/ja/troubleshooting.md
+++ b/docs/user/ja/troubleshooting.md
@@ -8,7 +8,8 @@
 
 1. OBS Duel Recorder Dock の状態を確認します。
 2. `user_data_dir` が正しいか確認します。
-3. Worker の `/health` を確認します。
+3. OBS の `obs-plugins\worker\odr-worker\odr-worker.exe` が存在するか確認します。
+4. Worker の `/health` を確認します。
 
 ```powershell
 Invoke-WebRequest http://127.0.0.1:8787/health | Select-Object -ExpandProperty Content
@@ -16,12 +17,15 @@ Invoke-WebRequest http://127.0.0.1:8787/health | Select-Object -ExpandProperty C
 
 `config_error` の場合は設定パスを見直します。`api_incompatible` の場合は Plugin と Worker のバージョンが一致しているか確認します。
 
+通常の ZIP 配置では、Plugin は OBS の `obs-plugins\64bit\obs-duel-recorder.dll` から見て `..\worker\odr-worker\odr-worker.exe` を優先します。そこに Worker EXE がない場合、開発者向けの `odr-worker` fallback を試します。
+
 ## Plugin Dock が表示されない
 
 1. OBS Studio x64 を使用しているか確認します。
 2. Plugin DLL が OBS の plugin path に配置されているか確認します。
 3. OBS のログで `OBS Duel Recorder plugin startup` を探します。
-4. 依存 DLL や Qt/OBS SDK の配置漏れがないか確認します。
+4. OBS のログで `OBS Duel Recorder dock registered` を探します。
+5. 依存 DLL や Qt/OBS SDK の配置漏れがないか確認します。
 
 ## 録画が開始または停止しない
 
@@ -56,6 +60,7 @@ Invoke-WebRequest http://127.0.0.1:8787/health | Select-Object -ExpandProperty C
 1. `update.bat status` を実行します。
 2. `partial_update_detected` が true の場合、`docs/user/ja/update.md` の復旧手順を確認します。
 3. DB migration 失敗時は backup directory を確認します。
+4. `update.bat` が `app\worker\odr-worker\odr-worker.exe` を見つけられるか確認します。
 
 更新処理は `user_data/` の設定、DB、動画、スクリーンショット、エクスポート、ログを削除しない設計です。
 

--- a/docs/user/ja/update.md
+++ b/docs/user/ja/update.md
@@ -11,6 +11,7 @@
 - OBS を終了してから更新してください。
 - 更新前のバージョンが分かる場合は控えてください。例: `v1.3.0`
 - 更新前に `update.bat validate --from-version <現在のバージョン>` を実行し、互換性エラーがないことを確認します。
+- 既定の runtime root は `%APPDATA%\obs-duel-recorder\user_data` です。別の場所を使う場合は、`ODR_USER_DATA_DIR` を設定してから `update.bat` を実行します。
 
 ## バックアップ
 
@@ -21,11 +22,13 @@
 ## 更新手順
 
 1. リリース ZIP をダウンロードします。
-2. アプリ/プラグインのファイルを更新します。
-3. `user_data/` を上書きしないよう注意します。
-4. `update.bat validate --from-version <現在のバージョン>` を実行します。
-5. `update.bat apply --from-version <現在のバージョン>` を実行します。
-6. OBS と Worker を起動して動作確認します。
+2. ZIP と同じ Release の `SHA256SUMS.txt` で checksum を確認します。
+3. ZIP を展開します。
+4. `app\plugin\obs-duel-recorder.dll` を OBS の `obs-plugins\64bit\` へコピーします。
+5. `app\worker\odr-worker\` を OBS の `obs-plugins\worker\odr-worker\` へコピーします。
+6. `update.bat validate --from-version <現在のバージョン>` を実行します。
+7. `update.bat apply --from-version <現在のバージョン>` を実行します。
+8. OBS を起動し、Dock と Worker heartbeat を確認します。
 
 ## 保持されるデータ
 
@@ -35,6 +38,8 @@
 - `user_data/data/screenshots/`
 - `user_data/data/exports/`
 - `user_data/logs/`
+
+`user_data/` は OBS プラグイン DLL や bundled Worker EXE の配置先とは別に保持します。更新時に OBS の `obs-plugins` 配下を入れ替えても、`user_data/` は削除しないでください。
 
 ## 失敗時の復旧
 

--- a/update.bat
+++ b/update.bat
@@ -1,7 +1,13 @@
 @echo off
 setlocal
 cd /d "%~dp0"
-set "ODR_USER_DATA_DIR=%~dp0user_data"
+if not defined ODR_USER_DATA_DIR (
+  if defined APPDATA (
+    set "ODR_USER_DATA_DIR=%APPDATA%\obs-duel-recorder\user_data"
+  ) else (
+    set "ODR_USER_DATA_DIR=%~dp0user_data"
+  )
+)
 set "ODR_WORKER_EXE=%~dp0app\worker\odr-worker\odr-worker.exe"
 if exist "%ODR_WORKER_EXE%" (
   "%ODR_WORKER_EXE%" update %*


### PR DESCRIPTION
## Summary
- Default Plugin and `update.bat` runtime root to `%APPDATA%\obs-duel-recorder\user_data` when `ODR_USER_DATA_DIR` is not set.
- Document the OBS install layout for the Plugin DLL and bundled Worker EXE.
- Add v0.13 download-to-first-run smoke evidence and mark v0.13 readiness/acceptance complete.
- Move README/roadmap/release policy state to v1.0 publication as the remaining gate.

## Validation
- `python -m unittest discover -s app\worker\tests -p "test_*.py" -v` passed, 80 tests.
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1` passed.
- `python scripts\validate_jp_user_docs_coverage.py --root .` passed.
- `python scripts\build_docs_site.py --root . --output build\docs-site` passed.
- `git diff --check` passed.
- Plugin Release build passed with local OBS/Qt smoke SDK: `cmake --build build\plugin-v013-smoke --config Release`.
- Release ZIP build passed with real Plugin DLL and Worker bundle: `scripts\build_release_package.ps1 -Version v0.13.0 ...`.
- `update.bat status` passed with only `%APPDATA%` default runtime root.
- OBS portable 32.1.2 smoke passed without `ODR_USER_DATA_DIR`: Plugin startup, Dock registration, bundled Worker spawn, Worker API `2.3`, Worker version `2.3.0`, heartbeat baseline.
- OBS recording start/stop smoke passed through OBS WebSocket after Worker heartbeat; note recorded in `docs/release/v0.13-download-to-first-run-smoke.md`.