### PR TITLE
[codex] Persist upload privacy settings

### DIFF
--- a/app/worker/odr_worker/api.py
+++ b/app/worker/odr_worker/api.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
-from .config import LoadedWorkerConfig, get_repo_root
+from .config import LoadedWorkerConfig, WorkerConfig, get_repo_root, save_worker_config
 from .db import DbInfo
 from .detection import DetectionRuntime, TemplateConfigError, load_template_config, load_templates
 from .exports import ExportError, ExportStore
@@ -110,6 +110,7 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
 
     app.state.paths = worker_paths
     app.state.config_loaded = loaded_config.config_loaded
+    app.state.worker_config = loaded_config.config
     app.state.overlay_state = OverlayState()
     app.state.recording_state_path = recording_state_path(runtime_dirs.data_dir)
     app.state.recording_state = initialize_recording_state(app.state.recording_state_path)
@@ -148,10 +149,19 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
         app.state.upload_store = UploadStore(
             queue_store=app.state.queue_store,
             videos_dir=runtime_dirs.videos_dir,
-            settings=build_upload_settings(user_data_dir=runtime_dirs.user_data_dir),
+            settings=build_upload_settings(
+                user_data_dir=runtime_dirs.user_data_dir,
+                privacy_status=app.state.worker_config.upload_privacy_status,
+            ),
             metadata_store=app.state.metadata_store,
         )
         app.state.export_store = ExportStore(db_path=db_info.db_path, runtime_dirs=runtime_dirs)
+
+    def _upload_settings():
+        return build_upload_settings(
+            user_data_dir=runtime_dirs.user_data_dir,
+            privacy_status=app.state.worker_config.upload_privacy_status,
+        )
 
     @app.get("/health")
     def health() -> dict[str, object]:
@@ -707,6 +717,7 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
         try:
             preview = app.state.metadata_store.render_upload_metadata(match_id)
             if app.state.upload_store is not None:
+                app.state.upload_store.update_settings(_upload_settings())
                 preview["privacy_status"] = app.state.upload_store.settings.privacy_status
             return preview
         except MetadataError as exc:
@@ -1044,7 +1055,7 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
                 message="Upload storage is unavailable",
             )
         try:
-            app.state.upload_store.update_settings(build_upload_settings(user_data_dir=runtime_dirs.user_data_dir))
+            app.state.upload_store.update_settings(_upload_settings())
             return app.state.upload_store.status()
         except QueueCommandError as exc:
             return _error_response(
@@ -1063,7 +1074,7 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
                 message="Upload storage is unavailable",
             )
         try:
-            app.state.upload_store.update_settings(build_upload_settings(user_data_dir=runtime_dirs.user_data_dir))
+            app.state.upload_store.update_settings(_upload_settings())
             return app.state.upload_store.list_upload_items()
         except (QueueCommandError, MetadataError) as exc:
             return _error_response(
@@ -1082,7 +1093,7 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
                 message="Upload storage is unavailable",
             )
         try:
-            app.state.upload_store.update_settings(build_upload_settings(user_data_dir=runtime_dirs.user_data_dir))
+            app.state.upload_store.update_settings(_upload_settings())
             return app.state.upload_store.next_upload_target()
         except (QueueCommandError, MetadataError) as exc:
             return _error_response(
@@ -1101,7 +1112,7 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
             redirect_uri = payload.get("redirect_uri", "http://127.0.0.1:8787/upload/oauth/callback")
             if not isinstance(redirect_uri, str) or not redirect_uri:
                 raise UploadCommandError("oauth_payload_invalid", {"redirect_uri": "required_string"})
-            workflow = YouTubeOAuthWorkflow(build_upload_settings(user_data_dir=runtime_dirs.user_data_dir))
+            workflow = YouTubeOAuthWorkflow(_upload_settings())
             return workflow.authorization_url(redirect_uri=redirect_uri)
         except UploadCommandError as exc:
             return _error_response(
@@ -1135,11 +1146,11 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
             )
         try:
             redirect_uri = str(request.url.replace(query=""))
-            settings = build_upload_settings(user_data_dir=runtime_dirs.user_data_dir)
+            settings = _upload_settings()
             workflow = YouTubeOAuthWorkflow(settings)
             result = workflow.exchange_code(code=code, redirect_uri=redirect_uri)
             if app.state.upload_store is not None:
-                app.state.upload_store.update_settings(build_upload_settings(user_data_dir=runtime_dirs.user_data_dir))
+                app.state.upload_store.update_settings(_upload_settings())
             return result
         except UploadCommandError as exc:
             return _error_response(
@@ -1161,11 +1172,11 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
                 raise UploadCommandError("oauth_payload_invalid", {"code": "must_be_string"})
             if not isinstance(redirect_uri, str) or not redirect_uri:
                 raise UploadCommandError("oauth_payload_invalid", {"redirect_uri": "required_string"})
-            settings = build_upload_settings(user_data_dir=runtime_dirs.user_data_dir)
+            settings = _upload_settings()
             workflow = YouTubeOAuthWorkflow(settings)
             result = workflow.exchange_code(code=code, redirect_uri=redirect_uri)
             if app.state.upload_store is not None:
-                app.state.upload_store.update_settings(build_upload_settings(user_data_dir=runtime_dirs.user_data_dir))
+                app.state.upload_store.update_settings(_upload_settings())
             return result
         except UploadCommandError as exc:
             return _error_response(
@@ -1184,11 +1195,11 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
     @app.post("/upload/oauth/refresh")
     def post_upload_oauth_refresh():
         try:
-            settings = build_upload_settings(user_data_dir=runtime_dirs.user_data_dir)
+            settings = _upload_settings()
             workflow = YouTubeOAuthWorkflow(settings)
             result = workflow.refresh_token()
             if app.state.upload_store is not None:
-                app.state.upload_store.update_settings(build_upload_settings(user_data_dir=runtime_dirs.user_data_dir))
+                app.state.upload_store.update_settings(_upload_settings())
             return result
         except UploadCommandError as exc:
             return _error_response(
@@ -1196,6 +1207,39 @@ def create_app(*, runtime_dirs: RuntimeDirs, loaded_config: LoadedWorkerConfig, 
                 code=exc.code,
                 message="OAuth token refresh is invalid",
                 details=exc.details,
+            )
+
+    @app.put("/upload/settings")
+    async def put_upload_settings(request: Request):
+        try:
+            payload = await request.json()
+            if not isinstance(payload, dict):
+                raise ValueError
+            privacy_status = payload.get("privacy_status", app.state.worker_config.upload_privacy_status)
+            if not isinstance(privacy_status, str):
+                raise UploadCommandError("upload_privacy_invalid", {"privacy_status": "must_be_string"})
+            settings = build_upload_settings(user_data_dir=runtime_dirs.user_data_dir, privacy_status=privacy_status)
+            app.state.worker_config = WorkerConfig(
+                host=app.state.worker_config.host,
+                port=app.state.worker_config.port,
+                upload_privacy_status=settings.privacy_status,
+            )
+            save_worker_config(user_data_dir=runtime_dirs.user_data_dir, config=app.state.worker_config)
+            if app.state.upload_store is not None:
+                app.state.upload_store.update_settings(settings)
+            return {"settings": settings.as_payload(), "config_path": str(runtime_dirs.config_dir / "worker.toml")}
+        except UploadCommandError as exc:
+            return _error_response(
+                status_code=400,
+                code=exc.code,
+                message="Upload settings are invalid",
+                details=exc.details,
+            )
+        except ValueError:
+            return _error_response(
+                status_code=400,
+                code="upload_settings_invalid",
+                message="Upload settings payload must be JSON object",
             )
 
     @app.post("/upload/process-next")

--- a/app/worker/odr_worker/config.py
+++ b/app/worker/odr_worker/config.py
@@ -10,6 +10,9 @@ class WorkerConfigError(RuntimeError):
     """Raised when the Worker config file cannot be parsed or validated."""
 
 
+ALLOWED_UPLOAD_PRIVACY_STATUSES = {"private", "unlisted"}
+
+
 @dataclass(frozen=True)
 class WorkerConfig:
     """Worker configuration scaffold (v0.2).
@@ -20,6 +23,7 @@ class WorkerConfig:
 
     host: str = "127.0.0.1"
     port: int = 8787
+    upload_privacy_status: str = "private"
 
 
 @dataclass(frozen=True)
@@ -79,13 +83,50 @@ def load_worker_config(user_data_dir: Path | None = None) -> LoadedWorkerConfig:
         if not isinstance(config_table, dict):
             raise ValueError("[worker] must be a TOML table")
 
+        upload_table = raw.get("upload", {})
+        if not isinstance(upload_table, dict):
+            raise ValueError("[upload] must be a TOML table")
+
         host = str(config_table.get("host", WorkerConfig.host))
         port = int(config_table.get("port", WorkerConfig.port))
+        upload_privacy_status = str(upload_table.get("privacy_status", WorkerConfig.upload_privacy_status))
+        if upload_privacy_status not in ALLOWED_UPLOAD_PRIVACY_STATUSES:
+            raise ValueError("[upload].privacy_status must be private or unlisted")
     except (OSError, tomllib.TOMLDecodeError, TypeError, ValueError) as exc:
         raise WorkerConfigError(f"Failed to load Worker config from {config_path}: {exc}") from exc
 
     return LoadedWorkerConfig(
-        config=WorkerConfig(host=host, port=port),
+        config=WorkerConfig(host=host, port=port, upload_privacy_status=upload_privacy_status),
         config_path=config_path,
         config_loaded=True,
     )
+
+
+def save_worker_config(*, user_data_dir: Path, config: WorkerConfig) -> Path:
+    """Persist non-secret Worker settings under user_data/config/worker.toml."""
+
+    if config.upload_privacy_status not in ALLOWED_UPLOAD_PRIVACY_STATUSES:
+        raise WorkerConfigError("upload_privacy_status must be private or unlisted")
+
+    config_path = get_default_config_path(user_data_dir)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "\n".join(
+            [
+                "[worker]",
+                f"host = {_toml_string(config.host)}",
+                f"port = {config.port}",
+                "",
+                "[upload]",
+                f"privacy_status = {_toml_string(config.upload_privacy_status)}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _toml_string(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'

--- a/app/worker/tests/test_runtime_dirs.py
+++ b/app/worker/tests/test_runtime_dirs.py
@@ -30,6 +30,38 @@ class RuntimeDirsTests(unittest.TestCase):
 
 
 class WorkerConfigTests(unittest.TestCase):
+    def test_worker_config_loads_and_saves_upload_privacy_status(self) -> None:
+        from odr_worker.config import WorkerConfig, load_worker_config, save_worker_config
+        from odr_worker.runtime_dirs import ensure_runtime_dirs
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dirs = ensure_runtime_dirs(user_data_dir=root)
+
+            saved_path = save_worker_config(
+                user_data_dir=root,
+                config=WorkerConfig(host="127.0.0.1", port=8787, upload_privacy_status="unlisted"),
+            )
+            loaded = load_worker_config(user_data_dir=root)
+
+            self.assertEqual(saved_path.name, "worker.toml")
+            self.assertTrue(saved_path.exists())
+            self.assertTrue(loaded.config_loaded)
+            self.assertEqual(loaded.config.upload_privacy_status, "unlisted")
+
+    def test_invalid_upload_privacy_status_returns_clear_error(self) -> None:
+        from odr_worker.config import WorkerConfigError, load_worker_config
+        from odr_worker.runtime_dirs import ensure_runtime_dirs
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dirs = ensure_runtime_dirs(user_data_dir=root)
+            config_path = dirs.config_dir / "worker.toml"
+            config_path.write_text('[upload]\nprivacy_status = "public"\n', encoding="utf-8")
+
+            with self.assertRaisesRegex(WorkerConfigError, "privacy_status"):
+                load_worker_config(user_data_dir=root)
+
     def test_invalid_config_returns_clear_error(self) -> None:
         from odr_worker.config import WorkerConfigError, load_worker_config
         from odr_worker.runtime_dirs import ensure_runtime_dirs

--- a/app/worker/tests/test_upload.py
+++ b/app/worker/tests/test_upload.py
@@ -408,6 +408,31 @@ class UploadApiTests(unittest.TestCase):
         self.assertNotIn("super-sensitive-refresh", str(status.json()["auth"]))
         self.assertNotIn("super-sensitive-client-secret", str(settings))
 
+    def test_upload_settings_endpoint_persists_privacy_status(self) -> None:
+        from odr_worker.config import load_worker_config
+
+        client, runtime_dirs = self._client()
+
+        updated = client.put("/upload/settings", json={"privacy_status": "unlisted"})
+
+        self.assertEqual(updated.status_code, 200)
+        self.assertEqual(updated.json()["settings"]["privacy_status"], "unlisted")
+        loaded_config = load_worker_config(user_data_dir=runtime_dirs.user_data_dir)
+        self.assertEqual(loaded_config.config.upload_privacy_status, "unlisted")
+
+        client, _ = self._client_for_runtime(runtime_dirs)
+        status = client.get("/upload/status")
+        self.assertEqual(status.status_code, 200)
+        self.assertEqual(status.json()["settings"]["privacy_status"], "unlisted")
+
+    def test_upload_settings_endpoint_rejects_invalid_privacy_status(self) -> None:
+        client, _ = self._client()
+
+        updated = client.put("/upload/settings", json={"privacy_status": "public"})
+
+        self.assertEqual(updated.status_code, 400)
+        self.assertEqual(updated.json()["code"], "upload_privacy_invalid")
+
     def test_oauth_status_reports_expired_refreshable_token_without_secret_values(self) -> None:
         client, runtime_dirs = self._client()
         secrets_dir = runtime_dirs.config_dir / "secrets"
@@ -662,15 +687,11 @@ class UploadApiTests(unittest.TestCase):
         from fastapi.testclient import TestClient
 
         from odr_worker.api import create_app
-        from odr_worker.config import LoadedWorkerConfig, WorkerConfig
+        from odr_worker.config import load_worker_config
         from odr_worker.db import init_db
 
         db_info = init_db(runtime_dirs=runtime_dirs)
-        loaded_config = LoadedWorkerConfig(
-            config=WorkerConfig(),
-            config_path=runtime_dirs.config_dir / "worker.toml",
-            config_loaded=False,
-        )
+        loaded_config = load_worker_config(user_data_dir=runtime_dirs.user_data_dir)
         client = TestClient(create_app(runtime_dirs=runtime_dirs, loaded_config=loaded_config, db_info=db_info))
         self.addCleanup(client.close)
         return client, runtime_dirs


### PR DESCRIPTION
## Summary
- Adds `[upload].privacy_status` support to `user_data/config/worker.toml`.
- Adds `PUT /upload/settings` so Worker clients can persist `private` / `unlisted` upload privacy settings.
- Uses the configured privacy status for upload status, OAuth workflow, metadata preview, upload item targets, and upload processing.
- Rejects invalid privacy values with a stable `upload_privacy_invalid` response.

## Validation
- `python -m unittest app.worker.tests.test_upload app.worker.tests.test_runtime_dirs`
- `python -m unittest discover -s app\worker\tests -p "test_*.py"`
- `git diff --check`

## Linked Issues
- Implements Worker-side scope for #564.
- Supports #526 and #527 by exposing and persisting the privacy status that the Upload tab can select/display.
- Supports #563 because the real upload settings now stay separate from deterministic mock test behavior.

## 日本語の初心者向け説明
このPRは、YouTubeアップロードの公開範囲設定をWorkerの設定ファイルに保存できるようにします。`private` と `unlisted` の選択がWorker再起動後も残り、アップロード文面プレビューや実際のアップロード処理で同じ値が使われます。秘密情報ではなく通常設定だけを `user_data/config/worker.toml` に保存するため、OAuthトークンやclient secretの扱いとは分離されています。