### PR TITLE
Guide YouTube client secret setup from the Dock

### DIFF
--- a/app/plugin/src/plugin-ui.cpp
+++ b/app/plugin/src/plugin-ui.cpp
@@ -14,10 +14,12 @@
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QComboBox>
+#include <QDir>
 #include <QDoubleSpinBox>
 #include <QElapsedTimer>
 #include <QEventLoop>
 #include <QFile>
+#include <QFileDialog>
 #include <QFileInfo>
 #include <QFormLayout>
 #include <QFrame>
@@ -468,7 +470,7 @@ std::string localized_upload_next_action(const std::string &language, const std:
 		return fallback.empty() ? "No action required." : fallback;
 	}
 	if (state == "client_secret_missing") {
-		return "user_data/config/secrets/youtube-client-secret.json を配置してください。";
+		return "Google OAuthクライアントJSONを認証ファイルとして選択してください。保存先フォルダを開いて手動配置することもできます。";
 	}
 	if (state == "token_missing") {
 		return "YouTube認証を実行してください。";
@@ -993,18 +995,35 @@ void PluginUiController::register_ui()
 
 	auto *oauth_controls = new QHBoxLayout;
 	oauth_authorize_button_ = new QPushButton(ui_text(ui_language_, "Authorize YouTube", "YouTube認証"));
+	select_oauth_client_secret_button_ = new QPushButton(
+		ui_text(ui_language_, "Select Auth File", "認証ファイルを選択"));
+	open_oauth_secrets_folder_button_ = new QPushButton(
+		ui_text(ui_language_, "Open Auth Folder", "保存先フォルダを開く"));
 	oauth_refresh_button_ = new QPushButton(ui_text(ui_language_, "Refresh Token", "トークン更新"));
 	oauth_help_button_ = new QPushButton(ui_text(ui_language_, "OAuth Help", "OAuthヘルプ"));
 	QObject::connect(oauth_authorize_button_, &QPushButton::clicked,
 			 [this]() { request_upload_oauth_authorization(); });
+	QObject::connect(select_oauth_client_secret_button_, &QPushButton::clicked,
+			 [this]() { request_select_upload_client_secret(); });
+	QObject::connect(open_oauth_secrets_folder_button_, &QPushButton::clicked,
+			 [this]() { request_open_upload_secrets_folder(); });
 	QObject::connect(oauth_refresh_button_, &QPushButton::clicked, [this]() { request_upload_oauth_refresh(); });
 	QObject::connect(oauth_help_button_, &QPushButton::clicked, [this]() { request_upload_oauth_help(); });
 	style_button(oauth_authorize_button_, "#1b5e20", "#ffffff");
+	style_button(select_oauth_client_secret_button_, "#2e7d32", "#ffffff");
+	style_button(open_oauth_secrets_folder_button_, "#6b7280", "#ffffff");
 	style_button(oauth_refresh_button_, "#388e3c", "#ffffff");
 	style_button(oauth_help_button_, "#6b7280", "#ffffff");
 	decorate_button(oauth_authorize_button_, QStyle::SP_ComputerIcon,
 			ui_text(ui_language_, "Open the YouTube OAuth authorization URL in your browser.",
 				"YouTube OAuth認証URLをブラウザで開きます。"));
+	decorate_button(select_oauth_client_secret_button_, QStyle::SP_DialogOpenButton,
+			ui_text(ui_language_,
+				"Copy a Google OAuth client JSON into the local OBS Duel Recorder secrets folder.",
+				"Google OAuthクライアントJSONをローカルの認証ファイル保存先へコピーします。"));
+	decorate_button(open_oauth_secrets_folder_button_, QStyle::SP_DirOpenIcon,
+			ui_text(ui_language_, "Open the local folder that stores YouTube OAuth files.",
+				"YouTube OAuthファイルのローカル保存先フォルダを開きます。"));
 	decorate_button(oauth_refresh_button_, QStyle::SP_BrowserReload,
 			ui_text(ui_language_, "Refresh the stored YouTube OAuth token.",
 				"保存済みのYouTube OAuthトークンを更新します。"));
@@ -1012,6 +1031,8 @@ void PluginUiController::register_ui()
 			ui_text(ui_language_, "Open the YouTube OAuth setup guide.",
 				"YouTube OAuth設定ガイドを開きます。"));
 	oauth_controls->addWidget(oauth_authorize_button_);
+	oauth_controls->addWidget(select_oauth_client_secret_button_);
+	oauth_controls->addWidget(open_oauth_secrets_folder_button_);
 	oauth_controls->addWidget(oauth_refresh_button_);
 	oauth_controls->addWidget(oauth_help_button_);
 	upload_layout->addLayout(oauth_controls);
@@ -1280,6 +1301,12 @@ void PluginUiController::apply_dock_theme(const std::string &theme)
 	if (open_youtube_button_) {
 		style_button(open_youtube_button_, palette.settings_bg, palette.settings_fg);
 	}
+	if (select_oauth_client_secret_button_) {
+		style_button(select_oauth_client_secret_button_, palette.header_bg, "#ffffff");
+	}
+	if (open_oauth_secrets_folder_button_) {
+		style_button(open_oauth_secrets_folder_button_, palette.secondary_bg, palette.secondary_fg);
+	}
 	if (edit_metadata_button_) {
 		style_button(edit_metadata_button_, palette.metadata_bg_button, palette.metadata_fg_button);
 	}
@@ -1443,6 +1470,13 @@ void PluginUiController::apply_ui_language()
 	if (oauth_authorize_button_) {
 		oauth_authorize_button_->setText(ui_text(ui_language_, "Authorize YouTube", "YouTube認証"));
 	}
+	if (select_oauth_client_secret_button_) {
+		select_oauth_client_secret_button_->setText(ui_text(ui_language_, "Select Auth File", "認証ファイルを選択"));
+	}
+	if (open_oauth_secrets_folder_button_) {
+		open_oauth_secrets_folder_button_->setText(
+			ui_text(ui_language_, "Open Auth Folder", "保存先フォルダを開く"));
+	}
 	if (oauth_refresh_button_) {
 		oauth_refresh_button_->setText(ui_text(ui_language_, "Refresh Token", "トークン更新"));
 	}
@@ -1495,6 +1529,13 @@ void PluginUiController::apply_ui_language()
 	decorate_button(oauth_authorize_button_, QStyle::SP_ComputerIcon,
 			ui_text(ui_language_, "Open the YouTube OAuth authorization URL in your browser.",
 				"YouTube OAuth認証URLをブラウザで開きます。"));
+	decorate_button(select_oauth_client_secret_button_, QStyle::SP_DialogOpenButton,
+			ui_text(ui_language_,
+				"Copy a Google OAuth client JSON into the local OBS Duel Recorder secrets folder.",
+				"Google OAuthクライアントJSONをローカルの認証ファイル保存先へコピーします。"));
+	decorate_button(open_oauth_secrets_folder_button_, QStyle::SP_DirOpenIcon,
+			ui_text(ui_language_, "Open the local folder that stores YouTube OAuth files.",
+				"YouTube OAuthファイルのローカル保存先フォルダを開きます。"));
 	decorate_button(oauth_refresh_button_, QStyle::SP_BrowserReload,
 			ui_text(ui_language_, "Refresh the stored YouTube OAuth token.",
 				"保存済みのYouTube OAuthトークンを更新します。"));
@@ -1684,6 +1725,16 @@ void PluginUiController::refresh()
 		const bool primary = snapshot.upload_status.readiness_state == "token_missing" ||
 				     snapshot.upload_status.readiness_state == "token_invalid";
 		style_button(oauth_authorize_button_, primary ? "#1b5e20" : "#6b7280", "#ffffff");
+	}
+	if (select_oauth_client_secret_button_) {
+		const bool client_secret_needed = snapshot.upload_status.readiness_state == "client_secret_missing" ||
+						  !snapshot.upload_status.client_secret_configured;
+		select_oauth_client_secret_button_->setEnabled(worker_running && !snapshot.user_data_dir.empty());
+		style_button(select_oauth_client_secret_button_, client_secret_needed ? "#1b5e20" : "#2e7d32",
+			     "#ffffff");
+	}
+	if (open_oauth_secrets_folder_button_) {
+		open_oauth_secrets_folder_button_->setEnabled(!snapshot.user_data_dir.empty());
 	}
 	if (oauth_refresh_button_) {
 		const bool refresh_needed = snapshot.upload_status.readiness_state == "token_expired_refreshable" ||
@@ -2091,6 +2142,126 @@ void PluginUiController::request_upload_to_youtube()
 			},
 			Qt::QueuedConnection);
 	}).detach();
+}
+
+bool PluginUiController::ensure_upload_secrets_dir(QString &secrets_dir)
+{
+	const WorkerStatusSnapshot snapshot = worker_manager_.status_snapshot();
+	if (snapshot.user_data_dir.empty()) {
+		QMessageBox::warning(dock_widget_,
+				     ui_text(ui_language_, "YouTube OAuth setup", "YouTube OAuth設定"),
+				     ui_text(ui_language_,
+					     "user_data_dir is not configured. Open Settings, set the user data folder, then save.",
+					     "user_data_dirが未設定です。設定でユーザーデータフォルダを指定して保存してください。"));
+		return false;
+	}
+
+	secrets_dir = QDir(qstr_wide(snapshot.user_data_dir)).filePath(QStringLiteral("config/secrets"));
+	if (QDir(secrets_dir).exists()) {
+		return true;
+	}
+	if (QDir().mkpath(secrets_dir)) {
+		return true;
+	}
+
+	QMessageBox::warning(
+		dock_widget_,
+		ui_text(ui_language_, "YouTube OAuth setup", "YouTube OAuth設定"),
+		ui_text(ui_language_, "Could not create the YouTube OAuth secrets folder:\n\n",
+			"YouTube OAuth認証ファイルの保存先フォルダを作成できませんでした:\n\n") +
+			QDir::toNativeSeparators(secrets_dir));
+	return false;
+}
+
+void PluginUiController::request_select_upload_client_secret()
+{
+	QString secrets_dir;
+	if (!ensure_upload_secrets_dir(secrets_dir)) {
+		return;
+	}
+
+	const QString source = QFileDialog::getOpenFileName(
+		dock_widget_,
+		ui_text(ui_language_, "Select Google OAuth client JSON", "Google OAuthクライアントJSONを選択"),
+		QString(),
+		ui_text(ui_language_, "JSON files (*.json);;All files (*)", "JSONファイル (*.json);;すべてのファイル (*)"));
+	if (source.isEmpty()) {
+		return;
+	}
+
+	const QFileInfo source_info(source);
+	if (!source_info.isFile()) {
+		QMessageBox::warning(dock_widget_,
+				     ui_text(ui_language_, "YouTube OAuth setup", "YouTube OAuth設定"),
+				     ui_text(ui_language_, "Select a JSON file downloaded from Google Cloud Console.",
+					     "Google Cloud Consoleから取得したJSONファイルを選択してください。"));
+		return;
+	}
+
+	const QString destination = QDir(secrets_dir).filePath(QStringLiteral("youtube-client-secret.json"));
+	const QFileInfo destination_info(destination);
+	if (source_info.absoluteFilePath() == destination_info.absoluteFilePath()) {
+		if (upload_result_value_) {
+			upload_result_value_->setText(ui_text(ui_language_,
+							      "YouTube auth file is already configured.",
+							      "YouTube認証ファイルは既に設定されています。"));
+		}
+		refresh();
+		return;
+	}
+
+	if (destination_info.exists()) {
+		const QMessageBox::StandardButton answer = QMessageBox::question(
+			dock_widget_,
+			ui_text(ui_language_, "Overwrite YouTube auth file?", "YouTube認証ファイルを上書きしますか？"),
+			ui_text(ui_language_,
+				"youtube-client-secret.json already exists. Replace it with the selected file?",
+				"youtube-client-secret.jsonは既に存在します。選択したファイルで置き換えますか？"),
+			QMessageBox::Yes | QMessageBox::No,
+			QMessageBox::No);
+		if (answer != QMessageBox::Yes) {
+			return;
+		}
+		if (!QFile::remove(destination)) {
+			QMessageBox::warning(
+				dock_widget_,
+				ui_text(ui_language_, "YouTube OAuth setup", "YouTube OAuth設定"),
+				ui_text(ui_language_, "Could not replace the existing YouTube auth file.",
+					"既存のYouTube認証ファイルを置き換えられませんでした。"));
+			return;
+		}
+	}
+
+	if (!QFile::copy(source, destination)) {
+		QMessageBox::warning(
+			dock_widget_,
+			ui_text(ui_language_, "YouTube OAuth setup", "YouTube OAuth設定"),
+			ui_text(ui_language_, "Could not copy the selected JSON file into the secrets folder.",
+				"選択したJSONファイルを認証ファイル保存先へコピーできませんでした。"));
+		return;
+	}
+
+	if (upload_result_value_) {
+		upload_result_value_->setText(ui_text(ui_language_,
+						      "YouTube auth file was saved as youtube-client-secret.json.",
+						      "YouTube認証ファイルをyoutube-client-secret.jsonとして保存しました。"));
+	}
+	refresh();
+}
+
+void PluginUiController::request_open_upload_secrets_folder()
+{
+	QString secrets_dir;
+	if (!ensure_upload_secrets_dir(secrets_dir)) {
+		return;
+	}
+	if (!QDesktopServices::openUrl(QUrl::fromLocalFile(secrets_dir))) {
+		QMessageBox::information(
+			dock_widget_,
+			ui_text(ui_language_, "YouTube OAuth folder", "YouTube OAuthフォルダ"),
+			ui_text(ui_language_, "Open this folder manually:\n\n", "次のフォルダを手動で開いてください:\n\n") +
+				QDir::toNativeSeparators(secrets_dir));
+	}
 }
 
 void PluginUiController::request_upload_oauth_authorization()

--- a/app/plugin/src/plugin-ui.hpp
+++ b/app/plugin/src/plugin-ui.hpp
@@ -6,6 +6,7 @@
 #include <string>
 
 class QLabel;
+class QString;
 class QPushButton;
 class QComboBox;
 class QCheckBox;
@@ -42,9 +43,12 @@ private:
 	void request_upload_to_youtube();
 	void request_save_upload_privacy();
 	void request_open_uploaded_youtube();
+	void request_select_upload_client_secret();
+	void request_open_upload_secrets_folder();
 	void request_upload_oauth_authorization();
 	void request_upload_oauth_refresh();
 	void request_upload_oauth_help();
+	bool ensure_upload_secrets_dir(QString &secrets_dir);
 	UploadTargetPayload selected_upload_target(const WorkerStatusSnapshot &snapshot) const;
 	bool has_selected_upload_target(const WorkerStatusSnapshot &snapshot) const;
 	void refresh_upload_queue_selector(const WorkerStatusSnapshot &snapshot);
@@ -158,6 +162,8 @@ private:
 	QPushButton *upload_to_youtube_button_ = nullptr;
 	QPushButton *save_upload_privacy_button_ = nullptr;
 	QPushButton *open_youtube_button_ = nullptr;
+	QPushButton *select_oauth_client_secret_button_ = nullptr;
+	QPushButton *open_oauth_secrets_folder_button_ = nullptr;
 	QPushButton *oauth_authorize_button_ = nullptr;
 	QPushButton *oauth_refresh_button_ = nullptr;
 	QPushButton *oauth_help_button_ = nullptr;

--- a/app/worker/odr_worker/upload.py
+++ b/app/worker/odr_worker/upload.py
@@ -543,8 +543,9 @@ def build_upload_settings(*, user_data_dir: Path, privacy_status: str = DEFAULT_
         raise UploadCommandError(
             "upload_privacy_invalid",
             {"privacy_status": privacy_status, "allowed": sorted(ALLOWED_PRIVACY_STATUSES)},
-        )
+    )
     secrets_dir = user_data_dir / "config" / "secrets"
+    secrets_dir.mkdir(parents=True, exist_ok=True)
     token_path = secrets_dir / "youtube-token.json"
     client_secret_path = secrets_dir / "youtube-client-secret.json"
     return UploadSettings(
@@ -603,7 +604,10 @@ def build_upload_readiness(
 
     if not settings.client_secret_configured:
         auth_state = "client_secret_missing"
-        next_action = "Place youtube-client-secret.json under user_data/config/secrets."
+        next_action = (
+            "Select the Google OAuth client JSON from the OBS Dock, or place it as "
+            "user_data/config/secrets/youtube-client-secret.json."
+        )
     elif token_state == "missing":
         auth_state = "token_missing"
         next_action = "Authorize YouTube upload and create youtube-token.json."

--- a/app/worker/tests/test_upload.py
+++ b/app/worker/tests/test_upload.py
@@ -513,15 +513,15 @@ class UploadApiTests(unittest.TestCase):
 
     def test_upload_readiness_reports_actionable_auth_states(self) -> None:
         client, runtime_dirs = self._client()
+        secrets_dir = runtime_dirs.config_dir / "secrets"
+        self.assertTrue(secrets_dir.is_dir())
+        self.assertFalse((secrets_dir / "youtube-client-secret.json").exists())
 
         missing = client.get("/upload/status")
         self.assertEqual(missing.status_code, 200)
         self.assertEqual(missing.json()["readiness"]["state"], "client_secret_missing")
         self.assertEqual(missing.json()["readiness_state"], "client_secret_missing")
         self.assertEqual(missing.json()["readiness"]["auth_state"], "client_secret_missing")
-
-        secrets_dir = runtime_dirs.config_dir / "secrets"
-        secrets_dir.mkdir(parents=True, exist_ok=True)
         (secrets_dir / "youtube-client-secret.json").write_text('{"client_secret":"secret"}', encoding="utf-8")
         client, _ = self._client_for_runtime(runtime_dirs)
         token_missing = client.get("/upload/status")

--- a/docs/architecture/upload.md
+++ b/docs/architecture/upload.md
@@ -193,7 +193,7 @@ The stable readiness states are:
 | State | Meaning | Typical next action |
 |---|---|---|
 | `ready` | Google upload dependencies, OAuth client secret, token, and queue state are usable. | Upload can proceed. |
-| `client_secret_missing` | `youtube-client-secret.json` is not present. | Place the client secret under `user_data/config/secrets/`. |
+| `client_secret_missing` | `youtube-client-secret.json` is not present. | Use the Dock auth-file selection action, or place the client secret under `user_data/config/secrets/`. |
 | `token_missing` | `youtube-token.json` is not present. | Run OAuth authorization. |
 | `token_invalid` | Token JSON is invalid, expired without refresh, or lacks an access token. | Reauthorize and replace the token. |
 | `token_expired_refreshable` | Token is expired but has a refresh token. | Run token refresh. |

--- a/docs/user/ja/youtube-oauth.md
+++ b/docs/user/ja/youtube-oauth.md
@@ -25,22 +25,24 @@ user_data/config/secrets/
 
 ## セットアップ手順
 
-1. YouTube Data API upload scope を使える Google OAuth デスクトップクライアントを用意します。
-2. ダウンロードした JSON を次の名前で保存します。
+1. YouTube Data API upload scope を使える Google OAuth デスクトップクライアントを用意します。Google側の作成手順は、Google Cloud Console の OAuth クライアント作成ヘルプを参照してください: <https://support.google.com/cloud/answer/6158849>
+2. Google Cloud Console から OAuth クライアント JSON をダウンロードします。
+3. OBS Duel Recorder Dock のアップロードタブで `認証ファイルを選択` を押し、ダウンロードした JSON を選択します。Dock が次の名前でコピーします。
 
    ```text
    user_data/config/secrets/youtube-client-secret.json
    ```
 
-3. OBS Duel Recorder を起動し、Worker が動作していることを確認します。
-4. 認可 URL を取得します。
+   手動で配置したい場合は `保存先フォルダを開く` を押し、上記の正確なファイル名でコピーしてください。
+4. OBS Duel Recorder を起動し、Worker が動作していることを確認します。
+5. 認可 URL を取得します。
 
    ```powershell
    Invoke-WebRequest http://127.0.0.1:8787/upload/oauth/authorization-url -Method Post -ContentType "application/json" -Body '{}' | Select-Object -ExpandProperty Content
    ```
 
-5. 返却された `authorization_url` をブラウザで開き、YouTube upload scope を許可します。
-6. 通常はブラウザが次の URL に戻ります。
+6. 返却された `authorization_url` をブラウザで開き、YouTube upload scope を許可します。
+7. 通常はブラウザが次の URL に戻ります。
 
    ```text
    http://127.0.0.1:8787/upload/oauth/callback
@@ -52,7 +54,7 @@ user_data/config/secrets/
    Invoke-WebRequest http://127.0.0.1:8787/upload/oauth/exchange-code -Method Post -ContentType "application/json" -Body '{"code":"PASTE_CODE_HERE"}' | Select-Object -ExpandProperty Content
    ```
 
-7. readiness を確認します。
+8. readiness を確認します。
 
    ```powershell
    Invoke-WebRequest http://127.0.0.1:8787/upload/status | Select-Object -ExpandProperty Content
@@ -65,7 +67,7 @@ user_data/config/secrets/
 | 状態 | 意味 | 次の操作 |
 |---|---|---|
 | `ready` | アップロード前提条件を満たしています。 | アップロード可能です。 |
-| `client_secret_missing` | OAuth クライアントファイルがありません。 | `youtube-client-secret.json` を `user_data/config/secrets/` に配置します。 |
+| `client_secret_missing` | OAuth クライアントファイルがありません。 | Dock の `認証ファイルを選択` を使うか、`youtube-client-secret.json` を `user_data/config/secrets/` に配置します。 |
 | `token_missing` | まだトークンが作成されていません。 | ブラウザ認可を完了します。 |
 | `token_invalid` | トークンが不正、未完成、または更新不能です。 | 再認可して `youtube-token.json` を置き換えます。 |
 | `token_expired_refreshable` | トークン期限切れですが refresh token があります。 | トークン更新を実行します。 |

--- a/docs/user/ja/youtube-setup.md
+++ b/docs/user/ja/youtube-setup.md
@@ -56,7 +56,7 @@ user_data/config/secrets/
 | 状態 | 意味 | 次の操作 |
 |---|---|---|
 | `ready` | アップロード準備ができています。 | アップロード可能です。 |
-| `client_secret_missing` | OAuth クライアントファイルがありません。 | `youtube-client-secret.json` を `user_data/config/secrets/` に配置します。 |
+| `client_secret_missing` | OAuth クライアントファイルがありません。 | Dock の `認証ファイルを選択` を使うか、`youtube-client-secret.json` を `user_data/config/secrets/` に配置します。 |
 | `token_missing` | まだ認可が完了していません。 | ブラウザ認可を実行します。 |
 | `token_invalid` | トークンが不正、未完成、または更新できません。 | 再認可して `youtube-token.json` を作り直します。 |
 | `token_expired_refreshable` | トークン期限切れですが更新可能です。 | トークン更新を実行します。 |

--- a/docs/user/setup.md
+++ b/docs/user/setup.md
@@ -90,7 +90,7 @@ Dock can show one clear action instead of raw debug fields:
 | `readiness_state` | Meaning | User action |
 |---|---|---|
 | `ready` | OAuth, provider dependencies, and queue state allow upload. | Upload can proceed. |
-| `client_secret_missing` | `youtube-client-secret.json` is not present. | Place the Google OAuth desktop client JSON under `user_data/config/secrets/`. |
+| `client_secret_missing` | `youtube-client-secret.json` is not present. | Use `Select Auth File` in the Dock, or place the Google OAuth desktop client JSON under `user_data/config/secrets/`. |
 | `token_missing` | Authorization has not created `youtube-token.json`. | Request an authorization URL and complete browser approval. |
 | `token_invalid` | The token file is unreadable, incomplete, or expired without refresh support. | Reauthorize and replace `youtube-token.json`. |
 | `token_expired_refreshable` | The token is expired but has a refresh token. | Use token refresh. |

--- a/docs/user/youtube-oauth.md
+++ b/docs/user/youtube-oauth.md
@@ -27,23 +27,29 @@ issue attachments.
 ## Setup Steps
 
 1. Create or choose a Google OAuth desktop client that is allowed to use the
-   YouTube Data API upload scope.
-2. Save the downloaded JSON as:
+   YouTube Data API upload scope. Google documents this flow in the Google
+   Cloud Console help for OAuth clients:
+   <https://support.google.com/cloud/answer/6158849>
+2. Download the OAuth client JSON from Google Cloud Console.
+3. In the OBS Duel Recorder Dock, open the Upload tab and choose
+   `Select Auth File`. Select the downloaded JSON file. The Dock copies it as:
 
    ```text
    user_data/config/secrets/youtube-client-secret.json
    ```
 
-3. Start OBS Duel Recorder and confirm the Worker is running.
-4. Request an authorization URL:
+   If you prefer manual placement, choose `Open Auth Folder` and copy the file
+   into that folder with the exact name above.
+4. Start OBS Duel Recorder and confirm the Worker is running.
+5. Request an authorization URL:
 
    ```powershell
    Invoke-WebRequest http://127.0.0.1:8787/upload/oauth/authorization-url -Method Post -ContentType "application/json" -Body '{}' | Select-Object -ExpandProperty Content
    ```
 
-5. Open the returned `authorization_url` in a browser and approve the YouTube
+6. Open the returned `authorization_url` in a browser and approve the YouTube
    upload scope.
-6. Let the browser return to:
+7. Let the browser return to:
 
    ```text
    http://127.0.0.1:8787/upload/oauth/callback
@@ -56,7 +62,7 @@ issue attachments.
    Invoke-WebRequest http://127.0.0.1:8787/upload/oauth/exchange-code -Method Post -ContentType "application/json" -Body '{"code":"PASTE_CODE_HERE"}' | Select-Object -ExpandProperty Content
    ```
 
-7. Check readiness:
+8. Check readiness:
 
    ```powershell
    Invoke-WebRequest http://127.0.0.1:8787/upload/status | Select-Object -ExpandProperty Content
@@ -70,7 +76,7 @@ Use `readiness_state` as the main upload readiness value. Use
 | State | Meaning | Next action |
 |---|---|---|
 | `ready` | Upload prerequisites are satisfied. | Upload can proceed. |
-| `client_secret_missing` | The OAuth client file is missing. | Place `youtube-client-secret.json` under `user_data/config/secrets/`. |
+| `client_secret_missing` | The OAuth client file is missing. | Use `Select Auth File` in the Dock, or place `youtube-client-secret.json` under `user_data/config/secrets/`. |
 | `token_missing` | Authorization has not produced a token yet. | Complete browser authorization. |
 | `token_invalid` | The token is invalid, incomplete, or cannot be refreshed. | Reauthorize and replace `youtube-token.json`. |
 | `token_expired_refreshable` | The token is expired but has a refresh token. | Refresh the token. |


### PR DESCRIPTION
## Summary
- Create `user_data/config/secrets/` automatically when upload settings are built.
- Add Dock actions to select a Google OAuth client JSON, copy it as `youtube-client-secret.json`, open the secrets folder, and refresh readiness after setup.
- Update YouTube OAuth docs and readiness tables to point users to the Dock-based setup flow.

Closes #592

## Tests
- `python -m unittest app.worker.tests.test_upload`
- `python -m unittest discover -s app\worker\tests -p "test_*.py"`
- `python scripts\validate_markdown_links.py --root .`
- `python scripts\validate_jp_user_docs_coverage.py --root .`
- `python scripts\build_docs_site.py --root . --output build\docs-site`
- `git diff --check`
- `cmd.exe /s /c ""C:\BuildTools2022\VC\Auxiliary\Build\vcvars64.bat" && "C:\BuildTools2022\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" --build build\plugin-v1.1.7-verify --config Release --target obs-duel-recorder"`

## 日本語説明
YouTube連携に必要なOAuthクライアントJSONは、Google Cloud Consoleでユーザーが作成・取得する秘密情報です。アプリ側で自動生成はできませんが、OBS Dockからファイルを選択して正しい保存先へコピーできるようにしました。これにより、初心者でもフォルダ作成やファイル名変更で迷いにくくなります。秘密情報の中身、OAuth token、authorization codeは表示・ログ出力しません。