### PR TITLE
Record v1.0.1 final release publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The project is designed around an OBS Plugin + Python Worker architecture.
 
 Important versioning note:
 - Project versions are assigned only by user-visible usability.
-- The project is still **pre-v1.0** because first public release publication and final tag approval are not complete yet.
-- The OBS Plugin DLL build, real OBS load smoke, packaging workflow, checksum gates, Worker EXE bundled distribution, and local download-to-first-run smoke are complete.
-- The planned active v1.0 publication tag is `v1.0.1` because legacy `v1.0.0` already exists.
+- The first user-ready OBS Plugin release is `v1.0.1`.
+- The OBS Plugin DLL build, real OBS load smoke, packaging workflow, checksum gates, Worker EXE bundled distribution, local download-to-first-run smoke, and public release publication are complete.
+- The active v1.0 publication uses `v1.0.1` because legacy `v1.0.0` already exists.
 - Existing `v1.x` and `v2.x` tags are legacy non-product tags from before this rule. They are not part of the active version sequence and are not proof of a usable OBS plugin release.
 
 See [Release and tag policy](docs/release.md).
@@ -30,16 +30,14 @@ See [Release and tag policy](docs/release.md).
 ## Current Development
 
 Latest release status:
-- Released user-ready version: none yet; the project remains pre-v1.0.
-- Latest completed version gate: `v0.13` - Practical Distribution Readiness
+- Released user-ready version: `v1.0.1` - First Usable OBS Plugin Release
+- Latest completed version gate: `v1.0` - First Usable OBS Plugin Release
 
 Current development target:
-- `v1.0` - First Usable OBS Plugin Release
-- Tracking issue: [#401](https://github.com/Tao-pyth/obs-duel-recorder/issues/401)
-- Planned active publication tag: `v1.0.1`
+- next roadmap target pending
 
 Next roadmap target:
-- Public GitHub Release publication and final tag approval
+- pending maintainer planning after `v1.0.1`
 
 ---
 
@@ -76,7 +74,7 @@ Completed foundation:
 - Worker EXE bundled distribution and local download-to-first-run smoke evidence
 
 Planned roadmap capabilities:
-- Release publication and final tag naming (`v1.0.1` planned)
+- Post-v1.0 roadmap planning
 
 ---
 
@@ -125,11 +123,11 @@ obs-duel-recorder/
 
 ### Latest Release
 
-- Released user-ready version: none yet
-- Status: pre-v1.0; OBS Plugin DLL build/load smoke, packaging automation, Worker EXE bundled distribution, and local download-to-first-run smoke are complete
-- Latest completed version gate: [#404](https://github.com/Tao-pyth/obs-duel-recorder/issues/404)
-- Current version tracking issue: [#401](https://github.com/Tao-pyth/obs-duel-recorder/issues/401)
-- Next release publication gate: [#401](https://github.com/Tao-pyth/obs-duel-recorder/issues/401)
+- Released user-ready version: [`v1.0.1`](https://github.com/Tao-pyth/obs-duel-recorder/releases/tag/v1.0.1)
+- Status: first usable OBS Plugin release published with ZIP and SHA256 assets
+- Latest completed version gate: [#401](https://github.com/Tao-pyth/obs-duel-recorder/issues/401)
+- Current version tracking issue: none
+- Next release publication gate: pending maintainer planning
 - Release record: [docs/release-history.md](docs/release-history.md)
 
 ### Completed Legacy Implementation Work
@@ -146,7 +144,7 @@ obs-duel-recorder/
 - `v0.11` - OBS Plugin Real Load Smoke
 - `v0.12` - Release Packaging Automation
 - `v0.13` - Practical Distribution Readiness
-- `v1.0` - First Usable OBS Plugin Release (current)
+- `v1.0` - First Usable OBS Plugin Release
 
 ---
 

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -12,8 +12,8 @@ usability.
 - #387 records completed OBS Plugin DLL build and real OBS load smoke evidence for the v0.11 version gate.
 - #396 records completed release packaging automation for the v0.12 version gate.
 - #404 records completed Worker EXE bundled distribution and local download-to-first-run smoke for the v0.13 version gate.
-- The project remains pre-v1.0 until release publication and tag-naming gates are completed.
-- The planned active v1.0 publication tag is `v1.0.1` because `v1.0.0` already exists as a legacy non-product tag.
+- The project reached its first user-ready OBS Plugin release at `v1.0.1`.
+- The active v1.0 publication tag is `v1.0.1` because `v1.0.0` already exists as a legacy non-product tag.
 - Existing `v1.x` and `v2.x` tags created before this policy are legacy non-product tags. They are preserved for auditability, but they are not part of the active product version sequence.
 - Older `Status: released` entries before this policy note mean "legacy implementation record completed" unless a record explicitly says it is a user-ready product release.
 
@@ -220,19 +220,24 @@ The version tracking issue may contain the working release summary, but finalize
 - Next version tracking issue: #401
 - Status: version gate complete; v1.0 publication is still pending
 
-### Active v1.0.1 - First Usable OBS Plugin Release
+### v1.0.1 - First Usable OBS Plugin Release
 
 - Version tracking issue: #401
 - Acceptance checklist: `docs/requirements/v1.0-first-usable-release-acceptance.md`
 - Release readiness checklist: `docs/release/v1.0-first-usable-release-readiness.md`
 - Release summary: `docs/release/v1.0-first-usable-release-summary.md`
-- Tag: `v1.0.1` planned
-- Tag target: pending final v1.0 release merge
-- Release finalized at: pending final publication
+- Tag: `v1.0.1`
+- Tag target: `14cbfe256a20e6263537d28b4d6df0156e2452a3`
+- Tag finalized at: `2026-05-24T04:03:31+09:00`
+- Release finalized at: `2026-05-24T04:06:42+09:00`
+- GitHub Release: `https://github.com/Tao-pyth/obs-duel-recorder/releases/tag/v1.0.1`
 - Prior gates: #393 / v0.11, #396 / v0.12, #404 / v0.13
-- Required final evidence: release ZIP, `SHA256SUMS.txt`, package validation, install/update verification, `user_data/` preservation verification, GitHub Release asset publication
+- Assets: `obs-duel-recorder-v1.0.1.zip`, `SHA256SUMS.txt`
+- ZIP SHA256: `28CF71B3C68736412B95495CDACEFDA7546EB1A11B4077426D7C9F79159CBBA3`
+- Verification: final package validation passed; packaged `update.bat validate --from-version v0.13.0` passed; packaged `update.bat apply --from-version v0.13.0` passed twice; `user_data/` sentinel files were preserved; SQLite backup was created under `user_data/data/db/backups/`
 - Legacy conflict: existing `v1.0.0` is preserved and must not be moved, deleted, or overwritten
-- Status: publication gate pending; not yet a user-ready released version
+- Next version tracking issue: pending maintainer planning
+- Status: released user-ready OBS Plugin package
 
 ### Legacy tag v1.0.0 - YouTube Upload MVP
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -28,8 +28,8 @@ As of #401, OBS Duel Recorder no longer uses separate usability and implementati
 version tracks. A version number is valid for the active product roadmap only
 when it reflects user-visible usability.
 
-The project is currently **pre-v1.0**. A `v1.0` release requires accepted
-evidence that:
+The project reached its first user-ready OBS Plugin release at `v1.0.1`. A
+`v1.0` release requires accepted evidence that:
 
 - the Plugin DLL can be built in Release configuration (completed by #387 / v0.11),
 - the DLL loads in a real Windows OBS Studio x64 runtime without crashing (completed by #387 / v0.11),
@@ -50,9 +50,7 @@ usability-based version conflicts with a legacy tag name, record the exact
 publication/tag naming decision before tagging.
 
 For the active v1.0 publication gate, the existing `v1.0.0` tag is a legacy
-non-product tag. The planned active publication tag is `v1.0.1` unless
-maintainers explicitly approve a different non-conflicting tag before
-publication.
+non-product tag. The active publication tag is `v1.0.1`.
 
 ## Version Terms
 
@@ -156,6 +154,8 @@ The active v1.0 readiness checklist is the publication gate for the first
 normal-user GitHub Release package. It must record final ZIP/SHA verification,
 install/update preservation evidence, Release asset publication, and the
 non-conflicting tag decision before #401 closes.
+
+The active v1.0 checklist was completed for `v1.0.1`.
 
 Do not retroactively create a `v0.1.0` tag unless explicitly approved.
 

--- a/docs/release/v1.0-first-usable-release-readiness.md
+++ b/docs/release/v1.0-first-usable-release-readiness.md
@@ -28,11 +28,11 @@ Non-goals:
 
 ## B. Package Evidence
 
-- [ ] A final release ZIP is built from the release Plugin DLL and bundled Worker executable.
-- [ ] The package manifest identifies the Plugin DLL, Worker executable, update entrypoint, and docs.
-- [ ] `scripts/validate_release_package.ps1` passes for the final ZIP.
-- [ ] The package excludes runtime data, logs, databases, videos, screenshots, exports, OAuth credentials, tokens, and secrets.
-- [ ] `SHA256SUMS.txt` contains the final ZIP hash and ZIP file name.
+- [x] A final release ZIP is built from the release Plugin DLL and bundled Worker executable.
+- [x] The package manifest identifies the Plugin DLL, Worker executable, update entrypoint, and docs.
+- [x] `scripts/validate_release_package.ps1` passes for the final ZIP.
+- [x] The package excludes runtime data, logs, databases, videos, screenshots, exports, OAuth credentials, tokens, and secrets.
+- [x] `SHA256SUMS.txt` contains the final ZIP hash and ZIP file name.
 
 Pre-publication local rehearsal on 2026-05-24:
 - Plugin DLL: `build/plugin-v101-release2/Release/obs-duel-recorder.dll`
@@ -40,17 +40,22 @@ Pre-publication local rehearsal on 2026-05-24:
 - Package command passed for `build/release-v101-real/obs-duel-recorder-v1.0.1.zip`.
 - SHA256 rehearsal value: `578BCB06B4C10DD9BF21654E6E10B28BCD026C8238EA765F6766C292654DEBEC`
 
-This rehearsal is not final publication evidence. The checklist remains open
-until the release PR is merged, the tag target is known, and the GitHub Release
-assets are published or explicitly approved by maintainers.
+Final publication evidence on 2026-05-24:
+- Tag target: `14cbfe256a20e6263537d28b4d6df0156e2452a3`
+- Plugin DLL: `build/plugin-v101-final/Release/obs-duel-recorder.dll`
+- Worker executable: `build/worker-v101-final/odr-worker/odr-worker.exe`
+- Package command passed for `build/release-v101-final/obs-duel-recorder-v1.0.1.zip`.
+- ZIP size: `15821701` bytes
+- SHA256: `28CF71B3C68736412B95495CDACEFDA7546EB1A11B4077426D7C9F79159CBBA3`
+- Release URL: `https://github.com/Tao-pyth/obs-duel-recorder/releases/tag/v1.0.1`
 
 ## C. Install And Update Evidence
 
-- [ ] The final package can be extracted into the documented OBS plugin layout.
-- [ ] `update.bat validate --from-version v0.13.0` succeeds from the extracted package.
-- [ ] `update.bat apply --from-version v0.13.0` succeeds from the extracted package.
-- [ ] Existing `user_data/config/`, `user_data/data/db/`, `user_data/data/videos/`, `user_data/data/screenshots/`, `user_data/data/exports/`, and `user_data/logs/` are preserved.
-- [ ] DB backup behavior is recorded when an existing SQLite DB is present.
+- [x] The final package can be extracted into the documented OBS plugin layout.
+- [x] `update.bat validate --from-version v0.13.0` succeeds from the extracted package.
+- [x] `update.bat apply --from-version v0.13.0` succeeds from the extracted package.
+- [x] Existing `user_data/config/`, `user_data/data/db/`, `user_data/data/videos/`, `user_data/data/screenshots/`, `user_data/data/exports/`, and `user_data/logs/` are preserved.
+- [x] DB backup behavior is recorded when an existing SQLite DB is present.
 
 Pre-publication local rehearsal on 2026-05-24:
 - `update.bat validate --from-version v0.13.0` returned `valid: true`.
@@ -58,25 +63,35 @@ Pre-publication local rehearsal on 2026-05-24:
 - The second apply created a SQLite backup under `user_data/data/db/backups/`.
 - Sentinel files under `config/secrets/`, `data/videos/`, `data/screenshots/`, `data/exports/`, and `logs/` were preserved.
 
+Final publication rehearsal on 2026-05-24:
+- `update.bat validate --from-version v0.13.0` returned `valid: true`.
+- Two `update.bat apply --from-version v0.13.0` runs completed from the final packaged layout.
+- The second apply created `user_data/data/db/backups/odr-20260523T19060289092-2.3.0.sqlite3`.
+- Sentinel files under `config/secrets/`, `data/videos/`, `data/screenshots/`, `data/exports/`, and `logs/` were preserved.
+
 ## D. Publication Evidence
 
-- [ ] A GitHub Release is created for the active v1.0 publication tag.
-- [ ] The release ZIP is attached as a GitHub Release asset.
-- [ ] `SHA256SUMS.txt` is attached beside the ZIP.
-- [ ] The release package workflow manual run, or an explicitly approved direct publication fallback, is linked from #401.
-- [ ] Downloaded assets match the recorded SHA256 checksum.
+- [x] A GitHub Release is created for the active v1.0 publication tag.
+- [x] The release ZIP is attached as a GitHub Release asset.
+- [x] `SHA256SUMS.txt` is attached beside the ZIP.
+- [x] The release package workflow manual run, or an explicitly approved direct publication fallback, is linked from #401.
+- [x] Downloaded assets match the recorded SHA256 checksum.
+
+Publication used a direct `gh release create` asset upload for the final local
+Plugin DLL package. The release package workflow remains the automation path for
+future asset publication when a matching Plugin DLL artifact is available.
 
 ## E. Tag Decision
 
 - [x] Existing `v1.0.0` is classified as a legacy non-product tag.
 - [x] Legacy `v1.0.0` will not be moved, deleted, or overwritten.
-- [x] Planned active publication tag: `v1.0.1`.
-- [ ] Final tag target commit on `main` is recorded after the release PR is merged.
+- [x] Active publication tag: `v1.0.1`.
+- [x] Final tag target commit on `main` is recorded after the release PR is merged.
 
 ## F. Durable Records
 
-- [ ] README current status is updated for the published release.
-- [ ] `docs/release-history.md` records the final tag, target commit, assets, verification, and next state.
-- [ ] `docs/release/v1.0-first-usable-release-summary.md` records final publication evidence.
-- [ ] `docs/traceability.md` links the active v1.0 acceptance and release readiness records.
-- [ ] #401 is updated and closed only after the evidence above is complete.
+- [x] README current status is updated for the published release.
+- [x] `docs/release-history.md` records the final tag, target commit, assets, verification, and next state.
+- [x] `docs/release/v1.0-first-usable-release-summary.md` records final publication evidence.
+- [x] `docs/traceability.md` links the active v1.0 acceptance and release readiness records.
+- [x] #401 is updated and closed only after the evidence above is complete.

--- a/docs/release/v1.0-first-usable-release-summary.md
+++ b/docs/release/v1.0-first-usable-release-summary.md
@@ -2,15 +2,16 @@
 
 This summary records the active usability-based v1.0 publication gate.
 
-The release is not final until #401 is closed with publication evidence.
-
 ## Release Identity
 
 - Version tracking issue: #401
 - Planned publication tag: `v1.0.1`
 - Legacy conflicting tag: `v1.0.0`
 - Legacy tag handling: preserved; not moved, deleted, or overwritten
-- Release state: pending final package verification and publication
+- Release state: published
+- GitHub Release: `https://github.com/Tao-pyth/obs-duel-recorder/releases/tag/v1.0.1`
+- Tag target: `14cbfe256a20e6263537d28b4d6df0156e2452a3`
+- Published at: `2026-05-24T04:06:42+09:00`
 
 ## Completed Prior Gates
 
@@ -18,16 +19,17 @@ The release is not final until #401 is closed with publication evidence.
 - v0.12 / #396: release packaging automation and SHA256 generation path
 - v0.13 / #404: Worker EXE bundled distribution and local download-to-first-run smoke
 
-## Pending Publication Evidence
+## Publication Evidence
 
-- Final release ZIP path: pending GitHub Release publication
-- `SHA256SUMS.txt`: pending GitHub Release publication
-- Package validation command/result: pending final tag-target package
-- `update.bat validate --from-version v0.13.0`: pending final tag-target package
-- `update.bat apply --from-version v0.13.0`: pending final tag-target package
-- GitHub Release URL: pending
-- Release asset publication evidence: pending
-- Final tag target commit: pending
+- Final release ZIP asset: `obs-duel-recorder-v1.0.1.zip`
+- `SHA256SUMS.txt` asset: published beside the ZIP
+- Package validation command/result: `scripts/build_release_package.ps1` passed and invoked `scripts/validate_release_package.ps1`
+- `update.bat validate --from-version v0.13.0`: passed with `valid: true`
+- `update.bat apply --from-version v0.13.0`: passed twice from the final packaged layout
+- GitHub Release URL: `https://github.com/Tao-pyth/obs-duel-recorder/releases/tag/v1.0.1`
+- Release asset publication evidence: ZIP and `SHA256SUMS.txt` attached to the Release
+- Final tag target commit: `14cbfe256a20e6263537d28b4d6df0156e2452a3`
+- Download verification: downloaded Release assets matched `SHA256SUMS.txt`
 
 ## Pre-publication Local Rehearsal
 
@@ -44,12 +46,21 @@ The release is not final until #401 is closed with publication evidence.
 - Runtime preservation: sentinel files under `config/secrets/`, `data/videos/`, `data/screenshots/`, `data/exports/`, and `logs/` remained present.
 - DB backup: second apply created `user_data/data/db/backups/odr-20260523T17023941293-2.3.0.sqlite3`.
 
-This rehearsal proves the local package path. It is not yet the final GitHub
-Release evidence because the release PR has not been merged and the final tag
-target has not been published.
+This rehearsal proved the local package path before the final GitHub Release
+publication.
 
-## Finalization Rule
+## Final Publication Verification
 
-#401 must remain open until the final ZIP, checksum, install/update
-verification, runtime data preservation verification, publication evidence, and
-tag target are recorded.
+2026-05-24 final publication results:
+
+- Plugin DLL build: `build/plugin-v101-final/Release/obs-duel-recorder.dll`
+- Worker executable build: `build/worker-v101-final/odr-worker/odr-worker.exe`
+- Release ZIP: `build/release-v101-final/obs-duel-recorder-v1.0.1.zip`
+- ZIP size: `15821701` bytes
+- `SHA256SUMS.txt`: `28CF71B3C68736412B95495CDACEFDA7546EB1A11B4077426D7C9F79159CBBA3  obs-duel-recorder-v1.0.1.zip`
+- Package validation: passed
+- Update validation: `update.bat validate --from-version v0.13.0` returned `valid: true`
+- Update apply: two packaged `update.bat apply --from-version v0.13.0` runs completed
+- Runtime preservation: sentinel files under `config/secrets/`, `data/videos/`, `data/screenshots/`, `data/exports/`, and `logs/` remained present
+- DB backup: second apply created `user_data/data/db/backups/odr-20260523T19060289092-2.3.0.sqlite3`
+- Download verification: downloaded `obs-duel-recorder-v1.0.1.zip` SHA256 matched published `SHA256SUMS.txt`

--- a/docs/requirements/v1.0-first-usable-release-acceptance.md
+++ b/docs/requirements/v1.0-first-usable-release-acceptance.md
@@ -16,14 +16,14 @@ OBS Studio user from a GitHub Release package.
 - [x] v0.11 OBS Plugin DLL Release build and real OBS Studio x64 load smoke are accepted.
 - [x] v0.12 release packaging automation, ZIP layout validation, and SHA256 generation are accepted.
 - [x] v0.13 Worker executable bundling and local download-to-first-run smoke are accepted.
-- [ ] A real release ZIP is built from an OBS Plugin DLL and bundled Worker executable.
-- [ ] `SHA256SUMS.txt` is generated and verified against the release ZIP.
-- [ ] The release package validates with `scripts/validate_release_package.ps1`.
-- [ ] `update.bat validate --from-version <previous>` succeeds from the packaged layout.
-- [ ] `update.bat apply --from-version <previous>` preserves `user_data/` runtime data.
-- [ ] GitHub Release assets are published or the publication run evidence is recorded.
-- [ ] The active v1.0 tag naming decision is recorded without moving legacy `v1.0.0`.
-- [ ] README, release docs, traceability, and release history are updated before #401 closes.
+- [x] A real release ZIP is built from an OBS Plugin DLL and bundled Worker executable.
+- [x] `SHA256SUMS.txt` is generated and verified against the release ZIP.
+- [x] The release package validates with `scripts/validate_release_package.ps1`.
+- [x] `update.bat validate --from-version <previous>` succeeds from the packaged layout.
+- [x] `update.bat apply --from-version <previous>` preserves `user_data/` runtime data.
+- [x] GitHub Release assets are published or the publication run evidence is recorded.
+- [x] The active v1.0 tag naming decision is recorded without moving legacy `v1.0.0`.
+- [x] README, release docs, traceability, and release history are updated before #401 closes.
 
 ## Tag Naming Decision
 
@@ -31,8 +31,7 @@ The active v1.0 publication must not use the existing `v1.0.0` tag because that
 tag predates the usability-based versioning rule and records a legacy
 implementation milestone.
 
-The planned active publication tag is `v1.0.1` unless maintainers explicitly
-approve a different non-conflicting tag before publication.
+The active publication tag is `v1.0.1`.
 
 ## Non-goals
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,12 +4,12 @@
 
 This roadmap uses one version sequence based on user-visible usability.
 
-- The project is currently pre-v1.0.
+- The project reached its first user-ready OBS Plugin release at `v1.0.1`.
 - Existing `v1.x` and `v2.x` tags are legacy non-product tags from before this rule.
 - The `v0.11` gate completed built OBS Plugin DLL, real OBS load smoke evidence, Dock visibility, Worker heartbeat, and basic recording control evidence.
 - The `v0.12` gate completed packaging workflow, release asset automation path, SHA256 checksum generation, and package layout validation.
 - The `v0.13` gate completed Worker EXE bundled distribution and local download-to-first-run smoke evidence.
-- A user-ready `v1.0` release still requires release publication and a recorded tag naming decision because legacy `v1.0.0` already exists. The planned active publication tag is `v1.0.1`.
+- The user-ready `v1.0` release was published as `v1.0.1` because legacy `v1.0.0` already exists.
 
 ---
 
@@ -150,7 +150,7 @@ Publish the first user-ready release after OBS plugin smoke, packaging, and prac
 - first usable OBS plugin release package
 - user-ready release notes
 - release publication evidence
-- active release tag `v1.0.1`, unless maintainers explicitly approve another non-conflicting tag
+- active release tag `v1.0.1`
 
 ---
 

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -191,7 +191,7 @@ Goals:
 - Release policy: `docs/release.md`
 - Release record: `docs/release-history.md`
 - Previous version gate: `#404` - `[v0.13] Practical Distribution Readiness release tracking`
-- Planned active publication tag: `v1.0.1`
+- Active publication tag: `v1.0.1`
 - Legacy conflicting tag: `v1.0.0` - preserved; not part of the active usability-based sequence
 - Required evidence:
   - v0.11 OBS plugin real-load smoke accepted
@@ -202,6 +202,7 @@ Goals:
   - ZIP / SHA256 verification
   - install/update verification
   - `user_data/` preservation verification
+- Release URL: `https://github.com/Tao-pyth/obs-duel-recorder/releases/tag/v1.0.1`
 
 ### Legacy record: v1.0 - YouTube Upload MVP
 


### PR DESCRIPTION
## Summary

- Record the published `v1.0.1` First Usable OBS Plugin Release in README, roadmap, release policy, release history, traceability, acceptance, readiness, and summary docs.
- Replace pending publication placeholders with the final tag target, Release URL, assets, SHA256, update validation, runtime preservation, and DB backup evidence.
- Mark the active v1.0 acceptance/readiness records complete while preserving the legacy `v1.0.0` non-product tag note.

## Release Evidence

- Release: https://github.com/Tao-pyth/obs-duel-recorder/releases/tag/v1.0.1
- Tag target: `14cbfe256a20e6263537d28b4d6df0156e2452a3`
- ZIP asset: `obs-duel-recorder-v1.0.1.zip`
- SHA256: `28CF71B3C68736412B95495CDACEFDA7546EB1A11B4077426D7C9F79159CBBA3`
- Published assets downloaded and checksum verified.

## Verification

- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File docs\tools\validate_markdown_links.ps1`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `git diff --check`
- Final Worker EXE build: `scripts\build_worker_exe.ps1 -PythonExe build\worker-bundle-venv\Scripts\python.exe -OutputDir build\worker-v101-final -Clean`
- Final Plugin Release build: `build\plugin-v101-final\Release\obs-duel-recorder.dll`
- Final package build: `scripts\build_release_package.ps1 -Version v1.0.1 -PluginDllPath build\plugin-v101-final\Release\obs-duel-recorder.dll -WorkerBundlePath build\worker-v101-final\odr-worker -OutputDir build\release-v101-final -Clean`
- Packaged `update.bat validate --from-version v0.13.0`
- Packaged `update.bat apply --from-version v0.13.0` twice with runtime sentinel preservation and SQLite backup evidence

Refs #401