### PR TITLE
[codex] Localize upload readiness in Dock

### DIFF
--- a/app/plugin/src/plugin-ui.cpp
+++ b/app/plugin/src/plugin-ui.cpp
@@ -405,6 +405,68 @@ std::string upload_blocking_summary(const WorkerStatusSnapshot &snapshot, const 
 	return localized_blocking_reasons(language, target.blocking_reasons);
 }
 
+std::string localized_upload_next_action(const std::string &language, const std::string &state,
+					 const std::string &fallback)
+{
+	if (!language_is_japanese(language)) {
+		return fallback.empty() ? "No action required." : fallback;
+	}
+	if (state == "client_secret_missing") {
+		return "user_data/config/secrets/youtube-client-secret.json を配置してください。";
+	}
+	if (state == "token_missing") {
+		return "YouTube認証を実行してください。";
+	}
+	if (state == "token_invalid") {
+		return "YouTubeを再認証し、トークンを作り直してください。";
+	}
+	if (state == "token_expired_refreshable") {
+		return "トークン更新を実行してください。";
+	}
+	if (state == "google_dependencies_missing" || state == "dependencies_missing") {
+		return "Googleアップロード依存ライブラリを含む配布版を使用してください。";
+	}
+	if (state == "quota_waiting") {
+		return "YouTubeクォータのリセット後に再試行してください。";
+	}
+	if (state == "manual_review_required") {
+		return "YouTube側を確認し、再試行・破棄・アップロード済み設定を選んでください。";
+	}
+	if (state == "ready") {
+		return "アップロード可能です。";
+	}
+	return fallback.empty() ? "状態を確認してください。" : fallback;
+}
+
+std::string upload_readiness_summary(const WorkerStatusSnapshot &snapshot, const std::string &language)
+{
+	if (!snapshot.upload_status_available) {
+		if (!snapshot.upload_status.error.empty()) {
+			return (language_is_japanese(language) ? "Upload API取得不可: " : "upload API not available: ") +
+			       snapshot.upload_status.error;
+		}
+		return language_is_japanese(language) ? "Upload API取得不可" : "upload API not available";
+	}
+
+	const UploadStatusResult &status = snapshot.upload_status;
+	std::ostringstream out;
+	out << (language_is_japanese(language) ? "状態: " : "State: ")
+	    << localized_upload_state(language, status.readiness_state) << "\n"
+	    << (language_is_japanese(language) ? "次の操作: " : "Next action: ")
+	    << localized_upload_next_action(language, status.readiness_state, status.readiness_next_action) << "\n"
+	    << "OAuth client secret: " << (status.client_secret_configured ? "configured" : "missing") << "\n"
+	    << "Token: " << (status.token_state.empty() ? "unknown" : status.token_state);
+	if (!status.token_expiry.empty()) {
+		out << " / expiry: " << status.token_expiry;
+	}
+	out << " / refreshable: " << (status.token_refreshable ? "yes" : "no") << "\n"
+	    << "Google dependencies: " << (status.google_dependencies_available ? "available" : "missing");
+	if (!status.privacy_status.empty()) {
+		out << "\nPrivacy: " << status.privacy_status;
+	}
+	return out.str();
+}
+
 QLabel *add_row(QFormLayout *layout, const char *name, QLabel **name_label = nullptr)
 {
 	auto *label = new QLabel(QString::fromUtf8(name));
@@ -1326,7 +1388,7 @@ void PluginUiController::refresh()
 	queue_value_->setText(qstr_utf8(queue_summary(snapshot)));
 	review_item_value_->setText(qstr_utf8(review_item_summary(snapshot)));
 	if (youtube_value_) {
-		youtube_value_->setText(qstr_utf8(youtube_summary(snapshot)));
+		youtube_value_->setText(qstr_utf8(upload_readiness_summary(snapshot, ui_language_)));
 	}
 	if (upload_target_value_) {
 		upload_target_value_->setText(qstr_utf8(upload_target_summary(snapshot, ui_language_)));
@@ -1392,10 +1454,18 @@ void PluginUiController::refresh()
 						  snapshot.queue_action_item.item.state == "need_manual_review");
 	}
 	if (oauth_authorize_button_) {
-		oauth_authorize_button_->setEnabled(worker_running);
+		oauth_authorize_button_->setEnabled(worker_running && snapshot.upload_status.client_secret_configured);
+		const bool primary = snapshot.upload_status.readiness_state == "token_missing" ||
+				     snapshot.upload_status.readiness_state == "token_invalid";
+		style_button(oauth_authorize_button_, primary ? "#1b5e20" : "#6b7280", "#ffffff");
 	}
 	if (oauth_refresh_button_) {
-		oauth_refresh_button_->setEnabled(worker_running);
+		const bool refresh_needed = snapshot.upload_status.readiness_state == "token_expired_refreshable" ||
+					    snapshot.upload_status.token_refreshable;
+		oauth_refresh_button_->setEnabled(worker_running && refresh_needed);
+		style_button(oauth_refresh_button_, snapshot.upload_status.readiness_state == "token_expired_refreshable" ?
+						   "#1b5e20" : "#6b7280",
+			     "#ffffff");
 	}
 	if (oauth_help_button_) {
 		oauth_help_button_->setEnabled(true);

--- a/app/plugin/src/worker-api.cpp
+++ b/app/plugin/src/worker-api.cpp
@@ -644,6 +644,30 @@ UploadStatusResult LocalhostApiClient::fetch_upload_status(const WorkerEndpoint 
 					     "0" : extract_json_number(response.body, "discarded"));
 	result.readiness_state = extract_json_string(response.body, "readiness_state");
 	result.readiness_next_action = extract_json_string(response.body, "readiness_next_action");
+	const std::string settings = extract_json_object(response.body, "settings");
+	const std::string auth = extract_json_object(response.body, "auth");
+	const std::string providers = extract_json_object(response.body, "providers");
+	result.privacy_status = settings.empty() ? extract_json_string(response.body, "privacy_status") :
+						  extract_json_string(settings, "privacy_status");
+	result.client_secret_configured = settings.empty() ? extract_json_bool(response.body, "client_secret_configured") :
+							      extract_json_bool(settings, "client_secret_configured");
+	result.token_configured = settings.empty() ? extract_json_bool(response.body, "token_configured") :
+						      extract_json_bool(settings, "token_configured");
+	result.token_state = auth.empty() ? extract_json_string(response.body, "token_state") :
+					    extract_json_string(auth, "token_state");
+	result.token_expiry = auth.empty() ? extract_json_string(response.body, "expiry") :
+					     extract_json_string(auth, "expiry");
+	result.auth_ready = auth.empty() ? extract_json_bool(response.body, "auth_ready") :
+					   extract_json_bool(auth, "auth_ready");
+	result.token_expired = auth.empty() ? extract_json_bool(response.body, "expired") :
+					      extract_json_bool(auth, "expired");
+	result.token_refreshable = auth.empty() ? extract_json_bool(response.body, "refreshable") :
+						 extract_json_bool(auth, "refreshable");
+	result.provider_default = providers.empty() ? extract_json_string(response.body, "default") :
+						      extract_json_string(providers, "default");
+	result.google_dependencies_available = providers.empty() ?
+						       extract_json_bool(response.body, "google_dependencies_available") :
+						       extract_json_bool(providers, "google_dependencies_available");
 	result.status = UploadStatusFetchStatus::reachable;
 	result.body = response.body;
 	return result;

--- a/app/plugin/src/worker-api.hpp
+++ b/app/plugin/src/worker-api.hpp
@@ -71,6 +71,10 @@ struct UploadStatusResult {
 	std::string body;
 	std::string readiness_state;
 	std::string readiness_next_action;
+	std::string privacy_status;
+	std::string token_state;
+	std::string token_expiry;
+	std::string provider_default;
 	int ready_upload = 0;
 	int uploading = 0;
 	int uploaded = 0;
@@ -78,6 +82,12 @@ struct UploadStatusResult {
 	int quota_waiting = 0;
 	int need_manual_review = 0;
 	int discarded = 0;
+	bool client_secret_configured = false;
+	bool token_configured = false;
+	bool auth_ready = false;
+	bool token_expired = false;
+	bool token_refreshable = false;
+	bool google_dependencies_available = false;
 
 	bool reachable() const
 	{


### PR DESCRIPTION
## Summary
- Expose OAuth client-secret, token, provider dependency, and privacy fields from `/upload/status` in the Plugin API layer.
- Render a concise localized YouTube readiness summary in the Dock.
- Promote the authorize and refresh actions only when token state makes them relevant.

## Validation
- `python -m unittest app.worker.tests.test_upload app.worker.tests.test_runtime_dirs`
- `python scripts\validate_markdown_links.py --root .`
- `git diff --check`

C++ plugin build was not run locally because `cmake` is not available on PATH in this shell.

## 日本語での初心者向け説明
YouTube連携では「client secretがあるか」「tokenがあるか」「tokenを更新できるか」「Googleアップロード用ライブラリがあるか」を分けて見る必要があります。このPRでは、その状態をOBS Dockに分かりやすく表示し、必要なときだけ認証・更新ボタンを主操作として使えるようにしています。