### PR TITLE
Record v1.1.7 release evidence

### DIFF
--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -367,9 +367,19 @@ The version tracking issue may contain the working release summary, but finalize
 - YouTube upload UX parent: #508
 - YouTube upload UX child issues: #509 through #578
 - Previous released user-ready version: `v1.1.6`
-- Target version: `v1.1.7`
-- Status: active, not yet released
-- Completion policy: this release cannot be marked complete until the open v1.1.7 issue set is implemented, explicitly superseded, or explicitly deferred, and release documentation plus validation evidence are updated.
+- Tag: `v1.1.7`
+- Tag target: `8cf45c29c8046400dbc96e0e05a46bc9ed4ebce2`
+- Release finalized at: `2026-05-30T16:07:07+09:00`
+- GitHub Release: `https://github.com/Tao-pyth/obs-duel-recorder/releases/tag/v1.1.7`
+- Release summary: `docs/release/v1.1.7-release-summary.md`
+- Major PRs: #585, #586, #587, #588, #589
+- Final ZIP evidence: `build/release-v1.1.7/obs-duel-recorder-v1.1.7.zip`
+- Final ZIP SHA256: `C88823D5938C9B2620E61D348EFF4AE4ED6015710EA6576FA1AA9BCE5FFC6E7B`
+- Rebuilt Plugin DLL SHA256: `80C7032FEB8F159E4E569427AB8F9ED08B4782E3EB20F236BDB9E2549CFAFF5B`
+- Rebuilt Worker EXE SHA256: `FA8EB2176B4BC14956D8675D733B387089A06FB06EE7F963C3CD1CFAF4B5E391`
+- Validation evidence: Worker unit tests passed; Worker full test discovery passed; Markdown link validation passed; Japanese user docs coverage passed; C++ Plugin configure and build passed with MSVC 19.44 through `NMake Makefiles`; Worker EXE build passed; final release package validation passed.
+- Deferred items: the broader remaining #508 YouTube UX refinements stay open for follow-up after v1.1.7 instead of blocking this stabilization release.
+- Status: released user-ready OBS Plugin package
 
 ### Legacy tag v1.0.0 - YouTube Upload MVP
 

--- a/docs/release/v1.1.7-release-summary.md
+++ b/docs/release/v1.1.7-release-summary.md
@@ -1,0 +1,43 @@
+# v1.1.7 Release Summary
+
+## Purpose
+
+v1.1.7 is a stabilization release for the current OBS Dock and YouTube upload work.
+
+The release confirms that the current Plugin and Worker can be built into a validated ZIP package, that the OBS Dock exposes the selected-target YouTube upload path, and that release/install documentation no longer describes stale behavior.
+
+## Included Work
+
+- Synchronized README and implementation documents with the v1.1.7 scope.
+- Clarified install/update verification and binary hash checks for OBS Plugin and Worker placement.
+- Documented that automatic GitHub Issue error reporting is not shipped as a default runtime feature.
+- Added Worker APIs for selected upload targets and upload processing.
+- Added Dock controls for selected-target YouTube upload, upload result display, privacy selection, and localized readiness guidance.
+- Persisted YouTube privacy setting behavior.
+- Rebuilt the C++ Plugin DLL and Worker EXE for the release package.
+
+## Release Artifacts
+
+- Tag: `v1.1.7`
+- Tag target: `8cf45c29c8046400dbc96e0e05a46bc9ed4ebce2`
+- GitHub Release: `https://github.com/Tao-pyth/obs-duel-recorder/releases/tag/v1.1.7`
+- ZIP: `obs-duel-recorder-v1.1.7.zip`
+- ZIP SHA256: `C88823D5938C9B2620E61D348EFF4AE4ED6015710EA6576FA1AA9BCE5FFC6E7B`
+- Plugin DLL SHA256: `80C7032FEB8F159E4E569427AB8F9ED08B4782E3EB20F236BDB9E2549CFAFF5B`
+- Worker EXE SHA256: `FA8EB2176B4BC14956D8675D733B387089A06FB06EE7F963C3CD1CFAF4B5E391`
+
+## Validation
+
+- Worker targeted upload/runtime tests passed.
+- Worker full test discovery passed.
+- Markdown link validation passed.
+- Japanese user documentation coverage validation passed.
+- C++ Plugin configure and build passed with MSVC 19.44 through `NMake Makefiles`.
+- Worker EXE build passed with PyInstaller.
+- Final ZIP package validation passed.
+
+## Deferred Follow-Up
+
+The remaining broader #508 YouTube UX refinements are not closed by v1.1.7. They remain open for later work because they are product UX improvements, not release-blocking stabilization defects.
+
+初心者向けにいうと、v1.1.7 は「すべての理想UIを完成させた版」ではなく、「現在のアップロード導線を安全に配布できる形に固めた版」です。未完成のUX改善は、GitHub issueに残して次の作業単位で扱います。


### PR DESCRIPTION
## Summary
- Record the published v1.1.7 release in `docs/release-history.md`.
- Add `docs/release/v1.1.7-release-summary.md` with release scope, artifact hashes, validation evidence, and deferred follow-up policy.

## Validation
- `python scripts\validate_markdown_links.py --root .`
- `python scripts\validate_jp_user_docs_coverage.py --root .`

## 日本語メモ
初心者向けにいうと、このPRはコード機能の追加ではなく、v1.1.7を実際に配布した記録を残すためのものです。どのタグ・ZIP・SHA256・検証結果を使ったかをドキュメントに残すことで、あとから安全に追跡できます。