### PR TITLE
[codex] Add selected upload target Worker APIs

### DIFF
--- a/app/worker/odr_worker/api.py
+++ b/app/worker/odr_worker/api.py
@@ -1054,6 +1054,44 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
                 details=exc.details,
             )
 
+    @app.get("/upload/items")
+    def get_upload_items() -> dict[str, object]:
+        if app.state.upload_store is None:
+            return _error_response(
+                status_code=503,
+                code="upload_unavailable",
+                message="Upload storage is unavailable",
+            )
+        try:
+            app.state.upload_store.update_settings(build_upload_settings(user_data_dir=runtime_dirs.user_data_dir))
+            return app.state.upload_store.list_upload_items()
+        except (QueueCommandError, MetadataError) as exc:
+            return _error_response(
+                status_code=400,
+                code=exc.code,
+                message="Upload items request is invalid",
+                details=exc.details,
+            )
+
+    @app.get("/upload/targets/next")
+    def get_upload_next_target() -> dict[str, object]:
+        if app.state.upload_store is None:
+            return _error_response(
+                status_code=503,
+                code="upload_unavailable",
+                message="Upload storage is unavailable",
+            )
+        try:
+            app.state.upload_store.update_settings(build_upload_settings(user_data_dir=runtime_dirs.user_data_dir))
+            return app.state.upload_store.next_upload_target()
+        except (QueueCommandError, MetadataError) as exc:
+            return _error_response(
+                status_code=400,
+                code=exc.code,
+                message="Upload target request is invalid",
+                details=exc.details,
+            )
+
     @app.post("/upload/oauth/authorization-url")
     async def post_upload_oauth_authorization_url(request: Request):
         try:
@@ -1188,6 +1226,50 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
                 status_code=status_code,
                 code=exc.code,
                 message="Upload queue transition is invalid",
+                details=exc.details,
+            )
+        except ValueError:
+            return _error_response(
+                status_code=400,
+                code="upload_payload_invalid",
+                message="Upload payload must be JSON object",
+            )
+
+    @app.post("/upload/items/{item_id}/process")
+    async def post_upload_process_item(item_id: int, request: Request):
+        if app.state.upload_store is None:
+            return _error_response(
+                status_code=503,
+                code="upload_unavailable",
+                message="Upload storage is unavailable",
+            )
+        try:
+            payload = await request.json()
+            if not isinstance(payload, dict):
+                raise ValueError
+            return app.state.upload_store.process_item(item_id, payload)
+        except UploadCommandError as exc:
+            return _error_response(
+                status_code=400,
+                code=exc.code,
+                message="Upload request is invalid",
+                details=exc.details,
+            )
+        except QueueCommandError as exc:
+            status_code = 409 if exc.code == "queue_transition_invalid" else 400
+            if exc.code == "queue_item_not_found":
+                status_code = 404
+            return _error_response(
+                status_code=status_code,
+                code=exc.code,
+                message="Upload queue transition is invalid",
+                details=exc.details,
+            )
+        except MetadataError as exc:
+            return _error_response(
+                status_code=404 if exc.code == "match_not_found" else 400,
+                code=exc.code,
+                message="Upload metadata is invalid",
                 details=exc.details,
             )
         except ValueError:

--- a/app/worker/odr_worker/upload.py
+++ b/app/worker/odr_worker/upload.py
@@ -321,20 +321,75 @@ class UploadStore:
             "manual_actions": ["retry", "discard", "mark_uploaded"],
         }
 
+    def list_upload_items(self) -> dict[str, object]:
+        items = self.queue_store.list_items()
+        return {
+            "items": [self.upload_target_payload(item) for item in _sort_upload_items_for_ui(items)],
+            "queue_counts": self.queue_store.count_by_state(),
+        }
+
+    def next_upload_target(self) -> dict[str, object]:
+        for item in _sort_upload_items_for_ui(self.queue_store.list_items()):
+            if item.state not in {"uploaded", "discarded"}:
+                return {"found": True, "target": self.upload_target_payload(item)}
+        return {"found": False, "reason": "no_upload_targets"}
+
+    def upload_target_payload(self, item: QueueItem) -> dict[str, object]:
+        upload_metadata = self._upload_metadata(item)
+        blocking_reasons = self._blocking_reasons(item, upload_metadata)
+        return {
+            "item": item.as_payload(),
+            "queue_item_id": item.id,
+            "match_id": item.match_id,
+            "state": item.state,
+            "video_path": item.video_path,
+            "resolved_video_path": str(self._resolve_video_path(item.video_path)) if item.video_path else "",
+            "video_exists": self._video_exists(self._resolve_video_path(item.video_path)) if item.video_path else False,
+            "upload_metadata": upload_metadata,
+            "blocking_reasons": blocking_reasons,
+            "can_upload": not blocking_reasons,
+        }
+
     def process_next(self, payload: dict[str, Any] | None = None) -> dict[str, object]:
         payload = payload or {}
         if not isinstance(payload, dict):
             raise UploadCommandError("upload_payload_invalid", {"payload": "must_be_object"})
+        provider = self._validate_process_payload(payload)
+
+        item = self._next_ready_item()
+        if item is None:
+            return {"processed": False, "reason": "no_ready_upload_items"}
+        return self._process_item(item, payload, provider=provider)
+
+    def process_item(self, item_id: int, payload: dict[str, Any] | None = None) -> dict[str, object]:
+        payload = payload or {}
+        if not isinstance(payload, dict):
+            raise UploadCommandError("upload_payload_invalid", {"payload": "must_be_object"})
+        provider = self._validate_process_payload(payload)
+        item = self.queue_store.get_item(item_id)
+        return self._process_item(item, payload, provider=provider)
+
+    def _validate_process_payload(self, payload: dict[str, Any]) -> str:
         provider = _string(payload, "provider", "mock")
         if provider not in UPLOAD_PROVIDERS:
             raise UploadCommandError("upload_payload_invalid", {"provider": "unsupported_provider"})
         if provider == "mock" and _string(payload, "mock_result", "success") not in MOCK_RESULTS:
             raise UploadCommandError("upload_payload_invalid", {"mock_result": "unknown_result"})
+        return provider
 
-        item = self._next_ready_item()
-        if item is None:
-            return {"processed": False, "reason": "no_ready_upload_items"}
-
+    def _process_item(self, item: QueueItem, payload: dict[str, Any], *, provider: str) -> dict[str, object]:
+        if item.state in {"uploaded", "discarded"} or item.youtube_video_id:
+            return {
+                "processed": False,
+                "reason": "upload_blocked",
+                "target": self.upload_target_payload(item),
+            }
+        if item.state not in {"ready_upload", "upload_failed"}:
+            return {
+                "processed": False,
+                "reason": "upload_blocked",
+                "target": self.upload_target_payload(item),
+            }
         video_path = self._resolve_video_path(item.video_path)
         if not self._video_exists(video_path):
             discarded = self.queue_store.apply_command(
@@ -349,6 +404,9 @@ class UploadStore:
                 "processed": True,
                 "outcome": "discarded_missing_file",
                 "item": discarded.as_payload(),
+                "queue_item_id": discarded.id,
+                "match_id": discarded.match_id,
+                "target": self.upload_target_payload(discarded),
             }
 
         uploading = self.queue_store.apply_command(item.id, {"action": "start_upload"})
@@ -363,6 +421,11 @@ class UploadStore:
             "processed": True,
             "outcome": outcome.outcome,
             "item": final_item.as_payload(),
+            "queue_item_id": final_item.id,
+            "match_id": final_item.match_id,
+            "youtube_video_id": final_item.youtube_video_id,
+            "youtube_url": final_item.youtube_url,
+            "target": self.upload_target_payload(final_item),
         }
         if upload_metadata is not None:
             result["upload_metadata"] = upload_metadata
@@ -391,6 +454,28 @@ class UploadStore:
 
     def _video_exists(self, path: Path) -> bool:
         return path.exists() and path.is_file()
+
+    def _blocking_reasons(self, item: QueueItem, upload_metadata: dict[str, object] | None) -> list[str]:
+        reasons: list[str] = []
+        if item.state in {"uploaded", "discarded"}:
+            reasons.append(f"queue_state_{item.state}")
+        elif item.state not in {"ready_upload", "upload_failed"}:
+            reasons.append(f"queue_state_{item.state}_not_uploadable")
+        if item.youtube_video_id:
+            reasons.append("youtube_video_id_already_present")
+        if not item.video_path:
+            reasons.append("video_path_missing")
+        elif not self._video_exists(self._resolve_video_path(item.video_path)):
+            reasons.append("local_video_missing")
+        if upload_metadata is not None:
+            if not str(upload_metadata.get("title", "")).strip():
+                reasons.append("upload_title_missing")
+            if not str(upload_metadata.get("description", "")).strip():
+                reasons.append("upload_description_missing")
+            tags = upload_metadata.get("tags", [])
+            if not isinstance(tags, list) or not [tag for tag in tags if isinstance(tag, str) and tag.strip()]:
+                reasons.append("upload_tags_missing")
+        return reasons
 
     def _apply_outcome(self, item: QueueItem, outcome: UploadOutcome) -> QueueItem:
         if outcome.outcome == "success":
@@ -455,6 +540,19 @@ def build_upload_settings(*, user_data_dir: Path, privacy_status: str = DEFAULT_
         client_secret_configured=client_secret_path.exists(),
         token_configured=token_path.exists(),
     )
+
+
+def _sort_upload_items_for_ui(items: list[QueueItem]) -> list[QueueItem]:
+    priority = {
+        "ready_upload": 0,
+        "upload_failed": 1,
+        "need_manual_review": 2,
+        "quota_waiting": 3,
+        "uploading": 4,
+        "uploaded": 5,
+        "discarded": 6,
+    }
+    return sorted(items, key=lambda item: (priority.get(item.state, 99), item.id))
 
 
 def build_oauth_status(settings: UploadSettings) -> dict[str, object]:

--- a/app/worker/tests/test_upload.py
+++ b/app/worker/tests/test_upload.py
@@ -141,6 +141,89 @@ class UploadApiTests(unittest.TestCase):
         self.assertFalse(resp.json()["processed"])
         self.assertEqual(resp.json()["reason"], "no_ready_upload_items")
 
+    def test_upload_items_endpoint_returns_ui_ready_targets_and_blocking_reasons(self) -> None:
+        client, runtime_dirs = self._client()
+        self._write_video(runtime_dirs, "ready.mp4")
+        ready = self._create_queue_item(client, "ready.mp4")
+        missing = self._create_queue_item(client, str(runtime_dirs.videos_dir / "missing.mp4"))
+        failed = self._create_queue_item(client, "failed.mp4")
+        client.post(f"/queue/items/{failed['id']}/command", json={"action": "start_upload"})
+        client.post(
+            f"/queue/items/{failed['id']}/command",
+            json={"action": "mark_upload_failed", "error_code": "network_timeout"},
+        )
+
+        items = client.get("/upload/items")
+
+        self.assertEqual(items.status_code, 200)
+        targets = items.json()["items"]
+        self.assertEqual([target["queue_item_id"] for target in targets], [ready["id"], missing["id"], failed["id"]])
+        self.assertTrue(targets[0]["can_upload"])
+        self.assertFalse(targets[1]["can_upload"])
+        self.assertIn("local_video_missing", targets[1]["blocking_reasons"])
+        self.assertEqual(items.json()["queue_counts"]["ready_upload"], 2)
+        self.assertEqual(items.json()["queue_counts"]["upload_failed"], 1)
+
+    def test_next_upload_target_skips_uploaded_history(self) -> None:
+        client, runtime_dirs = self._client()
+        self._write_video(runtime_dirs, "done.mp4")
+        self._write_video(runtime_dirs, "next.mp4")
+        done = self._create_queue_item(client, "done.mp4")
+        next_item = self._create_queue_item(client, "next.mp4")
+        uploaded = client.post(
+            f"/upload/items/{done['id']}/process",
+            json={"mock_result": "success", "youtube_video_id": "done123"},
+        )
+        self.assertEqual(uploaded.status_code, 200)
+
+        target = client.get("/upload/targets/next")
+
+        self.assertEqual(target.status_code, 200)
+        self.assertTrue(target.json()["found"])
+        self.assertEqual(target.json()["target"]["queue_item_id"], next_item["id"])
+
+    def test_selected_upload_processes_requested_queue_item(self) -> None:
+        client, runtime_dirs = self._client()
+        self._write_video(runtime_dirs, "first.mp4")
+        self._write_video(runtime_dirs, "second.mp4")
+        first = self._create_queue_item(client, "first.mp4")
+        second = self._create_queue_item(client, "second.mp4")
+
+        uploaded = client.post(
+            f"/upload/items/{second['id']}/process",
+            json={"mock_result": "success", "youtube_video_id": "selected123"},
+        )
+
+        self.assertEqual(uploaded.status_code, 200)
+        self.assertTrue(uploaded.json()["processed"])
+        self.assertEqual(uploaded.json()["queue_item_id"], second["id"])
+        self.assertEqual(uploaded.json()["youtube_video_id"], "selected123")
+        self.assertEqual(uploaded.json()["youtube_url"], "https://youtu.be/selected123")
+        self.assertEqual(client.get(f"/queue/items/{first['id']}").json()["state"], "ready_upload")
+        self.assertEqual(client.get(f"/queue/items/{second['id']}").json()["state"], "uploaded")
+
+    def test_selected_upload_blocks_terminal_or_in_progress_items_without_reupload(self) -> None:
+        client, runtime_dirs = self._client()
+        self._write_video(runtime_dirs, "done.mp4")
+        item = self._create_queue_item(client, "done.mp4")
+        uploaded = client.post(
+            f"/upload/items/{item['id']}/process",
+            json={"mock_result": "success", "youtube_video_id": "done123"},
+        )
+        self.assertEqual(uploaded.status_code, 200)
+
+        repeated = client.post(
+            f"/upload/items/{item['id']}/process",
+            json={"mock_result": "success", "youtube_video_id": "again123"},
+        )
+
+        self.assertEqual(repeated.status_code, 200)
+        self.assertFalse(repeated.json()["processed"])
+        self.assertEqual(repeated.json()["reason"], "upload_blocked")
+        self.assertIn("queue_state_uploaded", repeated.json()["target"]["blocking_reasons"])
+        self.assertIn("youtube_video_id_already_present", repeated.json()["target"]["blocking_reasons"])
+        self.assertEqual(client.get(f"/queue/items/{item['id']}").json()["youtube_video_id"], "done123")
+
     def test_invalid_mock_result_does_not_start_upload(self) -> None:
         client, runtime_dirs = self._client()
         self._write_video(runtime_dirs, "invalid.mp4")


### PR DESCRIPTION
## Summary
- Adds UI-oriented `GET /upload/items` and `GET /upload/targets/next` endpoints for the OBS Dock upload flow.
- Adds `POST /upload/items/{item_id}/process` so the Dock can upload an explicitly selected queue item instead of relying only on `/upload/process-next`.
- Returns stable queue item identity, match identity, YouTube result identity, upload metadata, and `blocking_reasons` for state-aware UI decisions.
- Keeps `/upload/process-next` as the backward-compatible endpoint.

## Validation
- `python -m unittest app.worker.tests.test_upload app.worker.tests.test_queue app.worker.tests.test_recording app.worker.tests.test_metadata`
- `python -m unittest discover -s app\worker\tests -p "test_*.py"`
- `git diff --check`

## Linked Issues
- Progresses #508.
- Implements Worker-side scope for #555, #556, #557, #560, and #561.
- Supports #517 and #569 by exposing pre-upload blocking reasons and preventing terminal items with saved YouTube IDs from being reprocessed by the selected-item endpoint.

## 日本語の初心者向け説明
このPRは、OBS Dock側のUIが「どの動画をYouTubeへアップロードするか」を安全に選べるようにするWorker側のAPI追加です。以前は次の1件を処理するAPIだけでしたが、UIでは一覧から対象動画を選ぶ必要があります。そのため、アップロード対象一覧、次の対象、選択した対象だけをアップロードするAPI、そしてアップロードできない理由を返す仕組みを追加しました。