### PR TITLE
Verify installed OBS binaries match release package

### DIFF
--- a/scripts/install_release_package.ps1
+++ b/scripts/install_release_package.ps1
@@ -100,6 +100,10 @@ function Copy-DirectoryContents {
     }
 }
 
+function Test-ObsProcessRunning {
+    return $null -ne (Get-Process -Name "obs64" -ErrorAction SilentlyContinue | Select-Object -First 1)
+}
+
 $packageRootPath = Resolve-ExistingDirectory -Path $PackageRoot -Label "Package root"
 $obsRootPath = Resolve-ExistingDirectory -Path $ObsRoot -Label "OBS root"
 
@@ -136,6 +140,9 @@ if (-not (Test-Path -LiteralPath $sourcePlugin -PathType Leaf)) {
 }
 if (-not (Test-WorkerBundle -WorkerDir $sourceWorkerDir)) {
     throw "Package Worker bundle is missing or incomplete. Expected odr-worker.exe and bundled files under: $sourceWorkerDir"
+}
+if (Test-ObsProcessRunning) {
+    throw "OBS is still running. Close OBS before installing so obs-duel-recorder.dll can be replaced safely."
 }
 
 Write-Output "OBS Duel Recorder ZIP install/update"

--- a/scripts/verify_obs_install_layout.ps1
+++ b/scripts/verify_obs_install_layout.ps1
@@ -52,6 +52,42 @@ function Add-CheckResult {
     $Failures.Add($FailureMessage)
 }
 
+function Get-FileSha256 {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $null
+    }
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash
+}
+
+function Add-HashCheckResult {
+    param(
+        [System.Collections.Generic.List[string]]$Failures,
+        [string]$Label,
+        [string]$SourcePath,
+        [string]$TargetPath
+    )
+
+    $sourceHash = Get-FileSha256 -Path $SourcePath
+    $targetHash = Get-FileSha256 -Path $TargetPath
+    $passed = -not [string]::IsNullOrWhiteSpace($sourceHash) -and $sourceHash -eq $targetHash
+
+    if ($passed) {
+        Write-Output "[OK] $Label"
+        Write-Output "     source: $sourceHash"
+        Write-Output "     target: $targetHash"
+        return
+    }
+
+    Write-Output "[FAIL] $Label"
+    Write-Output "       source: $SourcePath"
+    Write-Output "       target: $TargetPath"
+    Write-Output "       source hash: $sourceHash"
+    Write-Output "       target hash: $targetHash"
+    $Failures.Add("Installed file differs from the package. Copy '$SourcePath' to '$TargetPath' again while OBS is closed and PowerShell is running as Administrator.")
+}
+
 $packageRootPath = [System.IO.Path]::GetFullPath($PackageRoot)
 $obsRootPath = [System.IO.Path]::GetFullPath($ObsRoot)
 
@@ -93,12 +129,24 @@ Add-CheckResult `
     -Passed (Test-Path -LiteralPath $targetPlugin -PathType Leaf) `
     -FailureMessage "Missing OBS Plugin DLL. Copy '$sourcePlugin' to '$targetPlugin'."
 
+Add-HashCheckResult `
+    -Failures $failures `
+    -Label "OBS Plugin DLL matches package" `
+    -SourcePath $sourcePlugin `
+    -TargetPath $targetPlugin
+
 Add-CheckResult `
     -Failures $failures `
     -Label "OBS Worker bundle target is complete" `
     -Path $targetWorkerDir `
     -Passed (Test-WorkerBundle -WorkerDir $targetWorkerDir) `
     -FailureMessage "Missing or incomplete OBS Worker bundle. Copy the full directory '$sourceWorkerDir' to '$targetWorkerDir'. Do not copy only '$sourceWorkerExe'."
+
+Add-HashCheckResult `
+    -Failures $failures `
+    -Label "OBS Worker executable matches package" `
+    -SourcePath $sourceWorkerExe `
+    -TargetPath $targetWorkerExe
 
 if (Test-Path -LiteralPath $wrongWorkerDir -PathType Container) {
     Write-Output "[FAIL] Known wrong Worker placement detected"


### PR DESCRIPTION
## Summary
- Fail install verification when the installed OBS Plugin DLL differs from the package DLL.
- Fail install verification when the installed Worker executable differs from the package Worker executable.
- Stop install before copying if OBS is still running, so the DLL replacement cannot silently remain stale.

## Verification
- Ran `git diff --check`.
- Built local `v1.1.6` release package and package validation passed.
- Verified the new layout checker correctly fails on the current machine because OBS still contains the old Plugin DLL hash (`8CD898...`) instead of the package DLL hash (`2B52...`).

## Context
The latest OBS crash after attempting v1.1.5 was caused by the old Plugin DLL still being installed under `C:\Program Files\obs-studio\obs-plugins\64bit`. The previous verifier only checked file placement, not file identity.