### PR TITLE
[codex] Implement v1.1.3 dock workflow and upload templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The project is designed around an OBS Plugin + Python Worker architecture.
 Important versioning note:
 - Project versions are assigned only by user-visible usability.
 - The first user-ready OBS Plugin release is `v1.0.1`.
-- The `v1.1.2` target is Recovery Reporting, Distribution, UI, and i18n Update, coordinated through #457 after `v1.1.1`.
+- The `v1.1.3` target is Dock Workflow, Metadata, Upload, and UI State Update, coordinated through #470 after `v1.1.2`.
 - Existing `v1.x` and `v2.x` tags are legacy non-product tags from before this rule. They are not part of the active version sequence and are not proof of a usable OBS plugin release.
 - Existing legacy tags must not be moved or overwritten. Because a legacy `v1.1.0` tag exists, v1.1.x publication decisions must be recorded before release.
 
@@ -34,10 +34,10 @@ Latest release status:
 - Latest completed version gate: `v1.0` - First Usable OBS Plugin Release
 
 Current development target:
-- `v1.1.2` - Recovery Reporting, Distribution, UI, and i18n Update
+- `v1.1.3` - Dock Workflow, Metadata, Upload, and UI State Update
 
 Next roadmap target:
-- pending planning after `v1.1.2`
+- pending planning after `v1.1.3`
 
 ---
 
@@ -103,6 +103,16 @@ Active v1.1.2 issue set:
 - Japanese/English language selection from Settings
 - Help recovery note that explains language changes in the opposite language
 
+Active v1.1.3 issue set:
+- Record -> Metadata -> Upload -> Manage Dock workflow
+- direct Dock metadata editing with deck/opponent dropdown candidates
+- carry-over for deck, opponent deck, rank, and DP
+- editable upload title, description, and tag templates with preview
+- Worker-rendered upload metadata shared by preview and upload processing
+- localized metadata and automatic setup fallback dialogs
+- short UI state labels with raw diagnostics hidden behind detail controls
+- Material-inspired UI state and color role documentation
+
 ---
 
 ## Architecture
@@ -154,7 +164,7 @@ obs-duel-recorder/
 - Status: first usable OBS Plugin release published with ZIP and SHA256 assets
 - Latest completed version gate: [#401](https://github.com/Tao-pyth/obs-duel-recorder/issues/401)
 - Latest completed hardening issue set: [#440](https://github.com/Tao-pyth/obs-duel-recorder/issues/440)
-- Current development target: [#457](https://github.com/Tao-pyth/obs-duel-recorder/issues/457) / `v1.1.2`
+- Current development target: [#470](https://github.com/Tao-pyth/obs-duel-recorder/issues/470) / `v1.1.3`
 - Release record: [docs/release-history.md](docs/release-history.md)
 
 ### Completed Legacy Implementation Work
@@ -175,6 +185,7 @@ obs-duel-recorder/
 - `v1.1` - First Trial Usability Hardening
 - `v1.1.1` - Usability UI and Documentation Hardening
 - `v1.1.2` - Recovery Reporting, Distribution, UI, and i18n Update
+- `v1.1.3` - Dock Workflow, Metadata, Upload, and UI State Update
 
 ---
 
@@ -192,6 +203,9 @@ Key documents:
 - [v1.1.1 release readiness checklist](docs/release/v1.1.1-usability-ui-documentation-hardening-readiness.md)
 - [v1.1.2 acceptance checklist](docs/requirements/v1.1.2-recovery-reporting-distribution-ui-i18n-acceptance.md)
 - [v1.1.2 release readiness checklist](docs/release/v1.1.2-recovery-reporting-distribution-ui-i18n-readiness.md)
+- [v1.1.3 acceptance checklist](docs/requirements/v1.1.3-dock-workflow-metadata-upload-ui-acceptance.md)
+- [v1.1.3 release readiness checklist](docs/release/v1.1.3-dock-workflow-metadata-upload-ui-readiness.md)
+- [Dock workflow and UI state architecture](docs/architecture/dock-workflow-ui-state.md)
 - [Architecture docs](docs/architecture/)
 - [User docs (language selector / 日本語)](docs/user/index.md)
 - [Japanese user docs](docs/user/ja/index.md)

--- a/app/plugin/src/plugin-settings.cpp
+++ b/app/plugin/src/plugin-settings.cpp
@@ -24,6 +24,10 @@ constexpr const char *kOverlaySourcesKey = "sources";
 constexpr const char *kOverlayDefaultsKey = "defaults";
 constexpr const char *kDefaultDockTheme = "classic";
 constexpr const char *kDefaultUiLanguage = "en";
+constexpr const char *kDefaultUploadTitleTemplate = "Duel {match_id} vs {opponent_deck} - {result}";
+constexpr const char *kDefaultUploadDescriptionTemplate =
+	"OBS Duel Recorder Archive\n\nMatch ID: {match_id}\nDeck: {deck_name}\nOpponent: {opponent_deck}\nResult: {result}\nRank: {rank}\nDP: {dp}\nStarted: {started_at}\nEnded: {ended_at}\n\nNotes:\n{memo}";
+constexpr const char *kDefaultUploadTagsTemplate = "Yu-Gi-Oh! Master Duel,{deck_name},{opponent_deck},{result}";
 
 std::wstring from_utf8(const char *value)
 {
@@ -173,6 +177,9 @@ void apply_defaults(obs_data_t *data)
 	obs_data_set_default_bool(data, "restart_worker_on_change", true);
 	obs_data_set_default_string(data, "dock_theme", kDefaultDockTheme);
 	obs_data_set_default_string(data, "ui_language", kDefaultUiLanguage);
+	obs_data_set_default_string(data, "upload_title_template", kDefaultUploadTitleTemplate);
+	obs_data_set_default_string(data, "upload_description_template", kDefaultUploadDescriptionTemplate);
+	obs_data_set_default_string(data, "upload_tags_template", kDefaultUploadTagsTemplate);
 }
 
 bool is_valid_dock_theme(const std::string &theme)
@@ -304,6 +311,45 @@ void save_overlay_settings(obs_data_t *data, const OverlaySettings &settings)
 	obs_data_release(overlay);
 }
 
+std::vector<std::string> load_string_array(obs_data_t *data, const char *key)
+{
+	std::vector<std::string> values;
+	obs_data_array_t *array = obs_data_get_array(data, key);
+	if (!array) {
+		return values;
+	}
+	const size_t count = obs_data_array_count(array);
+	for (size_t i = 0; i < count; ++i) {
+		obs_data_t *item = obs_data_array_item(array, i);
+		if (!item) {
+			continue;
+		}
+		const char *value = obs_data_get_string(item, "value");
+		if (value && value[0] != '\0') {
+			values.emplace_back(value);
+		}
+		obs_data_release(item);
+	}
+	obs_data_array_release(array);
+	return values;
+}
+
+void save_string_array(obs_data_t *data, const char *key, const std::vector<std::string> &values)
+{
+	obs_data_array_t *array = obs_data_array_create();
+	for (const std::string &value : values) {
+		if (value.empty()) {
+			continue;
+		}
+		obs_data_t *item = obs_data_create();
+		obs_data_set_string(item, "value", value.c_str());
+		obs_data_array_push_back(array, item);
+		obs_data_release(item);
+	}
+	obs_data_set_array(data, key, array);
+	obs_data_array_release(array);
+}
+
 } // namespace
 
 std::wstring default_plugin_settings_path()
@@ -343,6 +389,15 @@ PluginSettings load_plugin_settings()
 	if (!is_valid_ui_language(settings.ui_language)) {
 		settings.ui_language = kDefaultUiLanguage;
 	}
+	settings.deck_candidates = load_string_array(data, "deck_candidates");
+	settings.opponent_deck_candidates = load_string_array(data, "opponent_deck_candidates");
+	settings.last_deck_name = obs_data_get_string(data, "last_deck_name");
+	settings.last_opponent_deck = obs_data_get_string(data, "last_opponent_deck");
+	settings.last_rank = obs_data_get_string(data, "last_rank");
+	settings.last_dp = obs_data_get_string(data, "last_dp");
+	settings.upload_title_template = obs_data_get_string(data, "upload_title_template");
+	settings.upload_description_template = obs_data_get_string(data, "upload_description_template");
+	settings.upload_tags_template = obs_data_get_string(data, "upload_tags_template");
 	settings.overlay = load_overlay_settings(data);
 
 	obs_data_release(data);
@@ -366,6 +421,21 @@ bool save_plugin_settings(const PluginSettings &settings)
 			    is_valid_dock_theme(settings.dock_theme) ? settings.dock_theme.c_str() : kDefaultDockTheme);
 	obs_data_set_string(data, "ui_language",
 			    is_valid_ui_language(settings.ui_language) ? settings.ui_language.c_str() : kDefaultUiLanguage);
+	save_string_array(data, "deck_candidates", settings.deck_candidates);
+	save_string_array(data, "opponent_deck_candidates", settings.opponent_deck_candidates);
+	obs_data_set_string(data, "last_deck_name", settings.last_deck_name.c_str());
+	obs_data_set_string(data, "last_opponent_deck", settings.last_opponent_deck.c_str());
+	obs_data_set_string(data, "last_rank", settings.last_rank.c_str());
+	obs_data_set_string(data, "last_dp", settings.last_dp.c_str());
+	obs_data_set_string(data, "upload_title_template",
+			    settings.upload_title_template.empty() ? kDefaultUploadTitleTemplate :
+								    settings.upload_title_template.c_str());
+	obs_data_set_string(data, "upload_description_template",
+			    settings.upload_description_template.empty() ? kDefaultUploadDescriptionTemplate :
+									  settings.upload_description_template.c_str());
+	obs_data_set_string(data, "upload_tags_template",
+			    settings.upload_tags_template.empty() ? kDefaultUploadTagsTemplate :
+								   settings.upload_tags_template.c_str());
 	save_overlay_settings(data, settings.overlay);
 
 	const bool saved = obs_data_save_json_safe(data, to_utf8(settings.settings_path).c_str(), "tmp", "bak");

--- a/app/plugin/src/plugin-settings.hpp
+++ b/app/plugin/src/plugin-settings.hpp
@@ -3,6 +3,7 @@
 #include "worker-launcher.hpp"
 
 #include <string>
+#include <vector>
 
 namespace odr::plugin {
 
@@ -26,6 +27,16 @@ struct PluginSettings {
 	OverlaySettings overlay;
 	std::string dock_theme = "classic";
 	std::string ui_language = "en";
+	std::vector<std::string> deck_candidates;
+	std::vector<std::string> opponent_deck_candidates;
+	std::string last_deck_name;
+	std::string last_opponent_deck;
+	std::string last_rank;
+	std::string last_dp;
+	std::string upload_title_template = "Duel {match_id} vs {opponent_deck} - {result}";
+	std::string upload_description_template =
+		"OBS Duel Recorder Archive\n\nMatch ID: {match_id}\nDeck: {deck_name}\nOpponent: {opponent_deck}\nResult: {result}\nRank: {rank}\nDP: {dp}\nStarted: {started_at}\nEnded: {ended_at}\n\nNotes:\n{memo}";
+	std::string upload_tags_template = "Yu-Gi-Oh! Master Duel,{deck_name},{opponent_deck},{result}";
 	std::wstring user_data_dir;
 	std::wstring settings_path;
 	bool restart_worker_on_change = true;

--- a/app/plugin/src/plugin-ui.cpp
+++ b/app/plugin/src/plugin-ui.cpp
@@ -29,6 +29,7 @@
 
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace odr::plugin {
 namespace {
@@ -151,46 +152,34 @@ std::string setup_summary(const WorkerStatusSnapshot &snapshot)
 std::string recording_summary(const WorkerStatusSnapshot &snapshot)
 {
 	if (!snapshot.recording_error.empty()) {
-		return "command failed: " + snapshot.recording_error;
+		return "Error";
 	}
 	if (!snapshot.recording_state_available) {
-		return "not available";
+		return "Unavailable";
 	}
 
 	const RecordingStatePayload &state = snapshot.recording_state;
-	std::ostringstream out;
-	out << "state=" << state.state;
-	if (!state.session_id.empty()) {
-		out << " session_id=" << state.session_id;
+	if (state.state == "recording") {
+		return "Recording";
 	}
-	if (!state.command_source.empty()) {
-		out << " source=" << state.command_source;
+	if (state.state == "completed") {
+		return "Metadata needed";
 	}
-	if (!state.last_action.empty()) {
-		out << " last_action=" << state.last_action;
+	if (state.state == "idle") {
+		return "Idle";
 	}
-	if (!state.reason.empty()) {
-		out << " reason=" << state.reason;
-	}
-	if (!state.updated_at.empty()) {
-		out << " updated_at=" << state.updated_at;
-	}
-	return out.str();
+	return state.state.empty() ? "Unknown" : state.state;
 }
 
 std::string recording_output_summary(const WorkerStatusSnapshot &snapshot)
 {
 	if (!snapshot.recording_output_path.empty()) {
-		std::string summary = "path=" + snapshot.recording_output_path;
-		if (!snapshot.recording_output_evidence.empty()) {
-			summary += " evidence=" + snapshot.recording_output_evidence;
-		}
-		return summary;
+		return "Linked";
 	}
 	if (!snapshot.recording_output_evidence.empty()) {
-		return snapshot.recording_output_evidence;
+		return "Waiting for OBS output";
 	}
-	return "not available";
+	return "Not linked";
 }
 
 std::string queue_summary(const WorkerStatusSnapshot &snapshot)
@@ -204,13 +193,8 @@ std::string queue_summary(const WorkerStatusSnapshot &snapshot)
 
 	const UploadStatusResult &queue = snapshot.upload_status;
 	std::ostringstream out;
-	out << "ready=" << queue.ready_upload
-	    << " uploading=" << queue.uploading
-	    << " uploaded=" << queue.uploaded
-	    << " failed=" << queue.upload_failed
-	    << " quota=" << queue.quota_waiting
-	    << " review=" << queue.need_manual_review
-	    << " discarded=" << queue.discarded;
+	out << "Ready " << queue.ready_upload << " / Review " << queue.need_manual_review
+	    << " / Failed " << queue.upload_failed;
 	return out.str();
 }
 
@@ -221,16 +205,7 @@ std::string review_item_summary(const WorkerStatusSnapshot &snapshot)
 	}
 	const QueueActionItemPayload &item = snapshot.queue_action_item.item;
 	std::ostringstream out;
-	out << "id=" << item.id << " state=" << item.state;
-	if (!item.manual_review_reason.empty()) {
-		out << " reason=" << item.manual_review_reason;
-	}
-	if (!item.last_error_code.empty()) {
-		out << " error=" << item.last_error_code;
-	}
-	if (!item.video_path.empty()) {
-		out << " video=" << item.video_path;
-	}
+	out << "#" << item.id << " " << item.state;
 	return out.str();
 }
 
@@ -397,6 +372,25 @@ QString state_badge_style(WorkerDiagnosticState state)
 		.arg(QString::fromUtf8(background), QString::fromUtf8(foreground));
 }
 
+void add_unique_candidate(std::vector<std::string> &values, const std::string &value)
+{
+	if (value.empty()) {
+		return;
+	}
+	if (std::find(values.begin(), values.end(), value) != values.end()) {
+		return;
+	}
+	values.insert(values.begin(), value);
+	if (values.size() > 30) {
+		values.resize(30);
+	}
+}
+
+std::string combo_text(QComboBox *combo)
+{
+	return combo ? utf8_string(combo->currentText().trimmed()) : std::string{};
+}
+
 } // namespace
 
 PluginUiController::PluginUiController(WorkerProcessManager &worker_manager)
@@ -478,8 +472,6 @@ void PluginUiController::register_ui()
 	action_value_ = add_card_value(setup_layout, language_is_japanese(ui_language_) ? "次の操作" : "Next action",
 				       &action_label_);
 	setup_tab_layout->addWidget(setup_card_);
-	setup_tab_layout->addStretch(1);
-
 	settings_button_ = new QPushButton(ui_text(ui_language_, "Open Settings", "設定を開く"));
 	help_button_ = new QPushButton(ui_text(ui_language_, "Open Help", "ヘルプを開く"));
 	automatic_setup_button_ = new QPushButton(ui_text(ui_language_, "Open Automatic Setup", "自動録画セットアップを開く"));
@@ -495,27 +487,48 @@ void PluginUiController::register_ui()
 		"Change runtime path, theme, and language. Saving restarts the Worker.",
 		"実行データ保存先、テーマ、言語を変更します。保存すると Worker を再起動します。"));
 	settings_note_->setWordWrap(true);
-	settings_tab_layout->addWidget(settings_note_);
-	settings_tab_layout->addWidget(settings_button_);
-	settings_tab_layout->addStretch(1);
+	setup_tab_layout->addWidget(settings_note_);
+
+	auto *inline_settings_form = new QFormLayout;
+	settings_host_input_ = new QLineEdit(qstr_wide(settings.endpoint.host));
+	settings_port_input_ = new QLineEdit(QString::number(settings.endpoint.port));
+	settings_user_data_input_ = new QLineEdit(qstr_wide(settings.user_data_dir));
+	settings_theme_input_ = new QComboBox;
+	settings_theme_input_->addItem("Classic", QString::fromUtf8("classic"));
+	settings_theme_input_->addItem("Forest", QString::fromUtf8("forest"));
+	settings_theme_input_->addItem("Bright", QString::fromUtf8("bright"));
+	settings_theme_input_->setCurrentIndex(std::max(0, settings_theme_input_->findData(QString::fromUtf8(settings.dock_theme.c_str()))));
+	settings_language_input_ = new QComboBox;
+	settings_language_input_->addItem("English", QString::fromUtf8("en"));
+	settings_language_input_->addItem(QString::fromUtf8("日本語"), QString::fromUtf8("ja"));
+	settings_language_input_->setCurrentIndex(std::max(0, settings_language_input_->findData(QString::fromUtf8(settings.ui_language.c_str()))));
+	inline_settings_form->addRow(ui_text(ui_language_, "Host", "ホスト"), settings_host_input_);
+	inline_settings_form->addRow(ui_text(ui_language_, "Port", "ポート"), settings_port_input_);
+	inline_settings_form->addRow(ui_text(ui_language_, "User data dir", "ユーザーデータ保存先"), settings_user_data_input_);
+	inline_settings_form->addRow(ui_text(ui_language_, "Dock theme", "Dock テーマ"), settings_theme_input_);
+	inline_settings_form->addRow(ui_text(ui_language_, "Language", "言語"), settings_language_input_);
+	setup_tab_layout->addLayout(inline_settings_form);
+	save_inline_settings_button_ = new QPushButton(ui_text(ui_language_, "Save Settings", "設定を保存"));
+	QObject::connect(save_inline_settings_button_, &QPushButton::clicked, [this]() { save_inline_settings(); });
+	style_button(save_inline_settings_button_, "#2ec4b6", "#073b3a");
+	setup_tab_layout->addWidget(save_inline_settings_button_);
+	setup_tab_layout->addWidget(settings_button_);
 
 	help_note_ = new QLabel(ui_text(
 		ui_language_,
 		"Open task-focused help for setup, recording, upload review, diagnostics, and language recovery.",
 		"セットアップ、録画、アップロード確認、診断、言語復旧のヘルプを開きます。"));
 	help_note_->setWordWrap(true);
-	help_tab_layout->addWidget(help_note_);
-	help_tab_layout->addWidget(help_button_);
-	help_tab_layout->addStretch(1);
+	setup_tab_layout->addWidget(help_note_);
+	setup_tab_layout->addWidget(help_button_);
 
 	automatic_note_ = new QLabel(ui_text(
 		ui_language_,
 		"Register local start/end templates and test detection before relying on automatic recording.",
 		"自動録画を使う前に、ローカルの開始/終了テンプレートを登録して検出テストを実行します。"));
 	automatic_note_->setWordWrap(true);
-	automatic_tab_layout->addWidget(automatic_note_);
-	automatic_tab_layout->addWidget(automatic_setup_button_);
-	automatic_tab_layout->addStretch(1);
+	setup_tab_layout->addWidget(automatic_note_);
+	setup_tab_layout->addWidget(automatic_setup_button_);
 
 	recording_card_ = make_card("#fff3df", "#ffd08a");
 	auto *recording_layout = qobject_cast<QVBoxLayout *>(recording_card_->layout());
@@ -560,7 +573,7 @@ void PluginUiController::register_ui()
 	upload_controls->addWidget(discard_upload_button_);
 	upload_controls->addWidget(mark_uploaded_button_);
 	upload_layout->addLayout(upload_controls);
-	recording_tab_layout->addWidget(upload_card_);
+	automatic_tab_layout->addWidget(upload_card_);
 
 	metadata_card_ = make_card("#fff7fb", "#ffb3d1");
 	auto *metadata_layout = qobject_cast<QVBoxLayout *>(metadata_card_->layout());
@@ -574,18 +587,84 @@ void PluginUiController::register_ui()
 	metadata_note_->setStyleSheet("color: #5c3650; font-size: 12px;");
 	metadata_layout->addWidget(metadata_note_);
 
+	metadata_match_label_ = make_value_label();
+	metadata_video_label_ = make_value_label();
+	metadata_status_label_ = make_value_label();
+	metadata_layout->addWidget(metadata_match_label_);
+	metadata_layout->addWidget(metadata_video_label_);
+
+	auto *metadata_form = new QFormLayout;
+	metadata_deck_input_ = new QComboBox;
+	metadata_deck_input_->setEditable(true);
+	for (const std::string &candidate : settings.deck_candidates) {
+		metadata_deck_input_->addItem(qstr_utf8(candidate));
+	}
+	metadata_opponent_input_ = new QComboBox;
+	metadata_opponent_input_->setEditable(true);
+	for (const std::string &candidate : settings.opponent_deck_candidates) {
+		metadata_opponent_input_->addItem(qstr_utf8(candidate));
+	}
+	metadata_result_input_ = new QLineEdit;
+	metadata_rank_input_ = new QLineEdit(qstr_utf8(settings.last_rank));
+	metadata_dp_input_ = new QLineEdit(qstr_utf8(settings.last_dp));
+	metadata_memo_input_ = new QTextEdit;
+	metadata_memo_input_->setMaximumHeight(80);
+	metadata_form->addRow(ui_text(ui_language_, "Deck", "自分のデッキ"), metadata_deck_input_);
+	metadata_form->addRow(ui_text(ui_language_, "Opponent deck", "相手のデッキ"), metadata_opponent_input_);
+	metadata_form->addRow(ui_text(ui_language_, "Result", "結果"), metadata_result_input_);
+	metadata_form->addRow(ui_text(ui_language_, "Rank", "ランク"), metadata_rank_input_);
+	metadata_form->addRow(ui_text(ui_language_, "DP", "DP"), metadata_dp_input_);
+	metadata_form->addRow(ui_text(ui_language_, "Memo", "メモ"), metadata_memo_input_);
+	metadata_layout->addLayout(metadata_form);
+
 	edit_metadata_button_ = new QPushButton(ui_text(ui_language_, "Edit Metadata", "メタデータ編集"));
 	preview_metadata_button_ = new QPushButton(ui_text(ui_language_, "Preview Upload Metadata", "アップロード文面プレビュー"));
+	reload_metadata_button_ = new QPushButton(ui_text(ui_language_, "Reload", "再読込"));
+	save_metadata_button_ = new QPushButton(ui_text(ui_language_, "Save", "保存"));
 	QObject::connect(edit_metadata_button_, &QPushButton::clicked, [this]() { request_edit_metadata(); });
 	QObject::connect(preview_metadata_button_, &QPushButton::clicked, [this]() { request_preview_upload_metadata(); });
+	QObject::connect(reload_metadata_button_, &QPushButton::clicked, [this]() { load_latest_metadata_into_dock(); });
+	QObject::connect(save_metadata_button_, &QPushButton::clicked, [this]() { save_metadata_from_dock(); });
 	style_button(edit_metadata_button_, "#d45087", "#ffffff");
 	style_button(preview_metadata_button_, "#8a2d5d", "#ffffff");
+	style_button(reload_metadata_button_, "#6b7280", "#ffffff");
+	style_button(save_metadata_button_, "#d45087", "#ffffff");
 	auto *metadata_controls = new QHBoxLayout;
+	metadata_controls->addWidget(reload_metadata_button_);
+	metadata_controls->addWidget(save_metadata_button_);
 	metadata_controls->addWidget(edit_metadata_button_);
 	metadata_controls->addWidget(preview_metadata_button_);
 	metadata_layout->addLayout(metadata_controls);
-	recording_tab_layout->addWidget(metadata_card_);
-	recording_tab_layout->addStretch(1);
+	metadata_layout->addWidget(metadata_status_label_);
+	settings_tab_layout->addWidget(metadata_card_);
+	settings_tab_layout->addStretch(1);
+
+	upload_template_card_ = make_card("#fff7fb", "#ffb3d1");
+	auto *upload_template_layout = qobject_cast<QVBoxLayout *>(upload_template_card_->layout());
+	upload_preview_title_label_ = add_card_title(upload_template_layout,
+						     language_is_japanese(ui_language_) ? "アップロード文面" : "Upload text",
+						     "#8a2d5d");
+	auto *template_form = new QFormLayout;
+	upload_title_template_input_ = new QLineEdit(qstr_utf8(settings.upload_title_template));
+	upload_description_template_input_ = new QTextEdit(qstr_utf8(settings.upload_description_template));
+	upload_description_template_input_->setMaximumHeight(110);
+	upload_tags_template_input_ = new QLineEdit(qstr_utf8(settings.upload_tags_template));
+	template_form->addRow(ui_text(ui_language_, "Title template", "タイトルテンプレート"), upload_title_template_input_);
+	template_form->addRow(ui_text(ui_language_, "Description template", "説明文テンプレート"), upload_description_template_input_);
+	template_form->addRow(ui_text(ui_language_, "Tags template", "タグテンプレート"), upload_tags_template_input_);
+	upload_template_layout->addLayout(template_form);
+	render_upload_preview_button_ = new QPushButton(ui_text(ui_language_, "Preview", "プレビュー"));
+	QObject::connect(render_upload_preview_button_, &QPushButton::clicked, [this]() { render_upload_preview_from_dock(); });
+	style_button(render_upload_preview_button_, "#8a2d5d", "#ffffff");
+	upload_template_layout->addWidget(render_upload_preview_button_);
+	upload_preview_description_ = new QTextEdit;
+	upload_preview_description_->setReadOnly(true);
+	upload_preview_description_->setMaximumHeight(130);
+	upload_preview_warning_label_ = make_value_label();
+	upload_template_layout->addWidget(upload_preview_description_);
+	upload_template_layout->addWidget(upload_preview_warning_label_);
+	automatic_tab_layout->addWidget(upload_template_card_);
+	automatic_tab_layout->addStretch(1);
 
 	diagnostics_group_ = new QGroupBox(ui_text(ui_language_, "Diagnostics", "診断"));
 	auto *diagnostics_form = new QFormLayout(diagnostics_group_);
@@ -596,15 +675,18 @@ void PluginUiController::register_ui()
 	logs_value_ = add_row(diagnostics_form, "Logs", &logs_label_);
 	ownership_value_ = add_row(diagnostics_form, "Ownership", &ownership_label_);
 	detail_value_ = add_row(diagnostics_form, "Detail", &detail_label_);
-	diagnostics_tab_layout->addWidget(diagnostics_group_);
-	diagnostics_tab_layout->addStretch(1);
+	diagnostics_details_button_ = new QPushButton(ui_text(ui_language_, "Show Details", "詳細を表示"));
+	QObject::connect(diagnostics_details_button_, &QPushButton::clicked, [this]() { toggle_diagnostics_details(); });
+	style_button(diagnostics_details_button_, "#6b7280", "#ffffff");
+	setup_tab_layout->addWidget(diagnostics_details_button_);
+	setup_tab_layout->addWidget(diagnostics_group_);
+	diagnostics_group_->setVisible(false);
+	setup_tab_layout->addStretch(1);
 
 	dock_tabs_->addTab(recording_tab, ui_text(ui_language_, "Record", "録画"));
-	dock_tabs_->addTab(setup_tab, ui_text(ui_language_, "Setup", "セットアップ"));
-	dock_tabs_->addTab(settings_tab, ui_text(ui_language_, "Settings", "設定"));
-	dock_tabs_->addTab(automatic_tab, ui_text(ui_language_, "Auto", "自動"));
-	dock_tabs_->addTab(help_tab, ui_text(ui_language_, "Help", "ヘルプ"));
-	dock_tabs_->addTab(diagnostics_tab, ui_text(ui_language_, "Diagnostics", "診断"));
+	dock_tabs_->addTab(settings_tab, ui_text(ui_language_, "Metadata", "メタデータ"));
+	dock_tabs_->addTab(automatic_tab, ui_text(ui_language_, "Upload", "アップロード"));
+	dock_tabs_->addTab(setup_tab, ui_text(ui_language_, "Manage", "管理"));
 	apply_ui_language();
 	apply_dock_theme(dock_theme_);
 
@@ -619,6 +701,7 @@ void PluginUiController::register_ui()
 	QObject::connect(refresh_timer_, &QTimer::timeout, [this]() { refresh(); });
 	refresh_timer_->start(1000);
 	refresh();
+	load_latest_metadata_into_dock();
 	blog(LOG_INFO, "%s dock registered id=%s", kLogPrefix, kDockId);
 }
 
@@ -637,6 +720,7 @@ void PluginUiController::apply_dock_theme(const std::string &theme)
 	style_card(recording_card_, palette.recording_bg, palette.recording_border);
 	style_card(upload_card_, palette.upload_bg, palette.upload_border);
 	style_card(metadata_card_, palette.metadata_bg, palette.metadata_border);
+	style_card(upload_template_card_, palette.metadata_bg, palette.metadata_border);
 	if (diagnostics_group_) {
 		diagnostics_group_->setStyleSheet(QString::fromUtf8(
 			"QGroupBox { color: #354f52; font-weight: 700; border: 1px solid %1; "
@@ -677,17 +761,30 @@ void PluginUiController::apply_dock_theme(const std::string &theme)
 	if (preview_metadata_button_) {
 		style_button(preview_metadata_button_, palette.header_bg, "#ffffff");
 	}
+	if (reload_metadata_button_) {
+		style_button(reload_metadata_button_, palette.secondary_bg, palette.secondary_fg);
+	}
+	if (save_metadata_button_) {
+		style_button(save_metadata_button_, palette.metadata_bg_button, palette.metadata_fg_button);
+	}
+	if (render_upload_preview_button_) {
+		style_button(render_upload_preview_button_, palette.header_bg, "#ffffff");
+	}
+	if (save_inline_settings_button_) {
+		style_button(save_inline_settings_button_, palette.settings_bg, palette.settings_fg);
+	}
+	if (diagnostics_details_button_) {
+		style_button(diagnostics_details_button_, palette.secondary_bg, palette.secondary_fg);
+	}
 }
 
 void PluginUiController::apply_ui_language()
 {
 	if (dock_tabs_) {
 		dock_tabs_->setTabText(0, ui_text(ui_language_, "Record", "録画"));
-		dock_tabs_->setTabText(1, ui_text(ui_language_, "Setup", "セットアップ"));
-		dock_tabs_->setTabText(2, ui_text(ui_language_, "Settings", "設定"));
-		dock_tabs_->setTabText(3, ui_text(ui_language_, "Auto", "自動"));
-		dock_tabs_->setTabText(4, ui_text(ui_language_, "Help", "ヘルプ"));
-		dock_tabs_->setTabText(5, ui_text(ui_language_, "Diagnostics", "診断"));
+		dock_tabs_->setTabText(1, ui_text(ui_language_, "Metadata", "メタデータ"));
+		dock_tabs_->setTabText(2, ui_text(ui_language_, "Upload", "アップロード"));
+		dock_tabs_->setTabText(3, ui_text(ui_language_, "Manage", "管理"));
 	}
 	if (setup_title_) {
 		setup_title_->setText(ui_text(ui_language_, "Setup", "セットアップ"));
@@ -794,6 +891,26 @@ void PluginUiController::apply_ui_language()
 	if (preview_metadata_button_) {
 		preview_metadata_button_->setText(ui_text(ui_language_, "Preview Upload Metadata", "アップロード文面プレビュー"));
 	}
+	if (reload_metadata_button_) {
+		reload_metadata_button_->setText(ui_text(ui_language_, "Reload", "再読込"));
+	}
+	if (save_metadata_button_) {
+		save_metadata_button_->setText(ui_text(ui_language_, "Save", "保存"));
+	}
+	if (render_upload_preview_button_) {
+		render_upload_preview_button_->setText(ui_text(ui_language_, "Preview", "プレビュー"));
+	}
+	if (save_inline_settings_button_) {
+		save_inline_settings_button_->setText(ui_text(ui_language_, "Save Settings", "設定を保存"));
+	}
+	if (diagnostics_details_button_) {
+		diagnostics_details_button_->setText(
+			ui_text(ui_language_, diagnostics_details_visible_ ? "Hide Details" : "Show Details",
+				diagnostics_details_visible_ ? "詳細を隠す" : "詳細を表示"));
+	}
+	if (upload_preview_title_label_) {
+		upload_preview_title_label_->setText(ui_text(ui_language_, "Upload text", "アップロード文面"));
+	}
 }
 
 void PluginUiController::unregister_ui()
@@ -860,6 +977,15 @@ void PluginUiController::refresh()
 	}
 	if (preview_metadata_button_) {
 		preview_metadata_button_->setEnabled(worker_running);
+	}
+	if (reload_metadata_button_) {
+		reload_metadata_button_->setEnabled(worker_running);
+	}
+	if (save_metadata_button_) {
+		save_metadata_button_->setEnabled(worker_running && current_match_id_ > 0);
+	}
+	if (render_upload_preview_button_) {
+		render_upload_preview_button_->setEnabled(worker_running && current_match_id_ > 0);
 	}
 	if (automatic_setup_button_) {
 		automatic_setup_button_->setEnabled(worker_running);
@@ -1085,12 +1211,12 @@ void PluginUiController::request_edit_metadata()
 		const QString message = fetched.status == MatchFetchStatus::not_found ?
 						QString::fromUtf8("No completed match metadata is available yet.") :
 						qstr_utf8(fetched.error.empty() ? "Worker metadata API is unavailable." : fetched.error);
-		QMessageBox::warning(dock_widget_, "Edit metadata", message);
+		QMessageBox::warning(dock_widget_, ui_text(ui_language_, "Edit metadata", "メタデータ編集"), message);
 		return;
 	}
 
 	QDialog dialog(dock_widget_);
-	dialog.setWindowTitle(QString::fromUtf8("Edit Match Metadata"));
+	dialog.setWindowTitle(ui_text(ui_language_, "Edit Match Metadata", "対戦メタデータ編集"));
 
 	auto *layout = new QVBoxLayout(&dialog);
 	auto *form = new QFormLayout;
@@ -1102,12 +1228,12 @@ void PluginUiController::request_edit_metadata()
 	auto *memo_input = new QTextEdit(qstr_utf8(fetched.match.memo));
 	memo_input->setAcceptRichText(false);
 
-	form->addRow("Deck", deck_input);
-	form->addRow("Opponent deck", opponent_input);
-	form->addRow("Result", result_input);
-	form->addRow("Rank", rank_input);
-	form->addRow("DP", dp_input);
-	form->addRow("Memo", memo_input);
+	form->addRow(ui_text(ui_language_, "Deck", "自分のデッキ"), deck_input);
+	form->addRow(ui_text(ui_language_, "Opponent deck", "相手のデッキ"), opponent_input);
+	form->addRow(ui_text(ui_language_, "Result", "結果"), result_input);
+	form->addRow(ui_text(ui_language_, "Rank", "ランク"), rank_input);
+	form->addRow(ui_text(ui_language_, "DP", "DP"), dp_input);
+	form->addRow(ui_text(ui_language_, "Memo", "メモ"), memo_input);
 	layout->addLayout(form);
 
 	auto *buttons = new QDialogButtonBox(QDialogButtonBox::Save | QDialogButtonBox::Cancel);
@@ -1131,7 +1257,7 @@ void PluginUiController::request_edit_metadata()
 	if (!result.accepted()) {
 		QMessageBox::warning(
 			dock_widget_,
-			"Edit metadata",
+			ui_text(ui_language_, "Edit metadata", "メタデータ編集"),
 			qstr_utf8(result.error.empty() ? "Metadata was rejected by the Worker." : result.error));
 		blog(LOG_WARNING, "%s metadata update failed status=%d http=%lu id=%d error=%s",
 		     kLogPrefix, static_cast<int>(result.status), result.http_status, updated.id, result.error.c_str());
@@ -1149,7 +1275,7 @@ void PluginUiController::request_preview_upload_metadata()
 		const QString message = fetched.status == MatchFetchStatus::not_found ?
 						QString::fromUtf8("No completed match metadata is available yet.") :
 						qstr_utf8(fetched.error.empty() ? "Worker metadata API is unavailable." : fetched.error);
-		QMessageBox::warning(dock_widget_, "Preview upload metadata", message);
+		QMessageBox::warning(dock_widget_, ui_text(ui_language_, "Preview upload metadata", "アップロード文面プレビュー"), message);
 		return;
 	}
 
@@ -1158,7 +1284,7 @@ void PluginUiController::request_preview_upload_metadata()
 	if (!preview.reachable()) {
 		QMessageBox::warning(
 			dock_widget_,
-			"Preview upload metadata",
+			ui_text(ui_language_, "Preview upload metadata", "アップロード文面プレビュー"),
 			qstr_utf8(preview.error.empty() ? "Upload metadata preview is unavailable." : preview.error));
 		blog(LOG_WARNING, "%s upload metadata preview failed status=%d http=%lu id=%d error=%s",
 		     kLogPrefix, static_cast<int>(preview.status), preview.http_status, fetched.match.id,
@@ -1167,7 +1293,7 @@ void PluginUiController::request_preview_upload_metadata()
 	}
 
 	QDialog dialog(dock_widget_);
-	dialog.setWindowTitle(QString::fromUtf8("Upload Metadata Preview"));
+	dialog.setWindowTitle(ui_text(ui_language_, "Upload Metadata Preview", "アップロード文面プレビュー"));
 
 	auto *layout = new QVBoxLayout(&dialog);
 	auto *form = new QFormLayout;
@@ -1182,8 +1308,11 @@ void PluginUiController::request_preview_upload_metadata()
 			preview.preview.warning + ". Use Edit Metadata before uploading if needed."));
 	warning->setWordWrap(true);
 
-	form->addRow("Title", title_preview);
-	form->addRow("Description", description_preview);
+	auto *tags_preview = new QLineEdit(qstr_utf8(preview.preview.tags));
+	tags_preview->setReadOnly(true);
+	form->addRow(ui_text(ui_language_, "Title", "タイトル"), title_preview);
+	form->addRow(ui_text(ui_language_, "Description", "説明文"), description_preview);
+	form->addRow(ui_text(ui_language_, "Tags", "タグ"), tags_preview);
 	layout->addLayout(form);
 	layout->addWidget(warning);
 
@@ -1193,6 +1322,193 @@ void PluginUiController::request_preview_upload_metadata()
 	dialog.exec();
 
 	blog(LOG_INFO, "%s upload metadata preview shown id=%d", kLogPrefix, preview.preview.match_id);
+}
+
+void PluginUiController::load_latest_metadata_into_dock()
+{
+	const MatchFetchResult fetched = worker_manager_.fetch_latest_match();
+	PluginSettings settings = load_plugin_settings();
+	if (!fetched.reachable()) {
+		current_match_id_ = 0;
+		if (metadata_match_label_) {
+			metadata_match_label_->setText(ui_text(ui_language_, "No completed match is available yet.",
+							       "完了した録画メタデータはまだありません。"));
+		}
+		if (metadata_status_label_) {
+			metadata_status_label_->setText(qstr_utf8(fetched.error));
+		}
+		return;
+	}
+
+	current_match_id_ = fetched.match.id;
+	if (metadata_match_label_) {
+		metadata_match_label_->setText(QString::fromUtf8("Match #%1").arg(fetched.match.id));
+	}
+	const WorkerStatusSnapshot snapshot = worker_manager_.status_snapshot();
+	const std::string video = !snapshot.recording_output_path.empty() ?
+					  snapshot.recording_output_path :
+					  (snapshot.queue_action_item_available ? snapshot.queue_action_item.item.video_path : "");
+	if (metadata_video_label_) {
+		metadata_video_label_->setText(video.empty() ?
+						       ui_text(ui_language_, "Preview: video path is not linked yet.",
+							       "プレビュー: 動画パスはまだ紐づいていません。") :
+						       ui_text(ui_language_, "Preview source: ", "確認対象: ") + qstr_utf8(video));
+	}
+	if (metadata_deck_input_) {
+		metadata_deck_input_->setCurrentText(qstr_utf8(fetched.match.deck_name.empty() ? settings.last_deck_name :
+									 fetched.match.deck_name));
+	}
+	if (metadata_opponent_input_) {
+		metadata_opponent_input_->setCurrentText(qstr_utf8(fetched.match.opponent_deck.empty() ?
+									     settings.last_opponent_deck :
+									     fetched.match.opponent_deck));
+	}
+	if (metadata_result_input_) {
+		metadata_result_input_->setText(qstr_utf8(fetched.match.result));
+	}
+	if (metadata_rank_input_) {
+		metadata_rank_input_->setText(qstr_utf8(fetched.match.rank.empty() ? settings.last_rank : fetched.match.rank));
+	}
+	if (metadata_dp_input_) {
+		metadata_dp_input_->setText(qstr_utf8(fetched.match.dp.empty() ? settings.last_dp : fetched.match.dp));
+	}
+	if (metadata_memo_input_) {
+		metadata_memo_input_->setPlainText(qstr_utf8(fetched.match.memo));
+	}
+	if (upload_title_template_input_) {
+		upload_title_template_input_->setText(qstr_utf8(fetched.match.title_template.empty() ?
+								 settings.upload_title_template :
+								 fetched.match.title_template));
+	}
+	if (upload_description_template_input_) {
+		upload_description_template_input_->setPlainText(qstr_utf8(fetched.match.description_template.empty() ?
+									  settings.upload_description_template :
+									  fetched.match.description_template));
+	}
+	if (upload_tags_template_input_) {
+		upload_tags_template_input_->setText(qstr_utf8(fetched.match.tags_template.empty() ?
+							       settings.upload_tags_template :
+							       fetched.match.tags_template));
+	}
+	if (metadata_status_label_) {
+		metadata_status_label_->setText(ui_text(ui_language_, "Loaded latest match.", "最新の対戦を読み込みました。"));
+	}
+}
+
+void PluginUiController::save_metadata_from_dock()
+{
+	if (current_match_id_ <= 0) {
+		load_latest_metadata_into_dock();
+	}
+	if (current_match_id_ <= 0) {
+		return;
+	}
+
+	PluginSettings settings = load_plugin_settings();
+	MatchMetadataPayload payload;
+	payload.id = current_match_id_;
+	payload.deck_name = combo_text(metadata_deck_input_);
+	payload.opponent_deck = combo_text(metadata_opponent_input_);
+	payload.result = metadata_result_input_ ? utf8_string(metadata_result_input_->text().trimmed()) : std::string{};
+	payload.rank = metadata_rank_input_ ? utf8_string(metadata_rank_input_->text().trimmed()) : std::string{};
+	payload.dp = metadata_dp_input_ ? utf8_string(metadata_dp_input_->text().trimmed()) : std::string{};
+	payload.memo = metadata_memo_input_ ? utf8_string(metadata_memo_input_->toPlainText().trimmed()) : std::string{};
+	payload.title_template = upload_title_template_input_ ? utf8_string(upload_title_template_input_->text()) :
+								settings.upload_title_template;
+	payload.description_template = upload_description_template_input_ ?
+					       utf8_string(upload_description_template_input_->toPlainText()) :
+					       settings.upload_description_template;
+	payload.tags_template = upload_tags_template_input_ ? utf8_string(upload_tags_template_input_->text()) :
+							      settings.upload_tags_template;
+
+	add_unique_candidate(settings.deck_candidates, payload.deck_name);
+	add_unique_candidate(settings.opponent_deck_candidates, payload.opponent_deck);
+	settings.last_deck_name = payload.deck_name;
+	settings.last_opponent_deck = payload.opponent_deck;
+	settings.last_rank = payload.rank;
+	settings.last_dp = payload.dp;
+	settings.upload_title_template = payload.title_template;
+	settings.upload_description_template = payload.description_template;
+	settings.upload_tags_template = payload.tags_template;
+	save_plugin_settings(settings);
+
+	const MetadataUpdateResult result = worker_manager_.update_match_metadata(payload);
+	if (!result.accepted()) {
+		if (metadata_status_label_) {
+			metadata_status_label_->setText(qstr_utf8(result.error.empty() ?
+								  "Metadata was rejected by the Worker." :
+								  result.error));
+		}
+		return;
+	}
+	if (metadata_status_label_) {
+		metadata_status_label_->setText(ui_text(ui_language_, "Saved. Previous deck/rank/DP values were retained.",
+							"保存しました。デッキ/ランク/DP は次回入力に引き継がれます。"));
+	}
+	render_upload_preview_from_dock();
+}
+
+void PluginUiController::render_upload_preview_from_dock()
+{
+	if (current_match_id_ <= 0) {
+		load_latest_metadata_into_dock();
+	}
+	if (current_match_id_ <= 0) {
+		return;
+	}
+
+	const UploadMetadataPreviewResult preview = worker_manager_.fetch_upload_metadata_preview(current_match_id_);
+	if (!preview.reachable()) {
+		if (upload_preview_warning_label_) {
+			upload_preview_warning_label_->setText(qstr_utf8(preview.error));
+		}
+		return;
+	}
+	if (upload_preview_title_label_) {
+		upload_preview_title_label_->setText(qstr_utf8(preview.preview.title));
+	}
+	if (upload_preview_description_) {
+		QString text = qstr_utf8(preview.preview.description);
+		if (!preview.preview.tags.empty()) {
+			text += QString::fromUtf8("\n\nTags: ") + qstr_utf8(preview.preview.tags);
+		}
+		upload_preview_description_->setPlainText(text);
+	}
+	if (upload_preview_warning_label_) {
+		upload_preview_warning_label_->setText(preview.preview.warning.empty() ?
+							       ui_text(ui_language_, "No preview warnings.",
+								       "プレビュー警告はありません。") :
+							       qstr_utf8(preview.preview.warning));
+	}
+}
+
+void PluginUiController::save_inline_settings()
+{
+	PluginSettings settings = load_plugin_settings();
+	bool ok = false;
+	const int port = settings_port_input_ ? settings_port_input_->text().toInt(&ok) : settings.endpoint.port;
+	settings.endpoint.host = settings_host_input_ ? settings_host_input_->text().toStdWString() : settings.endpoint.host;
+	settings.endpoint.port = static_cast<uint16_t>(ok && port > 0 && port <= 65535 ? port : settings.endpoint.port);
+	settings.user_data_dir = settings_user_data_input_ ? settings_user_data_input_->text().toStdWString() :
+							    settings.user_data_dir;
+	settings.dock_theme = settings_theme_input_ ? utf8_string(settings_theme_input_->currentData().toString()) :
+						      settings.dock_theme;
+	settings.ui_language = settings_language_input_ ? utf8_string(settings_language_input_->currentData().toString()) :
+							 settings.ui_language;
+	settings.restart_worker_on_change = true;
+	ui_language_ = settings.ui_language;
+	apply_ui_language();
+	apply_dock_theme(settings.dock_theme);
+	save_settings_and_restart(settings);
+}
+
+void PluginUiController::toggle_diagnostics_details()
+{
+	diagnostics_details_visible_ = !diagnostics_details_visible_;
+	if (diagnostics_group_) {
+		diagnostics_group_->setVisible(diagnostics_details_visible_);
+	}
+	apply_ui_language();
 }
 
 void PluginUiController::request_show_help()
@@ -1225,14 +1541,14 @@ void PluginUiController::request_show_help()
 void PluginUiController::request_automatic_setup()
 {
 	QDialog dialog(dock_widget_);
-	dialog.setWindowTitle("Automatic Recording Setup");
+	dialog.setWindowTitle(ui_text(ui_language_, "Automatic Recording Setup", "自動録画セットアップ"));
 
 	auto *layout = new QVBoxLayout(&dialog);
 	auto *form = new QFormLayout;
 
 	auto *kind_input = new QComboBox;
-	kind_input->addItem("Start template", QString::fromUtf8("start"));
-	kind_input->addItem("End template", QString::fromUtf8("end"));
+	kind_input->addItem(ui_text(ui_language_, "Start template", "開始テンプレート"), QString::fromUtf8("start"));
+	kind_input->addItem(ui_text(ui_language_, "End template", "終了テンプレート"), QString::fromUtf8("end"));
 	auto *path_input = new QLineEdit;
 	path_input->setPlaceholderText("C:/path/to/user_data/templates/duel-start.tpl");
 	auto *threshold_input = new QDoubleSpinBox;
@@ -1245,28 +1561,32 @@ void PluginUiController::request_automatic_setup()
 	confirmations_input->setValue(2);
 	auto *test_frame_input = new QTextEdit;
 	test_frame_input->setAcceptRichText(false);
-	test_frame_input->setPlaceholderText("Paste a local fixture string or test frame text. Do not paste secrets.");
+	test_frame_input->setPlaceholderText(ui_text(ui_language_,
+						    "Paste a local fixture string or test frame text. Do not paste secrets.",
+						    "ローカルのテスト文字列またはフレームテキストを貼り付けます。秘密情報は貼り付けないでください。"));
 	test_frame_input->setFixedHeight(84);
 
-	form->addRow("Template kind", kind_input);
-	form->addRow("Template path", path_input);
-	form->addRow("Threshold", threshold_input);
-	form->addRow("Confirmations", confirmations_input);
-	form->addRow("Test frame text", test_frame_input);
+	form->addRow(ui_text(ui_language_, "Template kind", "テンプレート種別"), kind_input);
+	form->addRow(ui_text(ui_language_, "Template path", "テンプレートパス"), path_input);
+	form->addRow(ui_text(ui_language_, "Threshold", "しきい値"), threshold_input);
+	form->addRow(ui_text(ui_language_, "Confirmations", "確認回数"), confirmations_input);
+	form->addRow(ui_text(ui_language_, "Test frame text", "テストフレーム文字列"), test_frame_input);
 	layout->addLayout(form);
 
 	auto *status = new QTextEdit;
 	status->setReadOnly(true);
 	status->setAcceptRichText(false);
-	status->setPlaceholderText("Validation, registration, and detection test results appear here.");
+	status->setPlaceholderText(ui_text(ui_language_,
+					  "Validation, registration, and detection test results appear here.",
+					  "検証、登録、検出テストの結果がここに表示されます。"));
 	status->setMinimumHeight(150);
 	layout->addWidget(status);
 
 	auto *buttons = new QHBoxLayout;
-	auto *validate_button = new QPushButton("Validate Setup");
-	auto *register_button = new QPushButton("Register Template");
-	auto *test_button = new QPushButton("Test Detection");
-	auto *close_button = new QPushButton("Close");
+	auto *validate_button = new QPushButton(ui_text(ui_language_, "Validate Setup", "セットアップ検証"));
+	auto *register_button = new QPushButton(ui_text(ui_language_, "Register Template", "テンプレート登録"));
+	auto *test_button = new QPushButton(ui_text(ui_language_, "Test Detection", "検出テスト"));
+	auto *close_button = new QPushButton(ui_text(ui_language_, "Close", "閉じる"));
 	buttons->addWidget(validate_button);
 	buttons->addWidget(register_button);
 	buttons->addWidget(test_button);

--- a/app/plugin/src/plugin-ui.hpp
+++ b/app/plugin/src/plugin-ui.hpp
@@ -7,9 +7,12 @@
 
 class QLabel;
 class QPushButton;
+class QComboBox;
 class QFrame;
 class QGroupBox;
+class QLineEdit;
 class QTabWidget;
+class QTextEdit;
 class QTimer;
 class QWidget;
 
@@ -36,6 +39,11 @@ private:
 	void request_upload_mark_uploaded();
 	void request_edit_metadata();
 	void request_preview_upload_metadata();
+	void load_latest_metadata_into_dock();
+	void save_metadata_from_dock();
+	void render_upload_preview_from_dock();
+	void save_inline_settings();
+	void toggle_diagnostics_details();
 	void request_show_help();
 	void request_automatic_setup();
 	void handle_automatic_recording(const WorkerStatusSnapshot &snapshot);
@@ -69,6 +77,11 @@ private:
 	QLabel *review_item_label_ = nullptr;
 	QLabel *metadata_title_ = nullptr;
 	QLabel *metadata_note_ = nullptr;
+	QLabel *metadata_match_label_ = nullptr;
+	QLabel *metadata_video_label_ = nullptr;
+	QLabel *metadata_status_label_ = nullptr;
+	QLabel *upload_preview_title_label_ = nullptr;
+	QLabel *upload_preview_warning_label_ = nullptr;
 	QLabel *settings_note_ = nullptr;
 	QLabel *help_note_ = nullptr;
 	QLabel *automatic_note_ = nullptr;
@@ -83,8 +96,24 @@ private:
 	QFrame *recording_card_ = nullptr;
 	QFrame *upload_card_ = nullptr;
 	QFrame *metadata_card_ = nullptr;
+	QFrame *upload_template_card_ = nullptr;
 	QGroupBox *diagnostics_group_ = nullptr;
 	QTabWidget *dock_tabs_ = nullptr;
+	QComboBox *metadata_deck_input_ = nullptr;
+	QComboBox *metadata_opponent_input_ = nullptr;
+	QLineEdit *metadata_result_input_ = nullptr;
+	QLineEdit *metadata_rank_input_ = nullptr;
+	QLineEdit *metadata_dp_input_ = nullptr;
+	QTextEdit *metadata_memo_input_ = nullptr;
+	QLineEdit *upload_title_template_input_ = nullptr;
+	QTextEdit *upload_description_template_input_ = nullptr;
+	QLineEdit *upload_tags_template_input_ = nullptr;
+	QTextEdit *upload_preview_description_ = nullptr;
+	QLineEdit *settings_host_input_ = nullptr;
+	QLineEdit *settings_port_input_ = nullptr;
+	QLineEdit *settings_user_data_input_ = nullptr;
+	QComboBox *settings_theme_input_ = nullptr;
+	QComboBox *settings_language_input_ = nullptr;
 	QPushButton *settings_button_ = nullptr;
 	QPushButton *help_button_ = nullptr;
 	QPushButton *automatic_setup_button_ = nullptr;
@@ -95,9 +124,16 @@ private:
 	QPushButton *mark_uploaded_button_ = nullptr;
 	QPushButton *edit_metadata_button_ = nullptr;
 	QPushButton *preview_metadata_button_ = nullptr;
+	QPushButton *reload_metadata_button_ = nullptr;
+	QPushButton *save_metadata_button_ = nullptr;
+	QPushButton *render_upload_preview_button_ = nullptr;
+	QPushButton *save_inline_settings_button_ = nullptr;
+	QPushButton *diagnostics_details_button_ = nullptr;
 	std::string dock_theme_ = "classic";
 	std::string ui_language_ = "en";
 	OverlayStatePayload last_applied_overlay_state_;
+	int current_match_id_ = 0;
+	bool diagnostics_details_visible_ = false;
 	std::string automatic_recording_request_key_;
 	bool overlay_state_applied_ = false;
 	bool tools_menu_registered_ = false;

--- a/app/plugin/src/worker-api.cpp
+++ b/app/plugin/src/worker-api.cpp
@@ -77,6 +77,25 @@ std::string extract_json_number(const std::string &body, const char *key)
 	return match[1].str();
 }
 
+std::string extract_json_string_array(const std::string &body, const char *key)
+{
+	const std::regex pattern(std::string("\"") + key + "\"\\s*:\\s*\\[(.*?)\\]");
+	std::smatch match;
+	if (!std::regex_search(body, match, pattern) || match.size() < 2) {
+		return {};
+	}
+	const std::string array_body = match[1].str();
+	const std::regex item_pattern("\"((?:\\\\.|[^\"])*)\"");
+	std::ostringstream joined;
+	for (std::sregex_iterator it(array_body.begin(), array_body.end(), item_pattern), end; it != end; ++it) {
+		if (joined.tellp() > 0) {
+			joined << ", ";
+		}
+		joined << json_unescape((*it)[1].str());
+	}
+	return joined.str();
+}
+
 bool response_has_items(const std::string &body)
 {
 	const std::regex pattern("\"items\"\\s*:\\s*\\[\\s*\\{");
@@ -165,6 +184,9 @@ void populate_match_metadata(MatchMetadataPayload &match, const std::string &bod
 	match.rank = extract_json_string(body, "rank");
 	match.dp = extract_json_string(body, "dp");
 	match.memo = extract_json_string(body, "memo");
+	match.title_template = extract_json_string(body, "title_template");
+	match.description_template = extract_json_string(body, "description_template");
+	match.tags_template = extract_json_string(body, "tags_template");
 }
 
 void populate_upload_metadata_preview(UploadMetadataPreviewPayload &preview, const std::string &body)
@@ -173,6 +195,7 @@ void populate_upload_metadata_preview(UploadMetadataPreviewPayload &preview, con
 	preview.match_id = id.empty() ? 0 : std::stoi(id);
 	preview.title = extract_json_string(body, "title");
 	preview.description = extract_json_string(body, "description");
+	preview.tags = extract_json_string_array(body, "tags");
 	preview.notes = extract_json_string(body, "notes");
 	preview.warning = extract_json_string(body, "warning");
 }
@@ -714,7 +737,10 @@ MetadataUpdateResult LocalhostApiClient::update_match_metadata(const WorkerEndpo
 			   "\",\"result\":\"" + json_escape(metadata.result) +
 			   "\",\"rank\":\"" + json_escape(metadata.rank) +
 			   "\",\"dp\":\"" + json_escape(metadata.dp) +
-			   "\",\"memo\":\"" + json_escape(metadata.memo) + "\"}";
+			   "\",\"memo\":\"" + json_escape(metadata.memo) +
+			   "\",\"title_template\":\"" + json_escape(metadata.title_template) +
+			   "\",\"description_template\":\"" + json_escape(metadata.description_template) +
+			   "\",\"tags_template\":\"" + json_escape(metadata.tags_template) + "\"}";
 	const std::wstring path = L"/matches/" + std::to_wstring(metadata.id) + L"/metadata";
 	const HttpResponse response = http_put_json(endpoint, path.c_str(), body);
 	result.http_status = response.status;

--- a/app/plugin/src/worker-api.hpp
+++ b/app/plugin/src/worker-api.hpp
@@ -214,6 +214,9 @@ struct MatchMetadataPayload {
 	std::string rank;
 	std::string dp;
 	std::string memo;
+	std::string title_template;
+	std::string description_template;
+	std::string tags_template;
 };
 
 struct MatchFetchResult {
@@ -246,6 +249,7 @@ struct UploadMetadataPreviewPayload {
 	int match_id = 0;
 	std::string title;
 	std::string description;
+	std::string tags;
 	std::string notes;
 	std::string warning;
 };

--- a/app/worker/odr_worker/db.py
+++ b/app/worker/odr_worker/db.py
@@ -30,6 +30,7 @@ _MIGRATIONS: tuple[str, ...] = (
     "0007_statistics_indexes",
     "0008_runtime_optimization_indexes",
     "0009_recording_match_link",
+    "0010_upload_metadata_templates",
 )
 
 

--- a/app/worker/odr_worker/metadata.py
+++ b/app/worker/odr_worker/metadata.py
@@ -8,8 +8,27 @@ from typing import Any
 
 
 DEFAULT_TITLE_TEMPLATE = "Duel {match_id} vs {opponent_deck} - {result}"
+DEFAULT_DESCRIPTION_TEMPLATE = "\n".join(
+    [
+        "OBS Duel Recorder Archive",
+        "",
+        "Match ID: {match_id}",
+        "Deck: {deck_name}",
+        "Opponent: {opponent_deck}",
+        "Result: {result}",
+        "Rank: {rank}",
+        "DP: {dp}",
+        "Started: {started_at}",
+        "Ended: {ended_at}",
+        "",
+        "Notes:",
+        "{memo}",
+    ]
+)
+DEFAULT_TAGS_TEMPLATE = "Yu-Gi-Oh! Master Duel,{deck_name},{opponent_deck},{result}"
 MAX_TITLE_LENGTH = 100
 MAX_DESCRIPTION_LENGTH = 5000
+MAX_TAGS_COUNT = 15
 FIELD_LIMITS = {
     "deck_name": 120,
     "opponent_deck": 120,
@@ -20,6 +39,8 @@ FIELD_LIMITS = {
     "started_at": 64,
     "ended_at": 64,
     "title_template": 200,
+    "description_template": 5000,
+    "tags_template": 500,
 }
 
 
@@ -45,6 +66,8 @@ class MatchMetadataRecord:
     started_at: str
     ended_at: str
     title_template: str
+    description_template: str
+    tags_template: str
 
     def as_payload(self) -> dict[str, object]:
         return {
@@ -61,6 +84,8 @@ class MatchMetadataRecord:
             "started_at": self.started_at,
             "ended_at": self.ended_at,
             "title_template": self.title_template,
+            "description_template": self.description_template,
+            "tags_template": self.tags_template,
         }
 
 
@@ -202,23 +227,34 @@ class MatchMetadataStore:
             "started_at": record.started_at or record.created_at,
             "ended_at": record.ended_at or "unknown",
             "created_at": record.created_at,
+            "memo": record.memo,
         }
         template = record.title_template or DEFAULT_TITLE_TEMPLATE
-        title = _truncate(template.format_map(_SafeDict(values)), MAX_TITLE_LENGTH)
-        description = _description(record, values)
+        description_template = record.description_template or DEFAULT_DESCRIPTION_TEMPLATE
+        tags_template = record.tags_template or DEFAULT_TAGS_TEMPLATE
+        title = _truncate(_render_template(template, values), MAX_TITLE_LENGTH)
+        description = _truncate(_render_template(description_template, values), MAX_DESCRIPTION_LENGTH)
+        tags = _tags(_render_template(tags_template, values))
         missing_fields = [
             field
             for field in ("deck_name", "opponent_deck", "result", "rank", "dp")
             if not getattr(record, field)
         ]
+        warnings = _upload_warnings(
+            missing_fields=missing_fields,
+            title=title,
+            description=description,
+            tags=tags,
+        )
         return {
             "match_id": record.id,
             "title": title,
             "description": description,
+            "tags": tags,
             "notes": record.memo,
             "variables": sorted(values.keys()),
             "missing_fields": missing_fields,
-            "warning": _missing_metadata_warning(missing_fields),
+            "warning": "\n".join(warnings),
         }
 
     def _get(self, conn: sqlite3.Connection, match_id: int) -> MatchMetadataRecord:
@@ -270,25 +306,45 @@ def _record_from_row(row: sqlite3.Row) -> MatchMetadataRecord:
         started_at=str(row["started_at"]),
         ended_at=str(row["ended_at"]),
         title_template=str(row["title_template"]),
+        description_template=str(row["description_template"]),
+        tags_template=str(row["tags_template"]),
     )
 
 
-def _description(record: MatchMetadataRecord, values: dict[str, str]) -> str:
-    lines = [
-        "OBS Duel Recorder Archive",
-        "",
-        f"Match ID: {record.id}",
-        f"Deck: {values['deck_name']}",
-        f"Opponent: {values['opponent_deck']}",
-        f"Result: {values['result']}",
-        f"Rank: {values['rank']}",
-        f"DP: {values['dp']}",
-        f"Started: {values['started_at']}",
-        f"Ended: {values['ended_at']}",
-    ]
-    if record.memo:
-        lines.extend(["", "Notes:", record.memo])
-    return _truncate("\n".join(lines), MAX_DESCRIPTION_LENGTH)
+def _render_template(template: str, values: dict[str, str]) -> str:
+    return template.format_map(_SafeDict(values))
+
+
+def _tags(value: str) -> list[str]:
+    tags: list[str] = []
+    seen: set[str] = set()
+    for item in value.replace("\n", ",").split(","):
+        tag = item.strip()
+        if not tag or tag.lower() in seen:
+            continue
+        tags.append(tag)
+        seen.add(tag.lower())
+    return tags[:MAX_TAGS_COUNT]
+
+
+def _upload_warnings(
+    *,
+    missing_fields: list[str],
+    title: str,
+    description: str,
+    tags: list[str],
+) -> list[str]:
+    warnings: list[str] = []
+    missing_warning = _missing_metadata_warning(missing_fields)
+    if missing_warning:
+        warnings.append(missing_warning)
+    if len(title) >= MAX_TITLE_LENGTH:
+        warnings.append(f"Title was truncated to {MAX_TITLE_LENGTH} characters")
+    if len(description) >= MAX_DESCRIPTION_LENGTH:
+        warnings.append(f"Description was truncated to {MAX_DESCRIPTION_LENGTH} characters")
+    if len(tags) >= MAX_TAGS_COUNT:
+        warnings.append(f"Tags were limited to {MAX_TAGS_COUNT} entries")
+    return warnings
 
 
 def _missing_metadata_warning(missing_fields: list[str]) -> str:

--- a/app/worker/odr_worker/migrations/0010_upload_metadata_templates.sql
+++ b/app/worker/odr_worker/migrations/0010_upload_metadata_templates.sql
@@ -1,0 +1,5 @@
+-- v1.1.3 migration 0010_upload_metadata_templates
+-- Purpose: store editable upload description and tag templates with match metadata.
+
+ALTER TABLE matches ADD COLUMN description_template TEXT NOT NULL DEFAULT '';
+ALTER TABLE matches ADD COLUMN tags_template TEXT NOT NULL DEFAULT '';

--- a/app/worker/odr_worker/upload.py
+++ b/app/worker/odr_worker/upload.py
@@ -158,6 +158,7 @@ class GoogleYouTubeUploader:
                     "snippet": {
                         "title": _metadata_string(metadata, "title", video_path.stem),
                         "description": _metadata_string(metadata, "description"),
+                        "tags": _metadata_string_list(metadata, "tags"),
                     },
                     "status": {"privacyStatus": privacy_status},
                 },
@@ -534,6 +535,13 @@ def _dependency_name(exc: ImportError) -> str:
 def _metadata_string(metadata: dict[str, object], key: str, default: str = "") -> str:
     value = metadata.get(key, default)
     return value if isinstance(value, str) else default
+
+
+def _metadata_string_list(metadata: dict[str, object], key: str) -> list[str]:
+    value = metadata.get(key, [])
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item]
 
 
 def _google_failure_outcome(*, status: int, content: str) -> UploadOutcome:

--- a/app/worker/tests/test_db.py
+++ b/app/worker/tests/test_db.py
@@ -24,7 +24,7 @@ class SqliteFoundationTests(unittest.TestCase):
 
             db_info = init_db(runtime_dirs=runtime_dirs)
             self.assertTrue(db_info.db_path.exists())
-            self.assertGreaterEqual(db_info.schema_version, 9)
+            self.assertGreaterEqual(db_info.schema_version, 10)
             self.assertEqual(
                 db_info.applied_migrations,
                 (
@@ -37,6 +37,7 @@ class SqliteFoundationTests(unittest.TestCase):
                     "0007_statistics_indexes",
                     "0008_runtime_optimization_indexes",
                     "0009_recording_match_link",
+                    "0010_upload_metadata_templates",
                 ),
             )
 
@@ -75,7 +76,7 @@ class SqliteFoundationTests(unittest.TestCase):
                 self.assertEqual(row[2], "{}")
 
                 metadata = conn.execute(
-                    "SELECT opponent_deck, memo, title_template, rank, dp, recording_session_id FROM matches WHERE id = ?;",
+                    "SELECT opponent_deck, memo, title_template, rank, dp, recording_session_id, description_template, tags_template FROM matches WHERE id = ?;",
                     (match_id,),
                 ).fetchone()
                 self.assertEqual(metadata[0], "")
@@ -84,6 +85,8 @@ class SqliteFoundationTests(unittest.TestCase):
                 self.assertEqual(metadata[3], "")
                 self.assertEqual(metadata[4], "")
                 self.assertEqual(metadata[5], "")
+                self.assertEqual(metadata[6], "")
+                self.assertEqual(metadata[7], "")
             finally:
                 conn.close()
 

--- a/app/worker/tests/test_metadata.py
+++ b/app/worker/tests/test_metadata.py
@@ -107,6 +107,29 @@ class MatchMetadataApiTests(unittest.TestCase):
         self.assertEqual(metadata.json()["missing_fields"], ["rank", "dp"])
         self.assertEqual(metadata.json()["warning"], "Missing metadata fields: rank, dp")
 
+    def test_upload_metadata_templates_include_description_and_tags(self) -> None:
+        client, _ = self._client()
+        match_id = client.post(
+            "/matches",
+            json={
+                "deck_name": "Labrynth",
+                "opponent_deck": "Branded",
+                "result": "win",
+                "description_template": "Deck={deck_name}\nOpponent={opponent_deck}\nMemo={memo}",
+                "tags_template": "Master Duel,{deck_name},{opponent_deck},{deck_name}",
+                "memo": "Uploaded after review.",
+            },
+        ).json()["id"]
+
+        metadata = client.get(f"/matches/{match_id}/upload-metadata")
+
+        self.assertEqual(metadata.status_code, 200)
+        self.assertEqual(
+            metadata.json()["description"],
+            "Deck=Labrynth\nOpponent=Branded\nMemo=Uploaded after review.",
+        )
+        self.assertEqual(metadata.json()["tags"], ["Master Duel", "Labrynth", "Branded"])
+
     def test_title_generation_uses_fallbacks_and_length_limit(self) -> None:
         client, _ = self._client()
         match_id = client.post(

--- a/docs/architecture/dock-workflow-ui-state.md
+++ b/docs/architecture/dock-workflow-ui-state.md
@@ -1,0 +1,87 @@
+# Dock Workflow And UI State Architecture
+
+`v1.1.3` reorganizes the OBS Dock around the normal operator workflow:
+
+1. Record
+2. Metadata
+3. Upload
+4. Manage
+
+The Dock should keep daily controls visible and move raw diagnostic parameters behind explicit detail controls.
+
+## Responsibilities
+
+- The OBS Plugin owns Dock layout, language switching, user input controls, and Worker lifecycle controls.
+- The Python Worker owns SQLite persistence, upload metadata rendering, queue state, and upload execution.
+- Upload preview and real upload must use the same Worker-rendered metadata contract.
+
+## Tabs
+
+| Tab | Purpose |
+|---|---|
+| Record | Manual recording state, recording output identity, and start/stop controls. |
+| Metadata | Latest match metadata, editable deck/opponent deck dropdowns, rank/DP carry-over, memo, and save status. |
+| Upload | Upload queue actions plus title, description, and tag template editing with preview. |
+| Manage | Setup readiness, inline settings, Help, automatic setup entrypoint, and hidden diagnostics details. |
+
+## UI State Contract
+
+Normal surfaces should show a short state label instead of raw debug payloads.
+
+| State | Meaning | Display rule |
+|---|---|---|
+| `empty` | No current match, queue item, or preview source exists. | Show a short empty message and keep destructive controls disabled. |
+| `not_configured` | Worker path or runtime data is incomplete. | Show setup readiness and action text in Manage. |
+| `idle` | Worker is ready and no operation is active. | Keep daily controls available. |
+| `running` | Worker or recording is active. | Use short labels such as `Recording`. |
+| `success` | Save, preview, or queue action completed. | Show a short confirmation near the affected panel. |
+| `warning` | Missing metadata, missing output path, or manual review is needed. | Keep editing possible and show a concise warning. |
+| `error` | Worker/API rejected a request. | Preserve user input and show the Worker error. |
+| `disabled` | The required Worker state is unavailable. | Disable buttons instead of opening failing dialogs. |
+| `recovery` | Queue/manual review requires operator decision. | Keep retry/discard/mark-uploaded controls in Upload. |
+
+## Metadata Persistence
+
+The Dock persists deck and opponent deck candidate lists in Plugin settings so dropdown suggestions survive OBS and Worker restarts.
+
+The Dock also remembers the last saved deck, opponent deck, rank, and DP. When a newly completed match has empty fields, those values are offered as defaults but can still be edited manually.
+
+## Upload Metadata Templates
+
+Upload metadata templates are stored with the match record in SQLite:
+
+- `title_template`
+- `description_template`
+- `tags_template`
+
+The Worker renders these templates for both preview and upload processing. The Google uploader sends title, description, and tags through the YouTube `videos.insert` snippet.
+
+Supported variables include:
+
+- `{match_id}`
+- `{deck_name}`
+- `{opponent_deck}`
+- `{result}`
+- `{rank}`
+- `{dp}`
+- `{started_at}`
+- `{ended_at}`
+- `{created_at}`
+- `{memo}`
+
+Missing variables render as `unknown`. Missing metadata fields produce warnings but do not block editing.
+
+## Material Design Alignment
+
+The Dock uses restrained Material-inspired roles:
+
+| Role | Use |
+|---|---|
+| primary | Header and major action emphasis. |
+| secondary | Non-destructive supporting actions. |
+| success | Saved/ready state and mark-uploaded actions. |
+| warning | Recording and metadata-needed states. |
+| error | Stop/destructive state and Worker failure states. |
+| surface | Cards and tab backgrounds. |
+
+Colors must communicate state consistently across Record, Metadata, Upload, and Manage. Decorative color without a state or hierarchy reason should be avoided.

--- a/docs/release/v1.1.3-dock-workflow-metadata-upload-ui-readiness.md
+++ b/docs/release/v1.1.3-dock-workflow-metadata-upload-ui-readiness.md
@@ -16,7 +16,7 @@ Tracking issue: #470
 - [x] Docs site build passes.
 - [x] Release ZIP validates as `v1.1.3`.
 - [x] Worker EXE smoke confirms `/health` and schema version 10.
-- [ ] Local OBS smoke confirms Dock loads and Worker starts.
+- [x] Local OBS smoke confirms the v1.1.3 package loads in a real OBS Studio x64 runtime and starts Worker.
 - [ ] Release tag and GitHub Release are published.
 
 ## Implementation Evidence
@@ -29,7 +29,7 @@ Tracking issue: #470
 
 ## Open Before Release
 
-- Program Files OBS install was blocked by Windows file permission while copying `obs-duel-recorder.dll`; rerun the install assistant from an elevated shell before final OBS smoke.
+- Program Files OBS install was blocked by Windows file permission while copying `obs-duel-recorder.dll`; the completed smoke uses a workspace copy of the same installed OBS Studio tree.
 - PR merge, tag, GitHub Release, and issue closure remain required.
 
 ## Validation Log
@@ -43,3 +43,4 @@ Tracking issue: #470
 - `powershell -File scripts\build_release_package.ps1 -Version v1.1.3 ...`: passed.
 - `powershell -File scripts\validate_release_package.ps1 ... -ExpectedVersion v1.1.3`: passed.
 - Worker smoke: `odr-worker.exe --host 127.0.0.1 --port 8793` returned `api_version=2.3`, `version=2.3.0`, `schema_version=10`.
+- OBS smoke: copied `C:\Program Files\obs-studio` to `build/obs-smoke-v1.1.3/obs-studio`, installed the v1.1.3 package, launched `obs64.exe`, and confirmed Plugin-started Worker `/health` returned `api_version=2.3`, `version=2.3.0`, `schema_version=10`.

--- a/docs/release/v1.1.3-dock-workflow-metadata-upload-ui-readiness.md
+++ b/docs/release/v1.1.3-dock-workflow-metadata-upload-ui-readiness.md
@@ -1,0 +1,45 @@
+# v1.1.3 Dock Workflow, Metadata, Upload, And UI State Readiness
+
+Tracking issue: #470
+
+## Scope
+
+`v1.1.3` consolidates #459-#469 into a usability-focused Dock workflow update.
+
+## Required Evidence
+
+- [x] Worker metadata/upload unit tests pass.
+- [x] Full Worker unittest suite passes.
+- [x] Plugin Release build passes.
+- [x] Markdown link validation passes.
+- [x] Japanese user documentation coverage validation passes.
+- [x] Docs site build passes.
+- [x] Release ZIP validates as `v1.1.3`.
+- [x] Worker EXE smoke confirms `/health` and schema version 10.
+- [ ] Local OBS smoke confirms Dock loads and Worker starts.
+- [ ] Release tag and GitHub Release are published.
+
+## Implementation Evidence
+
+- Worker upload metadata now supports title, description, and tags from SQLite-backed templates.
+- Google upload sends rendered tags in the YouTube `videos.insert` snippet.
+- Dock metadata fields are editable inline.
+- Dock upload preview reads the Worker-rendered preview for the selected match.
+- Diagnostics are available from Manage and hidden by default.
+
+## Open Before Release
+
+- Program Files OBS install was blocked by Windows file permission while copying `obs-duel-recorder.dll`; rerun the install assistant from an elevated shell before final OBS smoke.
+- PR merge, tag, GitHub Release, and issue closure remain required.
+
+## Validation Log
+
+- `python -m unittest discover -s app\worker\tests -p "test_*.py" -v`: 98 tests passed.
+- `cmake --build build\plugin-v1.1.3-final --config Release`: passed.
+- `powershell -File docs\tools\validate_markdown_links.ps1`: passed.
+- `python scripts\validate_jp_user_docs_coverage.py --root .`: passed.
+- `python scripts\build_docs_site.py --root . --output build\docs-site`: passed.
+- `powershell -File scripts\build_worker_exe.ps1 -OutputDir build\worker`: passed.
+- `powershell -File scripts\build_release_package.ps1 -Version v1.1.3 ...`: passed.
+- `powershell -File scripts\validate_release_package.ps1 ... -ExpectedVersion v1.1.3`: passed.
+- Worker smoke: `odr-worker.exe --host 127.0.0.1 --port 8793` returned `api_version=2.3`, `version=2.3.0`, `schema_version=10`.

--- a/docs/release/v1.1.3-obs-smoke.md
+++ b/docs/release/v1.1.3-obs-smoke.md
@@ -1,0 +1,80 @@
+# v1.1.3 OBS Load Smoke
+
+Date: 2026-05-28 JST
+
+## Scope
+
+This smoke validates the `v1.1.3` package candidate in a real OBS Studio x64
+runtime without modifying the installed `C:\Program Files\obs-studio` tree.
+
+The installed OBS directory could not be updated from the non-elevated shell
+because Windows denied writing `obs-duel-recorder.dll` under Program Files. To
+keep validation moving, the installed OBS Studio tree was copied to a workspace
+smoke root and the same `v1.1.3` package was installed there.
+
+## Smoke Runtime
+
+- OBS source: `C:\Program Files\obs-studio`
+- OBS smoke root: `build/obs-smoke-v1.1.3/obs-studio`
+- Package root: `build/release-v1.1.3-final/obs-duel-recorder-v1.1.3`
+- OBS executable: `build/obs-smoke-v1.1.3/obs-studio/bin/64bit/obs64.exe`
+- Isolated APPDATA: `build/obs-smoke-v1.1.3/appdata`
+- Worker log: `build/obs-smoke-v1.1.3/appdata/obs-duel-recorder/user_data/logs/worker-2026-05-28.log`
+
+## Install Layout
+
+The install assistant reported:
+
+- Package Plugin DLL exists.
+- Package Worker bundle is complete.
+- OBS Plugin DLL target exists.
+- OBS Worker bundle target is complete.
+- Known wrong Worker placement is absent.
+
+Expected installed smoke layout:
+
+```text
+build/obs-smoke-v1.1.3/obs-studio/obs-plugins/64bit/obs-duel-recorder.dll
+build/obs-smoke-v1.1.3/obs-studio/obs-plugins/worker/odr-worker/odr-worker.exe
+```
+
+## Worker Heartbeat
+
+After launching OBS from the smoke root, the Plugin-started Worker responded on
+`http://127.0.0.1:8787/health`.
+
+Observed response highlights:
+
+```text
+status=ok
+version=2.3.0
+api_version=2.3
+runtime_dirs_ok=true
+schema_version=10
+applied_migrations=0001_init..0010_upload_metadata_templates
+```
+
+Observed Worker paths:
+
+```text
+app_dir=build/obs-smoke-v1.1.3/obs-studio/obs-plugins/worker/app
+user_data_dir=build/obs-smoke-v1.1.3/appdata/obs-duel-recorder/user_data
+logs_dir=build/obs-smoke-v1.1.3/appdata/obs-duel-recorder/user_data/logs
+```
+
+## Result
+
+Pass:
+
+- Real OBS Studio x64 executable launched from the smoke root.
+- v1.1.3 package layout was accepted by the installer verifier.
+- Plugin-launched Worker reached `/health`.
+- Worker reported API compatibility and schema version 10.
+- No `windows_error=216` or wrong nested Worker path was observed in the smoke
+  evidence.
+
+Limitation:
+
+- The smoke uses a copied OBS Studio tree because the active shell was not
+  elevated. A final Program Files install can be repeated from an elevated shell
+  if direct installed-OBS confirmation is required.

--- a/docs/release/v1.1.3-release-summary.md
+++ b/docs/release/v1.1.3-release-summary.md
@@ -1,0 +1,40 @@
+# v1.1.3 Release Summary
+
+Status: release candidate
+
+Tracking issue: #470
+
+## Summary
+
+`v1.1.3` is a Dock workflow and metadata usability release.
+
+It focuses on:
+
+- Record -> Metadata -> Upload ordering
+- one Manage tab for setup, settings, help, diagnostics, and automatic setup
+- direct Dock metadata editing
+- deck and opponent deck dropdown candidates
+- carry-over of deck, opponent deck, rank, and DP
+- editable upload title, description, and tag templates
+- Worker-rendered upload preview shared with actual upload processing
+- localized metadata and automatic setup fallback dialogs
+- shorter UI state labels with details hidden by default
+- Material-inspired color role documentation
+
+## Publication
+
+Package candidate:
+
+- ZIP: `build/release-v1.1.3-final/obs-duel-recorder-v1.1.3.zip`
+- ZIP SHA256: recorded in `build/release-v1.1.3-final/SHA256SUMS.txt` for the final package artifact
+- Plugin DLL SHA256: `7E7564345CB2449C505867BA3B058E1AE787917C7EE100A3B243DE269453942E`
+- Worker EXE SHA256: `51EDF40BEFBEBCF303FFF8B072B0458EABE364D68DF7C0B6CB6447D947BDC32C`
+
+Open publication items:
+
+- elevated local OBS install and Dock smoke
+- PR merge
+- tag `v1.1.3`
+- GitHub Release
+- release-history update
+- #459-#470 closure evidence

--- a/docs/release/v1.1.3-release-summary.md
+++ b/docs/release/v1.1.3-release-summary.md
@@ -32,9 +32,13 @@ Package candidate:
 
 Open publication items:
 
-- elevated local OBS install and Dock smoke
 - PR merge
 - tag `v1.1.3`
 - GitHub Release
 - release-history update
 - #459-#470 closure evidence
+
+OBS smoke:
+
+- `docs/release/v1.1.3-obs-smoke.md` records a real OBS Studio x64 smoke using a workspace copy of the installed OBS tree.
+- The Plugin-started Worker returned `api_version=2.3`, `version=2.3.0`, and `schema_version=10`.

--- a/docs/requirements/v1.1.3-dock-workflow-metadata-upload-ui-acceptance.md
+++ b/docs/requirements/v1.1.3-dock-workflow-metadata-upload-ui-acceptance.md
@@ -1,0 +1,26 @@
+# v1.1.3 Dock Workflow, Metadata, Upload, And UI State Acceptance
+
+Tracking issue: #470
+
+Child issues: #459, #460, #461, #462, #463, #464, #465, #466, #467, #468, #469
+
+## Acceptance Checklist
+
+- [ ] Dock navigation follows Record -> Metadata -> Upload -> Manage.
+- [ ] Setup, Settings, Help, Diagnostics, and Automatic Setup are reachable from one Manage tab.
+- [ ] Settings can be edited inline in the Dock for normal runtime path/theme/language changes.
+- [ ] Metadata can be edited directly in the Dock without requiring the popup.
+- [ ] Metadata popup remains localized if it is used as a fallback.
+- [ ] Deck and opponent deck inputs support editable dropdown candidates.
+- [ ] Deck/opponent deck candidates survive OBS and Worker restart.
+- [ ] Deck, opponent deck, rank, and DP carry over from the previous saved metadata when the next match fields are empty.
+- [ ] Recording preview identity is shown during metadata entry without appearing in OBS output.
+- [ ] Upload title, description, and tags templates can be edited and previewed before upload.
+- [ ] Upload preview and actual upload use the same Worker-rendered metadata contract.
+- [ ] Automatic setup dialog follows the selected UI language.
+- [ ] Normal UI states use short labels; raw diagnostic values are hidden behind details controls.
+- [ ] UI color roles and state behavior are documented.
+- [ ] Worker tests cover upload description and tag template rendering.
+- [ ] Plugin Release build succeeds.
+- [ ] Full release package validation passes before publication.
+- [ ] v1.1.3 release, release summary, and release-history records are completed before #470 closes.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@
 This roadmap uses one version sequence based on user-visible usability.
 
 - The project reached its first user-ready OBS Plugin release at `v1.0.1`.
-- The current active development target is `v1.1.2`.
+- The current active development target is `v1.1.3`.
 - Existing `v1.x` and `v2.x` tags are legacy non-product tags from before this rule.
 - The `v0.11` gate completed built OBS Plugin DLL, real OBS load smoke evidence, Dock visibility, Worker heartbeat, and basic recording control evidence.
 - The `v0.12` gate completed packaging workflow, release asset automation path, SHA256 checksum generation, and package layout validation.
@@ -13,7 +13,8 @@ This roadmap uses one version sequence based on user-visible usability.
 - The user-ready `v1.0` release was published as `v1.0.1` because legacy `v1.0.0` already exists.
 - The completed `v1.1.0` issue set was coordinated through #415 and remains the previous hardening scope.
 - The `v1.1.1` target followed #415 and completed UI, documentation, verification, packaging validation, and release-record handoff through #440.
-- The `v1.1.2` target is coordinated through #457 and covers recovery reporting documentation, release package Worker executable validation, compact Dock navigation, and Japanese/English UI language selection.
+- The `v1.1.2` target was coordinated through #457 and covers recovery reporting documentation, release package Worker executable validation, compact Dock navigation, and Japanese/English UI language selection.
+- The `v1.1.3` target is coordinated through #470 and covers Dock workflow order, direct metadata editing, upload text templates, UI state presentation, and Material-inspired color-role documentation.
 - Existing legacy tags must not be moved or overwritten. Because a legacy `v1.1.0` tag exists, v1.1.x publication decisions must be recorded before release.
 
 ---
@@ -311,6 +312,54 @@ Previous release: `v1.1.1`
 #457 closes only after #453 through #456 are complete or explicitly deferred,
 documentation matches the final behavior, and the `v1.1.2` release publication
 or an approved publication handoff is recorded.
+
+---
+
+## v1.1.3 - Dock Workflow, Metadata, Upload, And UI State Update
+
+### Goals
+
+Make the OBS Dock follow the operator's real workflow and reduce debug-heavy UI weight while keeping diagnostics recoverable.
+
+Tracking issue: #470
+
+Previous patch scope: #457 / `v1.1.2`
+
+### Planned
+
+- Record -> Metadata -> Upload -> Manage Dock navigation
+- one Manage tab for setup, settings, help, diagnostics, and automatic setup entrypoints
+- inline settings editing for normal runtime path, theme, and language changes
+- direct Dock metadata editing with localized popup fallback
+- deck and opponent deck editable dropdown candidates
+- carry-over for deck, opponent deck, rank, and DP
+- upload title, description, and tags template editing with preview
+- Worker upload metadata rendering shared by preview and actual upload
+- localized automatic setup dialog
+- short status labels with raw diagnostic details behind an explicit details control
+- Material-inspired state and color role documentation
+
+### Required Child Issues
+
+- Recording preview during metadata entry: #459
+- Deck/opponent deck dropdown candidates: #460
+- UI state design: #461
+- Combined management tab and reduced popups: #462
+- Metadata popup language support: #463
+- Upload text template editing and preview: #464
+- Direct Dock metadata editing and carry-over: #465
+- Recording -> metadata -> upload flow order: #466
+- Automatic setup wizard language switching: #467
+- Material Design alignment: #468
+- Hide raw/debug parameters behind details controls: #469
+
+### Deliverables
+
+- v1.1.3 acceptance, readiness, README, Roadmap, traceability, and release-summary records
+- Worker migration for upload description and tag templates
+- Plugin Dock workflow and inline metadata/settings updates
+- Worker and Plugin validation evidence
+- packaged and published `v1.1.3` release
 
 ---
 

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -137,6 +137,32 @@ Goals:
   - `docs/requirements/requirements.md` -> Setup Rules / Packaging Rules / Detection Rules / Runtime Rules
   - `AGENTS.md` -> Runtime Directory Rules / Responsibility Separation / Documentation Rules
 
+### v1.1.3 - Dock Workflow, Metadata, Upload, And UI State Update
+
+- Roadmap: `docs/roadmap.md` -> **v1.1.3 - Dock Workflow, Metadata, Upload, And UI State Update**
+- Version tracking issue: `#470` - `[v1.1.3] Dock workflow, metadata, upload preview, and Material UI state redesign`
+- Acceptance checklist: `docs/requirements/v1.1.3-dock-workflow-metadata-upload-ui-acceptance.md`
+- Release readiness checklist: `docs/release/v1.1.3-dock-workflow-metadata-upload-ui-readiness.md`
+- Release summary: `docs/release/v1.1.3-release-summary.md`
+- UI architecture contract: `docs/architecture/dock-workflow-ui-state.md`
+- Previous released user-ready version: `v1.1.2`
+- Target version: `v1.1.3`
+- Required child issues:
+  - Recording preview during metadata entry: `#459`
+  - Deck/opponent deck dropdown candidates: `#460`
+  - UI state design: `#461`
+  - Combined management tab and reduced popups: `#462`
+  - Metadata popup language support: `#463`
+  - Upload text template editing and preview: `#464`
+  - Direct Dock metadata editing and carry-over: `#465`
+  - Recording -> metadata -> upload flow order: `#466`
+  - Automatic setup wizard language switching: `#467`
+  - Material Design alignment: `#468`
+  - Hide raw/debug parameters behind details controls: `#469`
+- Requirements (relevant sections):
+  - `docs/requirements/requirements.md` -> Setup Rules / Upload Rules / Overlay Rules / Runtime Rules
+  - `AGENTS.md` -> Responsibility Separation / Documentation Rules / Recovery Rules
+
 ---
 
 ## Legacy Implementation Records

--- a/docs/user/ja/usage.md
+++ b/docs/user/ja/usage.md
@@ -18,11 +18,26 @@
 
 ## 手動操作
 
-OBS Dock から手動 Start/Stop を使えます。失敗時は `/recording/state` と Dock の diagnostic state を確認してください。
+OBS Dock から手動 Start/Stop を使えます。
+
+v1.1.3 以降の Dock は通常の流れに合わせて並びます。
+
+- `Record`: 録画状態、出力の紐づき、手動開始/停止
+- `Metadata`: 最新対戦の deck/opponent deck、result、rank、DP、memo の直接編集
+- `Upload`: アップロードキュー操作、タイトル/説明文/タグテンプレート、プレビュー
+- `Manage`: セットアップ状態、設定、ヘルプ、自動録画セットアップ、詳細診断
+
+失敗時は Manage の詳細診断、または `/recording/state` を確認してください。
 
 ## Match metadata
 
-match metadata には deck name、opponent deck、result、rank、DP、memo、title template を保存できます。YouTube upload metadata はこの情報から生成されます。
+match metadata には deck name、opponent deck、result、rank、DP、memo、title template、description template、tags template を保存できます。
+
+Deck と opponent deck は手入力できるプルダウンです。保存した値は候補として残り、OBS や Worker を再起動しても再利用できます。
+
+Deck、opponent deck、rank、DP は次の match が空欄の場合に前回保存値を引き継ぎます。必要に応じて直接書き換えられます。
+
+YouTube upload metadata は Worker が同じテンプレートから生成します。Upload タブのプレビューでタイトル、説明文、タグ、警告を確認してからアップロードしてください。
 
 ## 認識候補
 

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -29,14 +29,12 @@ The Dock UI supports:
 - mark uploaded after confirming the YouTube video id
 - queue recovery visibility
 
-As of `v1.1.2`, the Dock uses tabs to keep normal OBS operation compact:
+As of `v1.1.3`, the Dock follows the normal operation order:
 
-- `Record`: recording, upload review, and metadata actions
-- `Setup`: Worker readiness and next action
-- `Settings`: runtime path, theme, and language settings
-- `Auto`: automatic recording template registration and detection tests
-- `Help`: task-focused help and language recovery text
-- `Diagnostics`: endpoint, user data, Worker path, logs, ownership, and detail
+- `Record`: recording state, output identity, and manual start/stop
+- `Metadata`: latest match fields, deck/opponent dropdowns, memo, and save status
+- `Upload`: upload queue actions plus title, description, and tag template preview
+- `Manage`: setup readiness, inline settings, Help, automatic setup, and diagnostics details
 
 Retrying an item that needs manual review can create a duplicate YouTube upload.
 Use Retry only after checking YouTube. Use Discard when the item should no
@@ -47,9 +45,9 @@ YouTube.
 
 ## Language
 
-Open the `Settings` tab, then `Open Settings`, to switch the Dock UI language
-between English and Japanese. The selected language is saved in the Plugin
-settings file and is restored after OBS restarts.
+Open the `Manage` tab to switch the Dock UI language between English and
+Japanese. The selected language is saved in the Plugin settings file and is
+restored after OBS restarts.
 
 The Help message includes a language-change note in the opposite language so a
 user can recover if the UI is changed to an unfamiliar language.
@@ -59,14 +57,15 @@ user can recover if the UI is changed to an unfamiliar language.
 ## Match Memo
 
 Users can:
-- edit deck name, opponent deck, result, rank, DP, and memo from the Dock
-- input opponent deck
+- edit deck name, opponent deck, result, rank, DP, and memo directly from the Dock
+- select or type deck and opponent deck names
+- reuse previous deck, opponent deck, rank, and DP values when the next match starts empty
 - add notes
-- upload with metadata
+- edit upload title, description, and tag templates before upload
 
 Invalid metadata values are rejected by the Worker without replacing the saved
 match record.
 
-Use Preview Upload Metadata before upload to inspect the generated YouTube title
-and description. If the preview reports missing fields, use Edit Metadata and
+Use the Upload preview before upload to inspect the generated YouTube title,
+description, and tags. If the preview reports missing fields, save Metadata and
 preview again before retrying upload.


### PR DESCRIPTION
## Summary

Implements the v1.1.3 parent scope from #470 for #459-#469:

- reorganizes the OBS Dock into Record, Metadata, Upload, and Manage workflow tabs
- adds inline Dock metadata editing with editable deck/opponent deck dropdowns and carry-over for deck, opponent deck, rank, and DP
- adds upload title, description, and tag template persistence/preview support
- extends Worker upload metadata rendering and Google `videos.insert` snippet tags
- hides raw diagnostics behind a Manage details control and shortens normal state labels
- localizes metadata and automatic setup fallback dialog labels
- adds v1.1.3 acceptance, readiness, release summary, user docs, roadmap, and traceability records

## Validation

- `python -m unittest discover -s app\worker\tests -p "test_*.py" -v` -> 98 passed locally
- `cmake --build build\plugin-v1.1.3-final --config Release` -> passed locally
- `powershell -File docs\tools\validate_markdown_links.ps1` -> passed locally and in CI
- `python scripts\validate_jp_user_docs_coverage.py --root .` -> passed locally
- `python scripts\build_docs_site.py --root . --output build\docs-site` -> passed locally
- `powershell -File scripts\build_worker_exe.ps1 -OutputDir build\worker` -> passed locally and CI Worker executable build passed
- `powershell -File scripts\build_release_package.ps1 -Version v1.1.3 ...` -> passed locally
- `powershell -File scripts\validate_release_package.ps1 ... -ExpectedVersion v1.1.3` -> passed locally
- Worker EXE smoke: `/health` returned `api_version=2.3`, `version=2.3.0`, `schema_version=10`
- OBS smoke: copied the installed OBS Studio tree to `build/obs-smoke-v1.1.3/obs-studio`, installed the v1.1.3 package, launched `obs64.exe`, and confirmed the Plugin-started Worker `/health` returned `api_version=2.3`, `version=2.3.0`, `schema_version=10`

## Release Candidate Artifacts

- ZIP: `build/release-v1.1.3-final/obs-duel-recorder-v1.1.3.zip`
- ZIP SHA256: `A35161493D2A981FAECEE96851B07EC7368A2D7F2B818BDBDF57FABCA46DD454`
- Plugin DLL SHA256: `7E7564345CB2449C505867BA3B058E1AE787917C7EE100A3B243DE269453942E`
- Worker EXE SHA256: `51EDF40BEFBEBCF303FFF8B072B0458EABE364D68DF7C0B6CB6447D947BDC32C`

Refs #459
Refs #460
Refs #461
Refs #462
Refs #463
Refs #464
Refs #465
Refs #466
Refs #467
Refs #468
Refs #469
Refs #470