### PR TITLE
[codex] Finalize v1.1.3 release records

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ See [Release and tag policy](docs/release.md).
 ## Current Development
 
 Latest release status:
-- Released user-ready version: `v1.0.1` - First Usable OBS Plugin Release
-- Latest completed version gate: `v1.0` - First Usable OBS Plugin Release
+- Released user-ready version: `v1.1.3` - Dock Workflow, Metadata, Upload, and UI State Update
+- Latest completed version gate: `v1.1.3` - Dock Workflow, Metadata, Upload, and UI State Update
 
 Current development target:
-- `v1.1.3` - Dock Workflow, Metadata, Upload, and UI State Update
+- pending planning after `v1.1.3`
 
 Next roadmap target:
 - pending planning after `v1.1.3`
@@ -103,7 +103,7 @@ Active v1.1.2 issue set:
 - Japanese/English language selection from Settings
 - Help recovery note that explains language changes in the opposite language
 
-Active v1.1.3 issue set:
+Completed v1.1.3 issue set:
 - Record -> Metadata -> Upload -> Manage Dock workflow
 - direct Dock metadata editing with deck/opponent dropdown candidates
 - carry-over for deck, opponent deck, rank, and DP
@@ -164,7 +164,7 @@ obs-duel-recorder/
 - Status: first usable OBS Plugin release published with ZIP and SHA256 assets
 - Latest completed version gate: [#401](https://github.com/Tao-pyth/obs-duel-recorder/issues/401)
 - Latest completed hardening issue set: [#440](https://github.com/Tao-pyth/obs-duel-recorder/issues/440)
-- Current development target: [#470](https://github.com/Tao-pyth/obs-duel-recorder/issues/470) / `v1.1.3`
+- Latest completed patch target: [#470](https://github.com/Tao-pyth/obs-duel-recorder/issues/470) / `v1.1.3`
 - Release record: [docs/release-history.md](docs/release-history.md)
 
 ### Completed Legacy Implementation Work

--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -293,6 +293,32 @@ The version tracking issue may contain the working release summary, but finalize
   version `2.3.0` without `windows_error=216`.
 - Status: released user-ready OBS Plugin package
 
+### v1.1.3 - Dock Workflow, Metadata, Upload, And UI State Update
+
+- Version tracking issue: #470
+- Acceptance checklist: `docs/requirements/v1.1.3-dock-workflow-metadata-upload-ui-acceptance.md`
+- Release readiness checklist: `docs/release/v1.1.3-dock-workflow-metadata-upload-ui-readiness.md`
+- Release summary: `docs/release/v1.1.3-release-summary.md`
+- OBS smoke: `docs/release/v1.1.3-obs-smoke.md`
+- Tag: `v1.1.3`
+- Tag target: `249fe93a6630faa134d36b347f8ecabbd023e837`
+- Release finalized at: `2026-05-28`
+- GitHub Release: `https://github.com/Tao-pyth/obs-duel-recorder/releases/tag/v1.1.3`
+- Major child issues: #459, #460, #461, #462, #463, #464, #465, #466, #467, #468, #469
+- Major PR: #471
+- Final ZIP evidence: `obs-duel-recorder-v1.1.3.zip`
+- Final ZIP SHA256: `E40D6D399AD1F26B5E25703645654FF65283BC94A57E670699AE720D066EE261`
+- Rebuilt Plugin DLL SHA256: `7E7564345CB2449C505867BA3B058E1AE787917C7EE100A3B243DE269453942E`
+- Rebuilt Worker EXE SHA256: `51EDF40BEFBEBCF303FFF8B072B0458EABE364D68DF7C0B6CB6447D947BDC32C`
+- Validation evidence: PR #471 CI passed; Worker unit tests passed locally
+  and in CI; Markdown link validation passed locally and in CI; Japanese user
+  docs coverage passed; documentation site build passed; Worker executable
+  build passed locally and in CI; final release package validation passed;
+  Worker EXE smoke reached Worker API `2.3` / Worker version `2.3.0` /
+  schema version `10`; OBS Studio x64 smoke using a workspace copy of the
+  installed OBS tree reached the Plugin-started Worker health endpoint.
+- Status: released user-ready OBS Plugin package
+
 ### Legacy tag v1.0.0 - YouTube Upload MVP
 
 - Version tracking issue: #318

--- a/docs/release/v1.1.3-release-summary.md
+++ b/docs/release/v1.1.3-release-summary.md
@@ -1,6 +1,6 @@
 # v1.1.3 Release Summary
 
-Status: release candidate
+Status: released
 
 Tracking issue: #470
 
@@ -23,22 +23,31 @@ It focuses on:
 
 ## Publication
 
-Package candidate:
+- Tag: `v1.1.3`
+- Tag target commit: `249fe93a6630faa134d36b347f8ecabbd023e837`
+- Release finalized at: `2026-05-28`
+- GitHub Release: `https://github.com/Tao-pyth/obs-duel-recorder/releases/tag/v1.1.3`
+- PR: #471
 
-- ZIP: `build/release-v1.1.3-final/obs-duel-recorder-v1.1.3.zip`
-- ZIP SHA256: recorded in `build/release-v1.1.3-final/SHA256SUMS.txt` for the final package artifact
+- Final ZIP: `obs-duel-recorder-v1.1.3.zip`
+- Final ZIP SHA256: `E40D6D399AD1F26B5E25703645654FF65283BC94A57E670699AE720D066EE261`
 - Plugin DLL SHA256: `7E7564345CB2449C505867BA3B058E1AE787917C7EE100A3B243DE269453942E`
 - Worker EXE SHA256: `51EDF40BEFBEBCF303FFF8B072B0458EABE364D68DF7C0B6CB6447D947BDC32C`
-
-Open publication items:
-
-- PR merge
-- tag `v1.1.3`
-- GitHub Release
-- release-history update
-- #459-#470 closure evidence
 
 OBS smoke:
 
 - `docs/release/v1.1.3-obs-smoke.md` records a real OBS Studio x64 smoke using a workspace copy of the installed OBS tree.
 - The Plugin-started Worker returned `api_version=2.3`, `version=2.3.0`, and `schema_version=10`.
+
+## Validation
+
+- PR #471 CI passed: Docs validation, Worker unit tests, and Worker executable build.
+- Local Worker tests passed: 98 tests.
+- Plugin Release build passed.
+- Markdown link validation passed.
+- Japanese user docs coverage passed.
+- Docs site build passed.
+- Worker EXE build passed.
+- Release package validation passed.
+- Worker EXE smoke passed.
+- OBS Studio x64 smoke passed with the workspace copy of the installed OBS tree.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@
 This roadmap uses one version sequence based on user-visible usability.
 
 - The project reached its first user-ready OBS Plugin release at `v1.0.1`.
-- The current active development target is `v1.1.3`.
+- The latest completed active development target is `v1.1.3`; the next target is pending planning.
 - Existing `v1.x` and `v2.x` tags are legacy non-product tags from before this rule.
 - The `v0.11` gate completed built OBS Plugin DLL, real OBS load smoke evidence, Dock visibility, Worker heartbeat, and basic recording control evidence.
 - The `v0.12` gate completed packaging workflow, release asset automation path, SHA256 checksum generation, and package layout validation.
@@ -14,7 +14,7 @@ This roadmap uses one version sequence based on user-visible usability.
 - The completed `v1.1.0` issue set was coordinated through #415 and remains the previous hardening scope.
 - The `v1.1.1` target followed #415 and completed UI, documentation, verification, packaging validation, and release-record handoff through #440.
 - The `v1.1.2` target was coordinated through #457 and covers recovery reporting documentation, release package Worker executable validation, compact Dock navigation, and Japanese/English UI language selection.
-- The `v1.1.3` target is coordinated through #470 and covers Dock workflow order, direct metadata editing, upload text templates, UI state presentation, and Material-inspired color-role documentation.
+- The `v1.1.3` target was coordinated through #470 and covers Dock workflow order, direct metadata editing, upload text templates, UI state presentation, and Material-inspired color-role documentation.
 - Existing legacy tags must not be moved or overwritten. Because a legacy `v1.1.0` tag exists, v1.1.x publication decisions must be recorded before release.
 
 ---

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -147,6 +147,8 @@ Goals:
 - UI architecture contract: `docs/architecture/dock-workflow-ui-state.md`
 - Previous released user-ready version: `v1.1.2`
 - Target version: `v1.1.3`
+- Release URL: `https://github.com/Tao-pyth/obs-duel-recorder/releases/tag/v1.1.3`
+- Release PR: `#471`
 - Required child issues:
   - Recording preview during metadata entry: `#459`
   - Deck/opponent deck dropdown candidates: `#460`


### PR DESCRIPTION
## Summary

Finalizes documentation records after publishing v1.1.3:

- updates README current status to v1.1.3 released
- records the v1.1.3 GitHub Release, tag target, package hashes, validation, PR, and child issues in release history
- marks the v1.1.3 release summary as released
- updates roadmap and traceability wording now that #470 is published

## Validation

- `powershell -File docs\tools\validate_markdown_links.ps1` -> passed
- `python scripts\validate_jp_user_docs_coverage.py --root .` -> passed
- `python scripts\build_docs_site.py --root . --output build\docs-site` -> passed

Refs #470